### PR TITLE
cli: return code 3 for processing failures and add tests

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -126,7 +126,7 @@ func RunE(cmd *cobra.Command, args []string) error {
 
 	changed, err := fileprocessing.Process(cmd.Context(), cfg)
 	if err != nil {
-		return &ExitCodeError{Err: err, Code: 1}
+		return &ExitCodeError{Err: err, Code: 3}
 	}
 
 	if changed && (mode == config.ModeCheck || mode == config.ModeDiff) {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/oferchen/hclalign/config"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "hclalign [target file or directory]",
+		Args:         cobra.ArbitraryArgs,
+		RunE:         RunE,
+		SilenceUsage: true,
+	}
+	cmd.Flags().Bool("write", false, "write result to file(s)")
+	cmd.Flags().Bool("check", false, "check if files are formatted")
+	cmd.Flags().Bool("diff", false, "print the diff of required changes")
+	cmd.Flags().Bool("stdin", false, "read from STDIN")
+	cmd.Flags().Bool("stdout", false, "write result to STDOUT")
+	cmd.Flags().StringSlice("include", config.DefaultInclude, "glob patterns to include")
+	cmd.Flags().StringSlice("exclude", config.DefaultExclude, "glob patterns to exclude")
+	cmd.Flags().StringSlice("order", config.DefaultOrder, "order of variable block fields")
+	cmd.Flags().Bool("strict-order", false, "enforce strict attribute ordering")
+	cmd.Flags().Int("concurrency", runtime.GOMAXPROCS(0), "maximum concurrency")
+	cmd.Flags().BoolP("verbose", "v", false, "enable verbose logging")
+	cmd.MarkFlagsMutuallyExclusive("write", "check", "diff")
+	return cmd
+}
+
+func TestRunEUsageError(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{})
+	_, err := cmd.ExecuteC()
+	require.Error(t, err)
+	var exitErr *ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 2, exitErr.Code)
+}
+
+func TestRunEFormattingNeeded(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.tf")
+	content := "variable \"a\" {\n  type = string\n  description = \"d\"\n}"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{path, "--check"})
+	_, err := cmd.ExecuteC()
+	require.Error(t, err)
+	var exitErr *ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 1, exitErr.Code)
+}
+
+func TestRunERuntimeError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.tf")
+	// Invalid HCL to trigger processing error
+	require.NoError(t, os.WriteFile(path, []byte("variable \"a\" {"), 0o644))
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{path})
+	_, err := cmd.ExecuteC()
+	require.Error(t, err)
+	var exitErr *ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 3, exitErr.Code)
+}


### PR DESCRIPTION
## Summary
- return exit code 3 when file processing fails
- ensure formatting-required paths still exit with code 1
- add tests for usage, formatting-needed, and runtime error cases

## Testing
- `go test -race -shuffle=on -cover ./...`
- `golangci-lint run` *(fails: depguard and other lints)*


------
https://chatgpt.com/codex/tasks/task_e_68b08b54e60c832399c38e42780e412d