### PR TITLE
Allow custom attribute ordering with strict validation

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,22 @@
+package config
+
+import "testing"
+
+func TestValidateOrder_StrictUnknownAttribute(t *testing.T) {
+	err := ValidateOrder([]string{"description", "unknown"}, true)
+	if err == nil {
+		t.Fatalf("expected error for unknown attribute in strict mode")
+	}
+}
+
+func TestValidateOrder_NonStrictUnknownAttribute(t *testing.T) {
+	if err := ValidateOrder([]string{"description", "unknown"}, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateOrder_StrictIncludesValidation(t *testing.T) {
+	if err := ValidateOrder(DefaultOrder, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/hclprocessing/hclprocessing_test.go
+++ b/hclprocessing/hclprocessing_test.go
@@ -28,6 +28,25 @@ func TestReorderAttributes_VariableBlock(t *testing.T) {
 	require.Equal(t, expected, string(f.Bytes()))
 }
 
+func TestReorderAttributes_CustomOrder(t *testing.T) {
+	src := `variable "example" {
+  description = "d"
+  default     = "v"
+  custom      = true
+}`
+	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	hclprocessing.ReorderAttributes(f, []string{"default", "description"})
+
+	expected := `variable "example" {
+  default     = "v"
+  description = "d"
+  custom      = true
+}`
+	require.Equal(t, expected, string(f.Bytes()))
+}
+
 func TestReorderAttributes_NestedBlocks(t *testing.T) {
 	src := `variable "example" {
   default = "v"


### PR DESCRIPTION
## Summary
- allow ReorderAttributes to apply user-specified attribute order
- validate order against canonical list and fail on unknown attributes in strict mode
- ensure CLI flags `--order` and `--strict-order` alter processing and add tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b05fc752ec83239940b7ff65fc7d43