### PR TITLE
Remove validation from attribute order

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -40,7 +40,10 @@ type Config struct {
 var (
 	DefaultInclude = []string{"**/*.tf"}
 	DefaultExclude = []string{"**/.terraform/**", "**/vendor/**", "**/.git/**", "**/node_modules/**"}
-	DefaultOrder   = []string{"description", "type", "default", "sensitive", "nullable", "validation"}
+	// DefaultOrder defines the canonical ordering of variable block attributes.
+	// Nested blocks such as "validation" are always appended after attributes
+	// and therefore are not part of this list.
+	DefaultOrder = []string{"description", "type", "default", "sensitive", "nullable"}
 )
 
 const (
@@ -67,7 +70,9 @@ func (c *Config) Validate() error {
 
 // ValidateOrder checks whether the provided order is valid. Duplicate
 // attributes always cause an error. When strict is true, all attributes must be
-// from the canonical DefaultOrder list and each must appear exactly once.
+// from the canonical DefaultOrder list and each must appear exactly once. The
+// canonical list only contains attribute names; nested blocks like "validation"
+// are not considered part of the order.
 func ValidateOrder(order []string, strict bool) error {
 	providedSet := make(map[string]struct{})
 	canonicalSet := make(map[string]struct{}, len(DefaultOrder))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,9 +25,15 @@ func TestValidateOrder_StrictDefaultOrder(t *testing.T) {
 }
 
 func TestDefaultOrderMatchesBuiltInAttributes(t *testing.T) {
-	expected := []string{"description", "type", "default", "sensitive", "nullable", "validation"}
+	expected := []string{"description", "type", "default", "sensitive", "nullable"}
 	if !reflect.DeepEqual(DefaultOrder, expected) {
 		t.Fatalf("expected DefaultOrder to be %v, got %v", expected, DefaultOrder)
+	}
+}
+
+func TestValidateOrder_StrictValidationBlock(t *testing.T) {
+	if err := ValidateOrder([]string{"description", "validation"}, true); err == nil {
+		t.Fatalf("expected error for validation block in strict mode")
 	}
 }
 


### PR DESCRIPTION
## Summary
- treat `validation` as a nested block appended after attributes rather than part of the attribute order
- document canonical attribute list and update default ordering
- add tests ensuring `validation` isn't allowed in strict order

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0bc97d0e48323ab27dbe9bd48cd5a