### PR TITLE
refactor: centralize newline and BOM handling

### DIFF
--- a/fileprocessing/fileprocessing_test.go
+++ b/fileprocessing/fileprocessing_test.go
@@ -165,7 +165,7 @@ func TestProcessReaderPreservesNewlineAndBOM(t *testing.T) {
 		t.Fatalf("parse expected: %v", diags)
 	}
 	hclprocessing.ReorderAttributes(expectedFile, config.DefaultOrder)
-	expected := internalfs.ApplyHints(expectedFile.Bytes(), []byte("\r\n"), bom)
+	expected := internalfs.ApplyHints(expectedFile.Bytes(), internalfs.Hints{HasBOM: true, Newline: "\r\n"})
 	if string(out) != string(expected) {
 		t.Fatalf("unexpected output: got %q, want %q", out, expected)
 	}


### PR DESCRIPTION
## Summary
- add Hints struct with BOM and newline info
- detect file hints on read and write using atomic temp files
- refactor file processing to use new helpers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b083ff31f08323b1b404f21e4436f2