### PR TITLE
Add golden test for template expressions

### DIFF
--- a/tests/cases/templates/in.tf
+++ b/tests/cases/templates/in.tf
@@ -1,0 +1,13 @@
+variable "interpolation" {
+  default = "${var.foo}"
+  type    = string
+}
+
+variable "directive" {
+  default = <<-EOT
+%{if var.bar}
+${var.bar}
+%{endif}
+EOT
+  type = string
+}

--- a/tests/cases/templates/out.tf
+++ b/tests/cases/templates/out.tf
@@ -1,0 +1,13 @@
+variable "interpolation" {
+  type    = string
+  default = "${var.foo}"
+}
+
+variable "directive" {
+  type    = string
+  default = <<-EOT
+%{if var.bar}
+${var.bar}
+%{endif}
+EOT
+}

--- a/tests/cases/templates/out_strict.tf
+++ b/tests/cases/templates/out_strict.tf
@@ -1,0 +1,13 @@
+variable "interpolation" {
+  type    = string
+  default = "${var.foo}"
+}
+
+variable "directive" {
+  type    = string
+  default = <<-EOT
+%{if var.bar}
+${var.bar}
+%{endif}
+EOT
+}


### PR DESCRIPTION
## Summary
- add golden test demonstrating attribute reordering when values contain interpolation and conditional templates

## Testing
- `go test ./internal/align -run Golden -v`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc8ec7048323a08cfe3ca8644379