### PR TITLE
Add coverage Makefile target and integrate into CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ test-race:
 	@echo "Running tests with race detector..."
 	go test -race -shuffle=on -cover ./...
 
+cover:
+	@echo "Running tests with race detector and coverage..."
+	go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out ./...
+	@echo "Coverage report:"
+	go tool cover -func=coverage.out
+
 fuzz:
 	@echo "Running fuzz tests..."
 	go test ./... -run Fuzz
@@ -57,13 +63,13 @@ vulncheck:
 clean:
 	@echo "Cleaning up..."
 	go clean -modcache -fuzzcache
-	rm -f ${BINARY_NAME}
+	rm -f ${BINARY_NAME} coverage.out
 
 init:
 	@echo "Initializing Go module..."
 	go mod init ${MODULE_NAME}
 
-ci: fmt vet lint test-race fuzz-short build
+ci: fmt vet lint cover fuzz-short build
 	@echo "Running CI pipeline..."
 
 help:
@@ -78,10 +84,11 @@ help:
 	@echo "lint      - Runs golangci-lint."
 	@echo "test      - Runs all the tests."
 	@echo "test-race - Runs tests with the race detector."
+	@echo "cover     - Runs tests with the race detector and generates a coverage report."
 	@echo "fuzz      - Runs fuzz tests."
 	@echo "fuzz-short - Runs short fuzz tests."
 	@echo "vulncheck - Checks for vulnerabilities using govulncheck."
-	@echo "ci        - Runs formatting, vetting, linting, tests, fuzz, and build."
+	@echo "ci        - Runs formatting, vetting, linting, coverage tests, fuzz, and build."
 	@echo "clean     - Cleans up the project."
 	@echo "init      - Initializes a new Go module."
 	@echo "help      - Prints this help message."


### PR DESCRIPTION
## Summary
- add `cover` target to run tests with race detector and atomic coverage
- report coverage details after tests
- hook `ci` into coverage and clean up `coverage.out`

## Testing
- `make cover`

------
https://chatgpt.com/codex/tasks/task_e_68b0c1b62ae08323a15c74ee934a810a