### PR TITLE
Preserve BOM and newline style for stdin

### DIFF
--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -15,6 +15,7 @@ import (
 func ApplyHints(data, newline, bom []byte) []byte {
 	out := make([]byte, len(data))
 	copy(out, data)
+	out = bytes.ReplaceAll(out, []byte("\r\n"), []byte("\n"))
 	if len(newline) > 0 && !bytes.Equal(newline, []byte("\n")) {
 		out = bytes.ReplaceAll(out, []byte("\n"), newline)
 	}


### PR DESCRIPTION
## Summary
- detect BOM and CRLF/LF style in stdin processing and apply fs hints before diff or stdout
- normalize existing CRLF sequences in `fs.ApplyHints` and handle cancelled contexts during file processing
- add tests to ensure `--stdin/--stdout` round‑trips BOM and CRLF data

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0676f1a6083238c8b5530f4467793