### PR TITLE
refactor: centralize diff generation

### DIFF
--- a/fileprocessing/fileprocessing.go
+++ b/fileprocessing/fileprocessing.go
@@ -18,10 +18,10 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/pmezard/go-difflib/difflib"
 
 	"github.com/oferchen/hclalign/config"
 	"github.com/oferchen/hclalign/hclprocessing"
+	"github.com/oferchen/hclalign/internal/diff"
 	internalfs "github.com/oferchen/hclalign/internal/fs"
 	"github.com/oferchen/hclalign/patternmatching"
 )
@@ -173,15 +173,7 @@ func processSingleFile(ctx context.Context, filePath string, cfg *config.Config)
 		}
 	case config.ModeDiff:
 		if changed {
-			ud := difflib.UnifiedDiff{
-				A:        difflib.SplitLines(string(original)),
-				B:        difflib.SplitLines(string(styled)),
-				FromFile: filePath,
-				ToFile:   filePath,
-				Context:  3,
-				Eol:      hints.Newline,
-			}
-			text, err := difflib.GetUnifiedDiffString(ud)
+			text, err := diff.Unified(filePath, filePath, original, styled, hints.Newline)
 			if err != nil {
 				return false, err
 			}
@@ -218,15 +210,7 @@ func processReader(ctx context.Context, r io.Reader, cfg *config.Config) (bool, 
 	switch cfg.Mode {
 	case config.ModeDiff:
 		if changed {
-			ud := difflib.UnifiedDiff{
-				A:        difflib.SplitLines(string(original)),
-				B:        difflib.SplitLines(string(styled)),
-				FromFile: "stdin",
-				ToFile:   "stdin",
-				Context:  3,
-				Eol:      hints.Newline,
-			}
-			text, err := difflib.GetUnifiedDiffString(ud)
+			text, err := diff.Unified("stdin", "stdin", original, styled, hints.Newline)
 			if err != nil {
 				return false, err
 			}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,17 @@
+package diff
+
+import "github.com/pmezard/go-difflib/difflib"
+
+// Unified generates a unified diff for two byte slices using the given
+// file names and line ending. The diff always uses a context of 3 lines.
+func Unified(fromFile, toFile string, original, styled []byte, eol string) (string, error) {
+	ud := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(original)),
+		B:        difflib.SplitLines(string(styled)),
+		FromFile: fromFile,
+		ToFile:   toFile,
+		Context:  3,
+		Eol:      eol,
+	}
+	return difflib.GetUnifiedDiffString(ud)
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,39 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUnifiedDiff(t *testing.T) {
+	a := []byte("line1\nline2\n")
+	b := []byte("line1\nline3\n")
+	diffStr, err := Unified("a", "a", a, b, "\n")
+	if err != nil {
+		t.Fatalf("Unified returned error: %v", err)
+	}
+	expected := strings.Join([]string{
+		"--- a",
+		"+++ a",
+		"@@ -1,3 +1,3 @@",
+		" line1",
+		"-line2",
+		"+line3",
+		" ",
+	}, "\n") + "\n"
+	if diffStr != expected {
+		t.Fatalf("unexpected diff:\n%q\nexpected:\n%q", diffStr, expected)
+	}
+}
+
+func TestUnifiedDiffUsesEOL(t *testing.T) {
+	a := []byte("line1\r\nline2\r\n")
+	b := []byte("line1\r\nline3\r\n")
+	diffStr, err := Unified("a", "a", a, b, "\r\n")
+	if err != nil {
+		t.Fatalf("Unified returned error: %v", err)
+	}
+	if !strings.Contains(diffStr, "-line2\r\n+line3\r\n") {
+		t.Fatalf("expected CRLF line endings in diff, got: %q", diffStr)
+	}
+}


### PR DESCRIPTION
## Summary
- add internal diff package wrapping go-difflib unified diff creation
- leverage diff helper in file processing code instead of direct difflib use
- cover diff helper with unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0acbb496083238c5c16a1a882c8af