### PR TITLE
Add test for stdin with target path

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -45,6 +45,19 @@ func TestRunEUsageError(t *testing.T) {
 	require.Equal(t, 2, exitErr.Code)
 }
 
+func TestRunETargetWithStdin(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.tf")
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{path, "--stdin"})
+	_, err := cmd.ExecuteC()
+	require.Error(t, err)
+	var exitErr *ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 2, exitErr.Code)
+}
+
 func TestRunEFormattingNeeded(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.tf")


### PR DESCRIPTION
## Summary
- test ExitCodeError code 2 when both target path and --stdin are given

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0d3d66f948323ba50b7feb48a4650