### PR TITLE
Preserve variable block tokens

### DIFF
--- a/tests/cases/one_line/in.tf
+++ b/tests/cases/one_line/in.tf
@@ -1,0 +1,1 @@
+variable "one" { default = 1 }

--- a/tests/cases/one_line/out.tf
+++ b/tests/cases/one_line/out.tf
@@ -1,0 +1,1 @@
+variable "one" { default = 1 }

--- a/tests/cases/validation_comments/in.tf
+++ b/tests/cases/validation_comments/in.tf
@@ -1,0 +1,10 @@
+variable "vc" {
+  default = ""
+  type    = string
+
+  # ensure non-empty
+  validation {
+    condition     = length(var.vc) > 0
+    error_message = "msg"
+  }
+}

--- a/tests/cases/validation_comments/out.tf
+++ b/tests/cases/validation_comments/out.tf
@@ -1,0 +1,10 @@
+variable "vc" {
+  type    = string
+  default = ""
+
+  # ensure non-empty
+  validation {
+    condition     = length(var.vc) > 0
+    error_message = "msg"
+  }
+}


### PR DESCRIPTION
## Summary
- retain prefix and per-block tokens when reordering variable attributes
- normalize carriage returns and reinstate captured tokens when rebuilding body
- add regression cases for single-line variables and comments before validation blocks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0b49d722483238237aac532163b7f