### PR TITLE
Use fs hints for newline/BOM handling

### DIFF
--- a/fileprocessing/fileprocessing.go
+++ b/fileprocessing/fileprocessing.go
@@ -179,6 +179,7 @@ func processSingleFile(ctx context.Context, filePath string, cfg *config.Config)
 				FromFile: filePath,
 				ToFile:   filePath,
 				Context:  3,
+				Eol:      hints.Newline,
 			}
 			text, err := difflib.GetUnifiedDiffString(ud)
 			if err != nil {
@@ -218,11 +219,12 @@ func processReader(ctx context.Context, r io.Reader, cfg *config.Config) (bool, 
 	case config.ModeDiff:
 		if changed {
 			ud := difflib.UnifiedDiff{
-				A:        difflib.SplitLines(string(data)),
+				A:        difflib.SplitLines(string(original)),
 				B:        difflib.SplitLines(string(styled)),
 				FromFile: "stdin",
 				ToFile:   "stdin",
 				Context:  3,
+				Eol:      hints.Newline,
 			}
 			text, err := difflib.GetUnifiedDiffString(ud)
 			if err != nil {

--- a/fileprocessing/fileprocessing_test.go
+++ b/fileprocessing/fileprocessing_test.go
@@ -42,14 +42,14 @@ func TestProcessPreservesNewlineAndBOM(t *testing.T) {
 		t.Fatalf("process: %v", err)
 	}
 
-	data, err := os.ReadFile(path)
+	_, _, hints, err := internalfs.ReadFileWithHints(path)
 	if err != nil {
 		t.Fatalf("read file: %v", err)
 	}
-	if !bytes.HasPrefix(data, bom) {
+	if !hints.HasBOM {
 		t.Fatalf("bom not preserved")
 	}
-	if bytes.Contains(bytes.ReplaceAll(data, []byte("\r\n"), []byte{}), []byte("\n")) {
+	if hints.Newline != "\r\n" {
 		t.Fatalf("LF line ending found")
 	}
 }
@@ -153,10 +153,11 @@ func TestProcessReaderPreservesNewlineAndBOM(t *testing.T) {
 		t.Fatalf("read stdout: %v", err)
 	}
 
-	if !bytes.HasPrefix(out, bom) {
+	hints := internalfs.DetectHintsFromBytes(out)
+	if !hints.HasBOM {
 		t.Fatalf("bom not preserved")
 	}
-	if bytes.Contains(bytes.ReplaceAll(out, []byte("\r\n"), []byte{}), []byte("\n")) {
+	if hints.Newline != "\r\n" {
 		t.Fatalf("LF line ending found")
 	}
 
@@ -197,7 +198,8 @@ func TestProcessReaderDiffPreservesNewline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read stdout: %v", err)
 	}
-	if !bytes.Contains(out, []byte("\r\n")) {
+	hints := internalfs.DetectHintsFromBytes(out)
+	if hints.Newline != "\r\n" {
 		t.Fatalf("expected CRLF in diff output")
 	}
 }


### PR DESCRIPTION
## Summary
- propagate newline hints to diffs and use original content adjusted with `ApplyHints`
- verify newline and BOM preservation via `ReadFileWithHints` and `DetectHintsFromBytes` in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b090caa40c83239ddeabd1d9a123f8