### PR TITLE
test: add config validation error cases

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,3 +44,24 @@ func TestDefaultExcludeMatchesExpected(t *testing.T) {
 		t.Fatalf("expected DefaultExclude to be %v, got %v", expected, DefaultExclude)
 	}
 }
+
+func TestValidate_ConcurrencyLessThanOne(t *testing.T) {
+	c := Config{Concurrency: 0}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("expected error for concurrency <1")
+	}
+}
+
+func TestValidate_InvalidIncludePattern(t *testing.T) {
+	c := Config{Concurrency: 1, Include: []string{"["}}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("expected error for invalid include pattern")
+	}
+}
+
+func TestValidate_InvalidExcludePattern(t *testing.T) {
+	c := Config{Concurrency: 1, Exclude: []string{"["}}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("expected error for invalid exclude pattern")
+	}
+}


### PR DESCRIPTION
## Summary
- test concurrency less than one
- ensure invalid include/exclude patterns report errors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0d3cf2c50832382849d17324009f1