### PR TITLE
Add config validation tests for default and duplicate order

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -65,3 +65,28 @@ func TestValidate_InvalidExcludePattern(t *testing.T) {
 		t.Fatalf("expected error for invalid exclude pattern")
 	}
 }
+
+func TestValidate_ValidConfig(t *testing.T) {
+	c := Config{
+		Concurrency: 1,
+		Include:     DefaultInclude,
+		Exclude:     DefaultExclude,
+		Order:       CanonicalOrder,
+		StrictOrder: true,
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidate_DuplicateOrderAttribute(t *testing.T) {
+	c := Config{
+		Concurrency: 1,
+		Include:     DefaultInclude,
+		Exclude:     DefaultExclude,
+		Order:       []string{"description", "description"},
+	}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("expected error for duplicate order attribute")
+	}
+}


### PR DESCRIPTION
## Summary
- Add unit test ensuring a Config with default include/exclude, canonical order, and valid concurrency validates successfully
- Add unit test verifying duplicate attributes in Order cause validation errors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0d6eea2008323a860590952d8dc6a