### PR TITLE
Add context-aware file operations

### DIFF
--- a/internal/fs/atomic_test.go
+++ b/internal/fs/atomic_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -177,7 +178,7 @@ func TestWriteFileAtomic(t *testing.T) {
 			if tc.setup != nil {
 				ctx = tc.setup(t, dir, path)
 			}
-			if err := WriteFileAtomic(path, tc.data, tc.perm, tc.hints); err != nil {
+			if err := WriteFileAtomic(context.Background(), path, tc.data, tc.perm, tc.hints); err != nil {
 				t.Fatalf("WriteFileAtomic: %v", err)
 			}
 			if tc.validate != nil {


### PR DESCRIPTION
## Summary
- bail out of directory walking when context cancellation occurs
- add context checks to file reading and atomic writes
- update tests for context-aware behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0c1b1c6e083239b38964ab028895e