### PR TITLE
refactor: validate order and add context

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -11,11 +11,6 @@ import (
 )
 
 func RunE(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		cmd.Printf("Error: accepts 1 arg(s), received %d\n\n", len(args))
-		cmd.Usage()
-		return fmt.Errorf(config.MissingTarget)
-	}
 	target := args[0]
 	criteria, err := cmd.Flags().GetStringSlice("criteria")
 	if err != nil {
@@ -26,11 +21,9 @@ func RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Validate the order
-	orderValid, err := config.IsValidOrder(order)
-	if !orderValid {
-		return fmt.Errorf("invalid order provided: %v", err)
+	if _, err := config.IsValidOrder(order); err != nil {
+		return fmt.Errorf("invalid order: %w", err)
 	}
-	// Process target dynamically
-	return config.ProcessTargetDynamically(target, criteria, order)
+
+	return config.ProcessTargetDynamically(cmd.Context(), target, criteria, order)
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -14,6 +14,7 @@ import (
 func setupTestCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "testcli",
+		Args: cobra.MinimumNArgs(1),
 		RunE: cli.RunE,
 	}
 	cmd.Flags().StringSlice("criteria", config.DefaultCriteria, "Set the criteria")
@@ -48,7 +49,7 @@ func TestRunE_Extended(t *testing.T) {
 				return hclFilePath, []string{hclFilePath, "--order=description,description"}
 			},
 			expectError:    true,
-			expectedErrMsg: "invalid order provided: duplicate attribute 'description' found in order",
+			expectedErrMsg: "invalid order: duplicate attribute 'description' found in order",
 		},
 		{
 			name: "Order has a missing entry",
@@ -58,7 +59,7 @@ func TestRunE_Extended(t *testing.T) {
 				return hclFilePath, []string{hclFilePath, "--order=type,default"}
 			},
 			expectError:    true,
-			expectedErrMsg: "invalid order provided: provided order length 2 doesn't match expected 6",
+			expectedErrMsg: "invalid order: provided order length 2 doesn't match expected 6",
 		},
 		{
 			name: "Order has an entry which is not allowed",
@@ -68,7 +69,7 @@ func TestRunE_Extended(t *testing.T) {
 				return hclFilePath, []string{hclFilePath, "--order=description,unicorn"}
 			},
 			expectError:    true,
-			expectedErrMsg: "invalid order provided: provided order length 2 doesn't match expected 6",
+			expectedErrMsg: "invalid order: provided order length 2 doesn't match expected 6",
 		},
 		{
 			name: "Order is reversed of the DefaultOrder",

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"github.com/oferchen/hclalign/fileprocessing"
 	"github.com/oferchen/hclalign/patternmatching"
@@ -57,8 +58,7 @@ func IsValidOrder(order []string) (bool, error) {
 }
 
 // ProcessTargetDynamically processes files in the target directory based on criteria and order.
-func ProcessTargetDynamically(target string, criteria []string, order []string) error {
-	// Implementation assumes existence of fileprocessing and patternmatching packages
+func ProcessTargetDynamically(ctx context.Context, target string, criteria []string, order []string) error {
 	if !patternmatching.IsValidCriteria(criteria) {
 		return fmt.Errorf("invalid criteria: %v", criteria)
 	}
@@ -66,5 +66,6 @@ func ProcessTargetDynamically(target string, criteria []string, order []string) 
 		return fmt.Errorf("no target specified")
 	}
 
-	return fileprocessing.ProcessFiles(target, criteria, order)
+	ctx = context.WithValue(ctx, fileprocessing.TargetContextKey, target)
+	return fileprocessing.ProcessFiles(ctx, target, criteria, order)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -122,7 +123,7 @@ func TestProcessTargetDynamically(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			target := tc.setupFunc(t) // Setup the target using the provided setup function
-			err := config.ProcessTargetDynamically(target, tc.criteria, tc.order)
+			err := config.ProcessTargetDynamically(context.Background(), target, tc.criteria, tc.order)
 			if tc.expectErr {
 				assert.Error(t, err)
 			} else {

--- a/fileprocessing/fileprocessing.go
+++ b/fileprocessing/fileprocessing.go
@@ -19,6 +19,11 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+type contextKey string
+
+// TargetContextKey is the context key used to propagate the target path.
+const TargetContextKey contextKey = "target"
+
 // DefaultProcessFile provides the default processing logic for a file.
 func DefaultProcessFile(filePath string, order []string) error {
 	fileContent, err := os.ReadFile(filePath)
@@ -41,7 +46,7 @@ func DefaultProcessFile(filePath string, order []string) error {
 }
 
 // ProcessFiles processes files in the specified target directory according to criteria and order.
-func ProcessFiles(target string, criteria []string, order []string) error {
+func ProcessFiles(ctx context.Context, target string, criteria []string, order []string) error {
 	compiledPatterns, err := patternmatching.CompilePatterns(criteria)
 	if err != nil {
 		return err
@@ -51,8 +56,6 @@ func ProcessFiles(target string, criteria []string, order []string) error {
 	errChan := make(chan error, 1)
 	maxConcurrency := runtime.GOMAXPROCS(0)
 	sem := semaphore.NewWeighted(int64(maxConcurrency))
-
-	ctx := context.Background()
 
 	err = filepath.WalkDir(target, func(filePath string, d os.DirEntry, err error) error {
 		if err != nil {

--- a/fileprocessing/fileprocessing_test.go
+++ b/fileprocessing/fileprocessing_test.go
@@ -1,6 +1,7 @@
 package fileprocessing_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,7 +44,7 @@ attribute4 = "value4"`,
 		criteria := []string{`.*\.hcl$`}
 		order := []string{"attribute2", "attribute1", "attribute4", "attribute3"}
 
-		err := fileprocessing.ProcessFiles(tmpDir, criteria, order)
+		err := fileprocessing.ProcessFiles(context.Background(), tmpDir, criteria, order)
 		require.NoError(t, err)
 
 		// Verify contents of the files after processing
@@ -71,7 +72,7 @@ attribute4 = "value4"`,
 		tmpDir := setupTestDir(t, map[string]string{})
 		defer os.RemoveAll(tmpDir)
 
-		err := fileprocessing.ProcessFiles(tmpDir, []string{`.*\.hcl$`}, []string{"attribute1", "attribute2"})
+		err := fileprocessing.ProcessFiles(context.Background(), tmpDir, []string{`.*\.hcl$`}, []string{"attribute1", "attribute2"})
 		assert.NoError(t, err)
 	})
 
@@ -79,7 +80,7 @@ attribute4 = "value4"`,
 		tmpDir := setupTestDir(t, map[string]string{"test.hcl": `attribute = "value"`})
 		defer os.RemoveAll(tmpDir)
 
-		err := fileprocessing.ProcessFiles(tmpDir, []string{"[\\"}, []string{"attribute"})
+		err := fileprocessing.ProcessFiles(context.Background(), tmpDir, []string{"[\\"}, []string{"attribute"})
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Summary
- remove manual argument length check
- validate ordering with `IsValidOrder`
- propagate target via context for file processing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b03f431d988323a943d4de3018f3f4