### PR TITLE
test: expand non-variable block coverage

### DIFF
--- a/tests/cases/non_variable/in.tf
+++ b/tests/cases/non_variable/in.tf
@@ -2,3 +2,43 @@ resource "r" "t" {
   b = 1
   a = 2
 }
+
+data "d" "t" {
+  b = 1
+  a = 2
+}
+
+provider "p" {
+  b = 1
+  a = 2
+}
+
+module "m" {
+  b = 1
+  a = 2
+}
+
+output "o" {
+  b = 1
+  a = 2
+}
+
+locals {
+  b = 1
+  a = 2
+}
+
+terraform {
+  b = 1
+  a = 2
+}
+
+moved {
+  from = aws_instance.foo
+  to   = aws_instance.bar
+}
+
+import {
+  id = "i-123"
+  to = aws_instance.example
+}

--- a/tests/cases/non_variable/out.tf
+++ b/tests/cases/non_variable/out.tf
@@ -2,3 +2,43 @@ resource "r" "t" {
   b = 1
   a = 2
 }
+
+data "d" "t" {
+  b = 1
+  a = 2
+}
+
+provider "p" {
+  b = 1
+  a = 2
+}
+
+module "m" {
+  b = 1
+  a = 2
+}
+
+output "o" {
+  b = 1
+  a = 2
+}
+
+locals {
+  b = 1
+  a = 2
+}
+
+terraform {
+  b = 1
+  a = 2
+}
+
+moved {
+  from = aws_instance.foo
+  to   = aws_instance.bar
+}
+
+import {
+  id = "i-123"
+  to = aws_instance.example
+}


### PR DESCRIPTION
## Summary
- expand non-variable golden test to include all Terraform block types

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0960e05b08323a35875c72926c2cf