### PR TITLE
Refactor file processing with context and atomic writes

### DIFF
--- a/fileprocessing/fileprocessing.go
+++ b/fileprocessing/fileprocessing.go
@@ -5,6 +5,7 @@ package fileprocessing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,27 +25,6 @@ type contextKey string
 // TargetContextKey is the context key used to propagate the target path.
 const TargetContextKey contextKey = "target"
 
-// DefaultProcessFile provides the default processing logic for a file.
-func DefaultProcessFile(filePath string, order []string) error {
-	fileContent, err := os.ReadFile(filePath)
-	if err != nil {
-		return fmt.Errorf("error reading file %s: %w", filePath, err)
-	}
-
-	file, diags := hclwrite.ParseConfig(fileContent, filePath, hcl.InitialPos)
-	if diags.HasErrors() {
-		return fmt.Errorf("parsing error in file %s: %v", filePath, diags.Errs())
-	}
-
-	hclprocessing.ReorderAttributes(file, order)
-
-	if err := os.WriteFile(filePath, file.Bytes(), 0644); err != nil {
-		return fmt.Errorf("error writing file %s: %w", filePath, err)
-	}
-
-	return nil
-}
-
 // ProcessFiles processes files in the specified target directory according to criteria and order.
 func ProcessFiles(ctx context.Context, target string, criteria []string, order []string) error {
 	compiledPatterns, err := patternmatching.CompilePatterns(criteria)
@@ -52,52 +32,88 @@ func ProcessFiles(ctx context.Context, target string, criteria []string, order [
 		return err
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var wg sync.WaitGroup
-	errChan := make(chan error, 1)
 	maxConcurrency := runtime.GOMAXPROCS(0)
 	sem := semaphore.NewWeighted(int64(maxConcurrency))
+	errChan := make(chan error, maxConcurrency)
+	var firstErr error
+	var once sync.Once
 
-	err = filepath.WalkDir(target, func(filePath string, d os.DirEntry, err error) error {
+	walkErr := filepath.WalkDir(target, func(filePath string, d os.DirEntry, err error) error {
 		if err != nil {
+			once.Do(func() { firstErr = err })
+			errChan <- err
+			cancel()
 			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
 		}
 		if !d.IsDir() && patternmatching.MatchesFileCriteria(filePath, compiledPatterns) {
 			if err := sem.Acquire(ctx, 1); err != nil {
+				once.Do(func() { firstErr = err })
+				errChan <- err
+				cancel()
 				return err
 			}
 			wg.Add(1)
-			go func() {
+			go func(path string) {
 				defer wg.Done()
 				defer sem.Release(1)
-
-				if err := ProcessSingleFile(filePath, order); err != nil {
-					select {
-					case errChan <- err:
-					default:
-					}
+				if err := ProcessSingleFile(ctx, path, order); err != nil {
+					once.Do(func() { firstErr = err })
+					errChan <- err
+					cancel()
 				}
-			}()
+			}(filePath)
 		}
 		return nil
 	})
 
 	wg.Wait()
+	cancel()
 	close(errChan)
-	if err == nil {
-		err, _ = <-errChan
+
+	var errs []error
+	if walkErr != nil {
+		errs = append(errs, walkErr)
 	}
-	return err
+	for e := range errChan {
+		errs = append(errs, e)
+	}
+	if firstErr != nil {
+		if len(errs) > 1 {
+			return errors.Join(errs...)
+		}
+		return firstErr
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
 }
 
-// processSingleFile reads and processes a single HCL file based on the given order.
-func ProcessSingleFile(filePath string, order []string) error {
+// ProcessSingleFile reads and processes a single HCL file based on the given order.
+func ProcessSingleFile(ctx context.Context, filePath string, order []string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {
 		return fmt.Errorf("error retrieving file info for %s: %w", filePath, err)
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	fileContent, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("error reading file %s: %w", filePath, err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	file, diags := hclwrite.ParseConfig(fileContent, filePath, hcl.InitialPos)
@@ -107,9 +123,43 @@ func ProcessSingleFile(filePath string, order []string) error {
 
 	hclprocessing.ReorderAttributes(file, order)
 
-	if err := os.WriteFile(filePath, file.Bytes(), fileInfo.Mode()); err != nil {
+	if err := writeFileAtomically(filePath, file.Bytes(), fileInfo.Mode()); err != nil {
 		return fmt.Errorf("error writing file %s with original permissions: %w", filePath, err)
 	}
 
 	return nil
+}
+
+func writeFileAtomically(filename string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(filename)
+	tmp, err := os.CreateTemp(dir, "hclalign-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, filename); err != nil {
+		return err
+	}
+	dirf, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer dirf.Close()
+	return dirf.Sync()
 }

--- a/fileprocessing/fileprocessing_test.go
+++ b/fileprocessing/fileprocessing_test.go
@@ -95,7 +95,7 @@ func TestProcessSingleFile_ValidHCL(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, []byte(initialContent), 0644))
 
 	order := []string{"attribute2", "attribute1"}
-	require.NoError(t, fileprocessing.ProcessSingleFile(filePath, order))
+	require.NoError(t, fileprocessing.ProcessSingleFile(context.Background(), filePath, order))
 
 	resultContent, err := os.ReadFile(filePath)
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestProcessSingleFile_NonHCLContent(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, []byte(nonHCLContent), 0644))
 
 	// Process the file; expect an error because the content is not valid HCL
-	err := fileprocessing.ProcessSingleFile(filePath, []string{})
+	err := fileprocessing.ProcessSingleFile(context.Background(), filePath, []string{})
 	require.Error(t, err, "Processing non-HCL content should result in an error")
 	require.Contains(t, err.Error(), "parsing error", "The error message should indicate a parsing error")
 

--- a/hclprocessing/hclprocessing_test.go
+++ b/hclprocessing/hclprocessing_test.go
@@ -1,6 +1,7 @@
 package hclprocessing_test
 
 import (
+	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -85,7 +86,7 @@ func TestProcessSingleFile_ValidHCL_PermissionsPreserved(t *testing.T) {
 	originalPerms := originalFileInfo.Mode()
 
 	order := []string{"attribute2", "attribute1"}
-	require.NoError(t, fileprocessing.ProcessSingleFile(filePath, order))
+	require.NoError(t, fileprocessing.ProcessSingleFile(context.Background(), filePath, order))
 
 	// After processing, check that the file permissions have not changed
 	processedFileInfo, err := os.Stat(filePath)


### PR DESCRIPTION
## Summary
- accept context in file processing routines and cancel on first error
- atomically rewrite files while preserving permissions
- drop unused DefaultProcessFile and update tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b04085d5f08323bbcc385260d5d3ce