### PR TITLE
Avoid reporting changes when processing fails

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -148,7 +148,7 @@ func processFiles(ctx context.Context, cfg *config.Config) (bool, error) {
 	}
 	if err := g.Wait(); err != nil {
 		close(results)
-		return changed.Load(), err
+		return false, err
 	}
 	close(results)
 


### PR DESCRIPTION
## Summary
- ensure processFiles returns no changes if file processing fails

## Testing
- `go test ./internal/engine`
- `go test -run TestProcessStopsAfterMalformedFile -v ./internal/engine`


------
https://chatgpt.com/codex/tasks/task_e_68b0da6512588323a82b76e52d4014fe