### PR TITLE
refactor: simplify CLI command and exit path

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,9 +3,6 @@
 package main
 
 import (
-	"log"
-	"os"
-
 	"github.com/oferchen/hclalign/cli"
 	"github.com/oferchen/hclalign/config"
 	"github.com/spf13/cobra"
@@ -13,7 +10,7 @@ import (
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:   "hcl_align [target file or directory]",
+		Use:   "hclalign [target file or directory]",
 		Short: "Aligns HCL files based on given criteria",
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  cli.RunE,
@@ -22,8 +19,5 @@ func main() {
 	rootCmd.Flags().StringSliceP("criteria", "c", config.DefaultCriteria, "List of file criteria to align")
 	rootCmd.Flags().StringSliceP("order", "o", config.DefaultOrder, "Comma-separated list of the order of variable block fields")
 
-	if err := rootCmd.Execute(); err != nil {
-		log.Fatalf("Error: %v", err)
-		os.Exit(1)
-	}
+	cobra.CheckErr(rootCmd.Execute())
 }

--- a/main_test.go
+++ b/main_test.go
@@ -70,7 +70,7 @@ func TestMainFunctionality(t *testing.T) {
 			args := tc.setup(t)
 
 			rootCmd := &cobra.Command{
-				Use:   "hcl_align [target file or directory]",
+				Use:   "hclalign [target file or directory]",
 				Short: "Aligns HCL files based on given criteria",
 				Args:  cobra.ExactArgs(1),
 				RunE:  cli.RunE,


### PR DESCRIPTION
## Summary
- rename CLI use string to `hclalign`
- streamline main entrypoint using `cobra.CheckErr`
- update tests for new command name

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b03ed473f88323bc64c668352b4143