### PR TITLE
Avoid attribute ordering duplicates in nested expressions

### DIFF
--- a/hclprocessing/hclprocessing.go
+++ b/hclprocessing/hclprocessing.go
@@ -185,10 +185,21 @@ func extractAttrTokens(attr *hclwrite.Attribute) attrTokens {
 
 func attributeOrder(body *hclwrite.Body, attrs map[string]*hclwrite.Attribute) []string {
 	tokens := body.BuildTokens(nil)
-	var order []string
+	order := make([]string, 0, len(attrs))
+	depth := 0
 	for i := 0; i < len(tokens)-1; i++ {
 		tok := tokens[i]
-		if tok.Type == hclsyntax.TokenIdent {
+		switch tok.Type {
+		case hclsyntax.TokenOBrace, hclsyntax.TokenOParen:
+			depth++
+			continue
+		case hclsyntax.TokenCBrace, hclsyntax.TokenCParen:
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if depth == 0 && tok.Type == hclsyntax.TokenIdent {
 			name := string(tok.Bytes)
 			if _, ok := attrs[name]; ok && tokens[i+1].Type == hclsyntax.TokenEqual {
 				order = append(order, name)

--- a/hclprocessing/hclprocessing_test.go
+++ b/hclprocessing/hclprocessing_test.go
@@ -147,3 +147,24 @@ func TestReorderAttributes_OnlyNestedBlocks(t *testing.T) {
 
 	require.Equal(t, src, string(f.Bytes()))
 }
+
+func TestReorderAttributes_DefaultBlockNestedType(t *testing.T) {
+	src := `variable "example" {
+  type    = string
+  default = {
+    type = string
+  }
+}`
+	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	hclprocessing.ReorderAttributes(f, nil, false)
+
+	expected := `variable "example" {
+  type = string
+  default = {
+    type = string
+  }
+}`
+	require.Equal(t, expected, string(f.Bytes()))
+}


### PR DESCRIPTION
## Summary
- Track brace and parenthesis depth when capturing attribute order
- Preallocate attribute order slice to length of attributes
- Add regression test for nested `type` inside a default block

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0b49c6a9883239bdf5a9d37ba9e15