### PR TITLE
Add Go coverage threshold check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,11 +48,7 @@ jobs:
         run: go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out ./...
 
       - name: Check coverage
-        run: |
-          go tool cover -func=coverage.out
-          total=$(go tool cover -func=coverage.out | grep ^total: | awk '{print substr($3, 1, length($3)-1)}')
-          echo "Total coverage: ${total}%"
-          awk -v total="$total" 'BEGIN {if (total+0 < 95.0) {printf "Coverage %.1f%% is below 95%%\n", total; exit 1}}'
+        run: go run ./internal/ci/covercheck
 
       - name: Upload coverage
         if: always()

--- a/internal/ci/covercheck/main.go
+++ b/internal/ci/covercheck/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const threshold = 95.0
+
+func main() {
+	const profile = "coverage.out"
+
+	f, err := os.Open(profile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not open %s: %v\n", profile, err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	if !s.Scan() { // skip first line (mode)
+		fmt.Fprintln(os.Stderr, "empty coverage profile")
+		os.Exit(1)
+	}
+
+	var total, covered float64
+	for s.Scan() {
+		fields := strings.Fields(s.Text())
+		if len(fields) < 3 {
+			continue
+		}
+		stmts, err1 := strconv.ParseFloat(fields[1], 64)
+		count, err2 := strconv.ParseFloat(fields[2], 64)
+		if err1 != nil || err2 != nil {
+			fmt.Fprintf(os.Stderr, "invalid line: %s\n", s.Text())
+			os.Exit(1)
+		}
+		total += stmts
+		if count > 0 {
+			covered += stmts
+		}
+	}
+	if err := s.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "error reading coverage profile: %v\n", err)
+		os.Exit(1)
+	}
+
+	if total == 0 {
+		fmt.Fprintln(os.Stderr, "no statements in coverage profile")
+		os.Exit(1)
+	}
+
+	pct := covered / total * 100
+	fmt.Printf("Total coverage: %.1f%%\n", pct)
+	if pct < threshold {
+		fmt.Fprintf(os.Stderr, "Coverage %.1f%% is below %.1f%%\n", pct, threshold)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- add internal coverage check tool enforcing 95% threshold
- invoke coverage checker in CI workflow instead of shell script

## Testing
- `go test ./...`
- `go vet ./...`
- `go run ./internal/ci/covercheck` *(fails: Coverage 62.8% is below 95.0%)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d3e12b148323af40753c1c3d0702