### PR TITLE
chore: add header comment to strict error test

### DIFF
--- a/internal/align/strict_error_test.go
+++ b/internal/align/strict_error_test.go
@@ -1,3 +1,4 @@
+// internal/align/strict_error_test.go
 package align
 
 import (


### PR DESCRIPTION
## Summary
- add explicit file header comment for strict_error_test.go

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0d3b78c388323b311568446de1810