### PR TITLE
refactor: drop DefaultOrder in favor of CanonicalOrder

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,8 +34,6 @@ type Config struct {
 var (
 	DefaultInclude = []string{"**/*.tf"}
 	DefaultExclude = []string{"**/.terraform/**", "**/vendor/**", "**/.git/**", "**/node_modules/**"}
-
-	DefaultOrder   = []string{"description", "type", "default", "sensitive", "nullable"}
 	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
 )
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -113,7 +113,7 @@ func TestProcessDiffDeterministicOrder(t *testing.T) {
 		Mode:        config.ModeDiff,
 		Include:     config.DefaultInclude,
 		Exclude:     config.DefaultExclude,
-		Order:       config.DefaultOrder,
+		Order:       config.CanonicalOrder,
 		Concurrency: 2,
 	}
 	if err := cfg.Validate(); err != nil {
@@ -534,7 +534,7 @@ func TestProcessStdoutError(t *testing.T) {
 		Mode:        config.ModeCheck,
 		Include:     config.DefaultInclude,
 		Exclude:     config.DefaultExclude,
-		Order:       config.DefaultOrder,
+		Order:       config.CanonicalOrder,
 		Stdout:      true,
 		Concurrency: 1,
 	}


### PR DESCRIPTION
## Summary
- remove unused `DefaultOrder` configuration constant
- update engine tests to rely on `CanonicalOrder`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0d6d794848323b79891de37d18bb9