### PR TITLE
Remove internal comments

### DIFF
--- a/fileprocessing/fileprocessing.go
+++ b/fileprocessing/fileprocessing.go
@@ -167,9 +167,6 @@ func processFiles(ctx context.Context, cfg *config.Config) (bool, error) {
 	return changed.Load(), nil
 }
 
-// processSingleFile processes a single file and returns whether the file was
-// changed along with any output that should be written to stdout. The output is
-// either formatted file bytes or diff text depending on the mode and flags.
 func processSingleFile(ctx context.Context, filePath string, cfg *config.Config) (bool, []byte, error) {
 	if err := ctx.Err(); err != nil {
 		return false, nil, err


### PR DESCRIPTION
## Summary
- ensure Go files only retain a single file path header comment
- remove stray processSingleFile comment in fileprocessing

## Testing
- `go test ./...` *(fails: not enough arguments in call to internalfs.WriteFileAtomic)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c5d71c588323b7f3758538f3614c