### PR TITLE
Ensure commentcheck validates itself

### DIFF
--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -1,3 +1,4 @@
+// cmd/commentcheck/main.go
 package main
 
 import (
@@ -11,7 +12,7 @@ import (
 	"strings"
 )
 
-var dirs = []string{"cli", "config", "fileprocessing", "hclprocessing", "internal", "patternmatching"}
+var dirs = []string{"cli", "cmd/commentcheck", "config", "fileprocessing", "hclprocessing", "internal", "patternmatching"}
 
 func main() {
 	var files []string

--- a/fileprocessing/fileprocessing_test.go
+++ b/fileprocessing/fileprocessing_test.go
@@ -413,8 +413,6 @@ func TestProcessStopsAfterMalformedFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read good file: %v", err)
 	}
-	// The good file should remain unmodified since processing stops after
-	// encountering the malformed file and the write operation is canceled.
 	expected := []byte("variable \"a\" {\n  default = 1\n  type = number\n}\n")
 	if string(data) != string(expected) {
 		t.Fatalf("good file unexpectedly processed: got %q, want %q", data, expected)


### PR DESCRIPTION
## Summary
- remove redundant comment lines in fileprocessing tests
- let commentcheck verify its own sources and annotate its main

## Testing
- `go run ./cmd/commentcheck && echo 'commentcheck passed'`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc8645348323993092cc0924c474