### PR TITLE
Respect original newline in variable blocks

### DIFF
--- a/hclprocessing/hclprocessing.go
+++ b/hclprocessing/hclprocessing.go
@@ -73,11 +73,14 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, knownSet map[st
 	}
 
 	tail := body.BuildTokens(nil)
-	if len(tail) > 0 && tail[0].Type == hclsyntax.TokenNewline {
+	hasNewline := len(tail) > 0 && tail[0].Type == hclsyntax.TokenNewline
+	if hasNewline {
 		tail = tail[1:]
 	}
 	body.Clear()
-	body.AppendNewline()
+	if hasNewline {
+		body.AppendNewline()
+	}
 
 	canonSet := map[string]struct{}{}
 	finalKnown := make([]string, 0, len(canonicalOrder))
@@ -139,6 +142,13 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, knownSet map[st
 		}
 	}
 
+	if !hasNewline {
+		toks := body.BuildTokens(nil)
+		if n := len(toks); n > 0 && toks[n-1].Type == hclsyntax.TokenNewline {
+			body.Clear()
+			body.AppendUnstructuredTokens(toks[:n-1])
+		}
+	}
 	body.AppendUnstructuredTokens(tail)
 
 	for _, nb := range nested {

--- a/hclprocessing/hclprocessing_test.go
+++ b/hclprocessing/hclprocessing_test.go
@@ -123,3 +123,27 @@ func TestReorderAttributes_LoosePreservesUnknownPositions(t *testing.T) {
 }`
 	require.Equal(t, expected, string(f.Bytes()))
 }
+
+func TestReorderAttributes_FirstAttrSameLine(t *testing.T) {
+	src := `variable "example" { default = "v" }`
+	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	hclprocessing.ReorderAttributes(f, nil, false)
+
+	require.Equal(t, src, string(f.Bytes()))
+}
+
+func TestReorderAttributes_OnlyNestedBlocks(t *testing.T) {
+	src := `variable "example" {
+  validation {
+    condition = true
+  }
+}`
+	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	hclprocessing.ReorderAttributes(f, nil, false)
+
+	require.Equal(t, src, string(f.Bytes()))
+}


### PR DESCRIPTION
## Summary
- detect if a variable block body originally started with a newline before clearing
- only insert a leading newline when present and strip trailing newlines when absent
- add regression tests for single-line attributes and blocks containing only nested blocks

## Testing
- `go test ./hclprocessing -run TestReorderAttributes_FirstAttrSameLine -count=1`
- `go test ./hclprocessing -run TestReorderAttributes_OnlyNestedBlocks -count=1`
- `go test ./... -race -shuffle=on -cover`


------
https://chatgpt.com/codex/tasks/task_e_68b0b2ad5eec8323b5fa465032f927df