### PR TITLE
docs: expand usage and safety sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+<!--
+WHAT: Summarize new features and safety improvements.
+WHY: Keep users informed about notable changes and safeguards.
+-->
+
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
@@ -7,3 +12,5 @@ All notable changes to this project will be documented in this file.
 - Added variable-attribute reordering tool with support for include/exclude globs and strict ordering.
 - Introduced safety features such as check and diff modes, idempotent operation, and atomic file writes.
 - Improved testing with race detector and fuzz test execution.
+- Added optional symlink traversal via `--follow-symlinks` and clarified default include/exclude patterns.
+- Documented exit codes and provided CI/editor usage examples to encourage safe automation.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # hclalign
 
+<!--
+WHAT: Document atomic write guarantees, default patterns, symlink handling, strict order, exit codes, and integration examples.
+WHY: Provide clearer usage guidance and highlight safety features for users.
+-->
+
 `hclalign` is a Command Line Interface (CLI) tool for reordering attributes inside HCL variable blocks. It helps maintain a consistent style across Terraform and other HCL files.
 
 ## Features
@@ -11,7 +16,12 @@
 - **STDIN/STDOUT Support**: Process input from standard in and write to standard out with `--stdin` and `--stdout` for easy pipeline integration.
 - **Idempotent & Atomic**: Running `hclalign` multiple times produces the same result and updates files using atomic writes to prevent partial edits.
 - **Concurrent Processing**: Utilizes Go's concurrency features to process files in parallel.
+- **Optional Symlink Traversal**: Follow symbolic links during directory walks with `--follow-symlinks`.
 - **Verbose Logging**: Enable additional output with `-v` for debugging or development.
+
+## Atomic Write Guarantees
+
+`hclalign` writes changes to a temporary file and atomically renames it over the original. This prevents partial writes and ensures files are either fully updated or left untouched if an error occurs.
 
 ## Getting Started
 
@@ -45,14 +55,17 @@ This compiles the project and creates an executable named `hclalign` in the curr
 - `--check`: Exit with a non-zero status if formatting changes are needed.
 - `--diff`: Print a unified diff of required changes instead of modifying files.
 - `--stdin`, `--stdout`: Read from STDIN and/or write results to STDOUT.
-- `--include`: Glob patterns of files to include (default: `*.hcl`).
+- `--include`: Glob patterns of files to include.
 - `--exclude`: Glob patterns of files to exclude.
+- `--follow-symlinks`: Follow symbolic links when traversing directories.
 - `--order`: Attribute order for variable blocks.
 - `--strict-order`: Fail if attributes appear outside the specified order.
 - `--concurrency`: Maximum number of files processed in parallel (default: number of CPUs).
 - `-v, --verbose`: Enable verbose logging.
 
 ## Examples
+
+### Basic Formatting
 
 Format all `.tf` files under the current directory and write the result back to disk:
 
@@ -77,6 +90,50 @@ Process a single file from STDIN and write the result to STDOUT:
 ```sh
 cat variables.tf | ./hclalign --stdin --stdout
 ```
+
+### CI Usage
+
+Use `--check` in Continuous Integration to fail builds when formatting is needed:
+
+```sh
+hclalign . --check
+```
+
+### Editor Integration
+
+Editors can format on save by piping file contents through `hclalign`:
+
+```sh
+hclalign --stdin --stdout <file.tf >formatted.tf && mv formatted.tf file.tf
+```
+
+## Default Include and Exclude Patterns
+
+By default, `hclalign` processes Terraform files and skips common build artifacts:
+
+| Type    | Patterns                                                                 |
+|---------|---------------------------------------------------------------------------|
+| Include | `**/*.tf`                                                                |
+| Exclude | `**/.terraform/**`, `**/vendor/**`, `**/.git/**`, `**/node_modules/**`    |
+
+## Following Symlinks
+
+Symbolic links are ignored by default to avoid unexpected traversals. Use `--follow-symlinks` to include files reachable via symlinks.
+
+## Strict Order Enforcement
+
+Specify attribute order with `--order`. When `--strict-order` is set, all attributes must appear exactly once in the given order and no other attributes are allowed.
+
+## Exit Codes
+
+`hclalign` returns the following exit codes:
+
+| Code | Meaning                                              |
+|------|------------------------------------------------------|
+| 0    | Success; files were formatted or already aligned.    |
+| 1    | Files need formatting in `--check` or `--diff` mode. |
+| 2    | Invalid usage or configuration error.                |
+| 3    | Processing error.                                    |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- document atomic writes, default patterns, symlink handling, strict order, exit codes, and CI/editor usage
- highlight new symlink traversal and exit code docs in changelog

## Testing
- `golangci-lint run` *(fails: depguard import errors and formatting issues)*
- `go test -race ./...`
- `go test -run Fuzz ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0aa62f6188323a4e1df1f292bc487