### PR TITLE
Remove debug byte dumps

### DIFF
--- a/fileprocessing/fileprocessing.go
+++ b/fileprocessing/fileprocessing.go
@@ -162,9 +162,7 @@ func processSingleFile(ctx context.Context, filePath string, cfg *config.Config)
 	hclprocessing.ReorderAttributes(file, cfg.Order, cfg.StrictOrder)
 
 	formatted := bytes.ReplaceAll(file.Bytes(), []byte("\r\n"), []byte("\n"))
-	fmt.Printf("formatted bytes: %v\n", formatted)
 	styled := internalfs.ApplyHints(formatted, hints)
-	fmt.Printf("styled bytes: %v\n", styled)
 	original := data
 	if bom := hints.BOM(); len(bom) > 0 {
 		original = append(append([]byte{}, bom...), original...)


### PR DESCRIPTION
## Summary
- remove leftover fmt.Printf debug statements dumping formatted and styled bytes

## Testing
- `go test ./fileprocessing`


------
https://chatgpt.com/codex/tasks/task_e_68b0bc9525388323998a9ccf47fb674d