### PR TITLE
Add tests for file hint detection

### DIFF
--- a/internal/fs/hints_test.go
+++ b/internal/fs/hints_test.go
@@ -1,0 +1,98 @@
+// internal/fs/hints_test.go
+package fs
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectHintsFromBytes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input []byte
+		want  Hints
+	}{
+		{
+			name:  "lf",
+			input: []byte("one\ntwo\n"),
+			want:  Hints{Newline: "\n"},
+		},
+		{
+			name:  "crlf",
+			input: []byte("one\r\ntwo\r\n"),
+			want:  Hints{Newline: "\r\n"},
+		},
+		{
+			name:  "bom_lf",
+			input: append(append([]byte{}, utf8BOM...), []byte("one\ntwo\n")...),
+			want:  Hints{HasBOM: true, Newline: "\n"},
+		},
+		{
+			name:  "bom_crlf",
+			input: append(append([]byte{}, utf8BOM...), []byte("one\r\ntwo\r\n")...),
+			want:  Hints{HasBOM: true, Newline: "\r\n"},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := DetectHintsFromBytes(tc.input)
+			if got.HasBOM != tc.want.HasBOM || got.Newline != tc.want.Newline {
+				t.Fatalf("DetectHintsFromBytes returned %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadFileWithHints(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		content  []byte
+		mode     os.FileMode
+		wantData []byte
+		wantHint Hints
+	}{
+		{
+			name:     "bom_crlf",
+			content:  append(append([]byte{}, utf8BOM...), []byte("one\r\ntwo\r\n")...),
+			mode:     0o600,
+			wantData: []byte("one\r\ntwo\r\n"),
+			wantHint: Hints{HasBOM: true, Newline: "\r\n"},
+		},
+		{
+			name:     "plain",
+			content:  []byte("one\ntwo\n"),
+			mode:     0o644,
+			wantData: []byte("one\ntwo\n"),
+			wantHint: Hints{Newline: "\n"},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "in.txt")
+			if err := os.WriteFile(path, tc.content, tc.mode); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+			data, perm, hint, err := ReadFileWithHints(context.Background(), path)
+			if err != nil {
+				t.Fatalf("ReadFileWithHints: %v", err)
+			}
+			if !bytes.Equal(data, tc.wantData) {
+				t.Fatalf("data mismatch: %q != %q", data, tc.wantData)
+			}
+			if perm != tc.mode {
+				t.Fatalf("mode mismatch: got %v want %v", perm, tc.mode)
+			}
+			if hint.HasBOM != tc.wantHint.HasBOM || hint.Newline != tc.wantHint.Newline {
+				t.Fatalf("hints mismatch: got %+v want %+v", hint, tc.wantHint)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- test DetectHintsFromBytes for BOM and CRLF handling
- test ReadFileWithHints for hints and permissions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0d3c5d658832390a026e392d5a935