### PR TITLE
Remove redundant ParseConfig in ReorderAttributes

### DIFF
--- a/hclprocessing/benchmark_test.go
+++ b/hclprocessing/benchmark_test.go
@@ -1,0 +1,25 @@
+package hclprocessing
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"testing"
+)
+
+func BenchmarkReorderAttributes(b *testing.B) {
+	src := []byte(`variable "example" {
+  description = "d"
+  type        = string
+  default     = "v"
+  sensitive   = true
+  nullable    = false
+  extra       = 1
+}`)
+	for i := 0; i < b.N; i++ {
+		f, diags := hclwrite.ParseConfig(src, "test.hcl", hcl.InitialPos)
+		if diags.HasErrors() {
+			b.Fatalf("parse: %v", diags)
+		}
+		ReorderAttributes(f, nil)
+	}
+}

--- a/hclprocessing/hclprocessing.go
+++ b/hclprocessing/hclprocessing.go
@@ -4,7 +4,6 @@
 package hclprocessing
 
 import (
-	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
@@ -17,10 +16,6 @@ func ReorderAttributes(file *hclwrite.File, order []string) {
 	if len(order) == 0 {
 		order = canonicalOrder
 	}
-	if _, diags := hclwrite.ParseConfig(file.Bytes(), "", hcl.InitialPos); diags.HasErrors() {
-		return
-	}
-
 	body := file.Body()
 	for _, block := range body.Blocks() {
 		if block.Type() != "variable" {


### PR DESCRIPTION
## Summary
- drop redundant hclwrite.ParseConfig inside `ReorderAttributes`
- add benchmark for `ReorderAttributes`

## Testing
- `go test ./...`
- `go test ./hclprocessing -bench=ReorderAttributes -benchmem`


------
https://chatgpt.com/codex/tasks/task_e_68b064b4f65c83238a562da6cf66b7a4