### PR TITLE
Remove unused canonicalOrder variable

### DIFF
--- a/internal/hclalign/hclalign.go
+++ b/internal/hclalign/hclalign.go
@@ -12,8 +12,6 @@ import (
 	"github.com/oferchen/hclalign/config"
 )
 
-var canonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
-
 func ReorderAttributes(file *hclwrite.File, order []string, strict bool) error {
 	if len(order) == 0 {
 		order = config.CanonicalOrder


### PR DESCRIPTION
## Summary
- remove leftover `canonicalOrder` slice from `hclalign`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0d3bdb60c8323bfc309c42e7c5aec