### PR TITLE
Add CI targets and update contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,15 +10,24 @@ Thank you for considering a contribution to `hclalign`!
 
 ## Required Checks
 
-Before submitting a pull request, ensure all of the following commands succeed:
+Before submitting a pull request, ensure the continuous integration pipeline passes:
 
 ```sh
-golangci-lint run
-go test -race ./...
-go test -run Fuzz ./...
+make ci
 ```
 
-These commands must be run from the repository root. Additional tests are welcome.
+This command formats the code, vets, lints, runs the tests with the race detector,
+performs a short fuzz run, and builds the project. If you prefer to run steps
+individually, execute the following from the repository root:
+
+```sh
+make fmt
+make vet
+make lint
+make test-race
+make fuzz-short
+make build
+```
 
 ## Commit Guidelines
 

--- a/Makefile
+++ b/Makefile
@@ -6,59 +6,83 @@ MODULE_NAME=github.com/oferchen/hclalign
 all: build
 
 build:
-        @echo "Compiling the project..."
-        go build ./...
+	@echo "Compiling the project..."
+	go build ./...
 
 run: build
-        @echo "Running the project..."
-        ./${BINARY_NAME}
+	@echo "Running the project..."
+	./${BINARY_NAME}
 
 deps:
-        @echo "Checking and downloading dependencies..."
-        go mod download
+	@echo "Checking and downloading dependencies..."
+	go mod download
 
 tidy:
-        @echo "Tidying and verifying module dependencies..."
-        go mod tidy -v
-        git diff --exit-code go.mod go.sum
+	@echo "Tidying and verifying module dependencies..."
+	go mod tidy -v
+	git diff --exit-code go.mod go.sum
 
 lint:
-        @echo "Running linters..."
-        golangci-lint run
+	@echo "Running linters..."
+	golangci-lint run
+
+fmt:
+	@echo "Formatting code..."
+	go fmt ./...
+
+vet:
+	@echo "Running go vet..."
+	go vet ./...
 
 test:
-        @echo "Running tests..."
-        go test -race -shuffle=on -cover ./...
+	@echo "Running tests..."
+	go test -shuffle=on -cover ./...
+
+test-race:
+	@echo "Running tests with race detector..."
+	go test -race -shuffle=on -cover ./...
 
 fuzz:
-        @echo "Running fuzz tests..."
-        go test ./... -run Fuzz
+	@echo "Running fuzz tests..."
+	go test ./... -run Fuzz
+
+fuzz-short:
+	@echo "Running short fuzz tests..."
+	go test ./... -run Fuzz -fuzztime=5s
 
 vulncheck:
-        @echo "Checking for vulnerabilities..."
-        govulncheck ./... || true
+	@echo "Checking for vulnerabilities..."
+	govulncheck ./... || true
 
 clean:
-        @echo "Cleaning up..."
-        go clean -modcache -fuzzcache
-        rm -f ${BINARY_NAME}
+	@echo "Cleaning up..."
+	go clean -modcache -fuzzcache
+	rm -f ${BINARY_NAME}
 
 init:
-        @echo "Initializing Go module..."
-        go mod init ${MODULE_NAME}
+	@echo "Initializing Go module..."
+	go mod init ${MODULE_NAME}
+
+ci: fmt vet lint test-race fuzz-short build
+	@echo "Running CI pipeline..."
 
 help:
-        @echo "Makefile commands:"
-        @echo "all       - Compiles the project."
-        @echo "build     - Builds the binary executable."
-        @echo "run       - Runs the compiled binary."
-        @echo "deps      - Downloads the project dependencies."
-        @echo "tidy      - Tidies and verifies the module dependencies."
-        @echo "lint      - Runs golangci-lint."
-        @echo "test      - Runs all the tests with race and coverage."
-        @echo "fuzz      - Runs fuzz tests."
-        @echo "vulncheck - Checks for vulnerabilities using govulncheck."
-        @echo "clean     - Cleans up the project."
-        @echo "init      - Initializes a new Go module."
-        @echo "help      - Prints this help message."
+	@echo "Makefile commands:"
+	@echo "all       - Compiles the project."
+	@echo "build     - Builds the binary executable."
+	@echo "run       - Runs the compiled binary."
+	@echo "deps      - Downloads the project dependencies."
+	@echo "tidy      - Tidies and verifies the module dependencies."
+	@echo "fmt       - Formats the code."
+	@echo "vet       - Runs go vet."
+	@echo "lint      - Runs golangci-lint."
+	@echo "test      - Runs all the tests."
+	@echo "test-race - Runs tests with the race detector."
+	@echo "fuzz      - Runs fuzz tests."
+	@echo "fuzz-short - Runs short fuzz tests."
+	@echo "vulncheck - Checks for vulnerabilities using govulncheck."
+	@echo "ci        - Runs formatting, vetting, linting, tests, fuzz, and build."
+	@echo "clean     - Cleans up the project."
+	@echo "init      - Initializes a new Go module."
+	@echo "help      - Prints this help message."
 


### PR DESCRIPTION
## Summary
- add formatting, vetting, race testing, short fuzzing and CI targets to the Makefile and help output
- document running `make ci` and individual workflow steps in CONTRIBUTING

## Testing
- `make fmt`
- `make vet`
- `make lint` *(fails: undefined: doublestar)*
- `make test-race`
- `make fuzz-short`
- `make build`
- `make help`


------
https://chatgpt.com/codex/tasks/task_e_68b0bc9b45788323aae0ced4ebb586c8