### PR TITLE
feat: add concurrency control and verbose logging

### DIFF
--- a/fileprocessing/fileprocessing_test.go
+++ b/fileprocessing/fileprocessing_test.go
@@ -3,8 +3,10 @@ package fileprocessing
 import (
 	"bytes"
 	"context"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/oferchen/hclalign/config"
@@ -44,5 +46,81 @@ func TestProcessPreservesNewlineAndBOM(t *testing.T) {
 	}
 	if bytes.Contains(bytes.ReplaceAll(data, []byte("\r\n"), []byte{}), []byte("\n")) {
 		t.Fatalf("LF line ending found")
+	}
+}
+
+func TestProcessLogsFilesWhenVerbose(t *testing.T) {
+	dir := t.TempDir()
+
+	file1 := filepath.Join(dir, "a.tf")
+	if err := os.WriteFile(file1, []byte("variable \"a\" {\n type = string\n}\n"), 0644); err != nil {
+		t.Fatalf("write file1: %v", err)
+	}
+	file2 := filepath.Join(dir, "b.tf")
+	if err := os.WriteFile(file2, []byte("variable \"b\" {\n type = string\n}\n"), 0644); err != nil {
+		t.Fatalf("write file2: %v", err)
+	}
+
+	cfg := &config.Config{
+		Target:      dir,
+		Mode:        config.ModeCheck,
+		Include:     config.DefaultInclude,
+		Exclude:     config.DefaultExclude,
+		Order:       config.DefaultOrder,
+		Concurrency: 2,
+		Verbose:     true,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	var buf bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(old)
+
+	if _, err := Process(context.Background(), cfg); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "a.tf") || !strings.Contains(out, "b.tf") {
+		t.Fatalf("expected log to contain file names, got: %q", out)
+	}
+}
+
+func TestProcessContextCanceledNoLog(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.tf")
+	if err := os.WriteFile(path, []byte("variable \"a\" {\n type = string\n}\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	cfg := &config.Config{
+		Target:      dir,
+		Mode:        config.ModeCheck,
+		Include:     config.DefaultInclude,
+		Exclude:     config.DefaultExclude,
+		Order:       config.DefaultOrder,
+		Concurrency: 1,
+		Verbose:     true,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var buf bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(old)
+
+	if _, err := Process(ctx, cfg); err == nil {
+		t.Fatalf("expected error due to canceled context")
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected no logs, got %q", buf.String())
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sync v0.16.0
 )
 
 require (
@@ -20,7 +21,6 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/zclconf/go-cty v1.16.4 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
## Summary
- add `--concurrency` CLI flag defaulting to `runtime.GOMAXPROCS(0)`
- process files concurrently and log each processed file when `--verbose`
- respect context cancellation during logging to avoid goroutine leaks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b059fd1cfc83238f7575cc85b3cebb