### PR TITLE
test: cover dynamic and lifecycle blocks in non_variable case

### DIFF
--- a/tests/cases/non_variable/in.tf
+++ b/tests/cases/non_variable/in.tf
@@ -42,3 +42,26 @@ import {
   id = "i-123"
   to = aws_instance.example
 }
+
+dynamic "d" {
+  for_each = [1]
+  content {
+    b = 1
+    a = 2
+  }
+}
+
+lifecycle {
+  prevent_destroy       = false
+  create_before_destroy = true
+
+  precondition {
+    error_message = "pre"
+    condition     = true
+  }
+
+  postcondition {
+    error_message = "post"
+    condition     = true
+  }
+}

--- a/tests/cases/non_variable/out.tf
+++ b/tests/cases/non_variable/out.tf
@@ -42,3 +42,26 @@ import {
   id = "i-123"
   to = aws_instance.example
 }
+
+dynamic "d" {
+  for_each = [1]
+  content {
+    b = 1
+    a = 2
+  }
+}
+
+lifecycle {
+  prevent_destroy       = false
+  create_before_destroy = true
+
+  precondition {
+    error_message = "pre"
+    condition     = true
+  }
+
+  postcondition {
+    error_message = "post"
+    condition     = true
+  }
+}


### PR DESCRIPTION
## Summary
- add dynamic block to non_variable fixtures
- extend non_variable fixtures with lifecycle block using pre/post condition

## Testing
- `go test ./internal/align -run Golden`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc93dc2083239228ec44c68508ab