### PR TITLE
refactor: remove local canonical order

### DIFF
--- a/hclprocessing/hclprocessing.go
+++ b/hclprocessing/hclprocessing.go
@@ -9,15 +9,13 @@ import (
 	"github.com/oferchen/hclalign/config"
 )
 
-var canonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
-
 func ReorderAttributes(file *hclwrite.File, order []string, strict bool) {
 	if len(order) == 0 {
 		order = config.CanonicalOrder
 	}
 
-	canonicalSet := make(map[string]struct{}, len(canonicalOrder))
-	for _, name := range canonicalOrder {
+	canonicalSet := make(map[string]struct{}, len(config.CanonicalOrder))
+	for _, name := range config.CanonicalOrder {
 		canonicalSet[name] = struct{}{}
 	}
 
@@ -142,7 +140,7 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 	body.AppendUnstructuredTokens(prefixTokens)
 
 	canonicalOrderSet := map[string]struct{}{}
-	orderedKnown := make([]string, 0, len(canonicalOrder))
+	orderedKnown := make([]string, 0, len(config.CanonicalOrder))
 	for _, name := range order {
 		canonicalOrderSet[name] = struct{}{}
 		if _, ok := attrTokensMap[name]; ok {
@@ -150,7 +148,7 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 		}
 	}
 
-	for _, name := range canonicalOrder {
+	for _, name := range config.CanonicalOrder {
 		if _, already := canonicalOrderSet[name]; already {
 			continue
 		}


### PR DESCRIPTION
## Summary
- use config.CanonicalOrder directly in hclprocessing

## Testing
- `go vet ./...`
- `go test ./hclprocessing`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc994da88323b6a53eb6c47d3d9f