### PR TITLE
Match patterns against relative paths

### DIFF
--- a/patternmatching/patternmatching.go
+++ b/patternmatching/patternmatching.go
@@ -52,6 +52,8 @@ func (m *Matcher) Matches(path string) bool {
 	if err != nil {
 		rel = path
 	}
+	// Normalize path separators for consistent glob matching across platforms.
+	rel = filepath.ToSlash(rel)
 	// Check excludes first.
 	for _, ex := range m.exclude {
 		if ok, _ := doublestar.PathMatch(ex, rel); ok {

--- a/patternmatching/patternmatching_test.go
+++ b/patternmatching/patternmatching_test.go
@@ -20,14 +20,22 @@ func TestMatcherMatches(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(wd, "vendor"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "vendor", "v.tf"), []byte(""), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "note.txt"), []byte(""), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(wd, "nested", "included"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "nested", "included", "in.tf"), []byte(""), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(wd, "nested", "excluded"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "nested", "excluded", "out.tf"), []byte(""), 0644))
 
-	m, err := NewMatcher([]string{"**/*.tf"}, []string{"**/vendor/**"})
+	m, err := NewMatcher([]string{"**/*.tf"}, []string{"**/vendor/**", "nested/excluded/**"})
 	require.NoError(t, err)
 
 	assert.True(t, m.Matches(filepath.Join(wd, "main.tf")))
+	assert.True(t, m.Matches(filepath.Join(wd, "nested", "included")))
+	assert.True(t, m.Matches(filepath.Join(wd, "nested", "included", "in.tf")))
 	assert.False(t, m.Matches(filepath.Join(wd, "note.txt")))
 	assert.False(t, m.Matches(filepath.Join(wd, "vendor")))
 	assert.False(t, m.Matches(filepath.Join(wd, "vendor", "v.tf")))
+	assert.False(t, m.Matches(filepath.Join(wd, "nested", "excluded")))
+	assert.False(t, m.Matches(filepath.Join(wd, "nested", "excluded", "out.tf")))
 }
 
 func TestValidatePatterns(t *testing.T) {


### PR DESCRIPTION
## Summary
- Normalize matcher paths with `filepath.ToSlash` before glob comparisons
- Exercise matcher against nested directories and subpath exclusions

## Testing
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b05bb07ccc8323b5f3656b45265b38