### PR TITLE
chore: set Go 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.23'
 
       - name: Tidy modules
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oferchen/hclalign
 
-go 1.24.3
+go 1.23.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1


### PR DESCRIPTION
## Summary
- require Go 1.23 in go.mod
- use Go 1.23 in CI workflow

## Testing
- `GOTOOLCHAIN=go1.23.0 go mod tidy`
- `GOTOOLCHAIN=go1.23.0 go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b05e622c7483239b7ba2d96e6d69ab