### PR TITLE
Handle missing Go toolchain

### DIFF
--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"go/parser"
 	"go/token"
@@ -12,6 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 )
+
+var execCommand = exec.Command
 
 func main() {
 	dirs, err := packageDirs()
@@ -84,8 +87,12 @@ func checkFile(path string) error {
 }
 
 func packageDirs() ([]string, error) {
-	out, err := exec.Command("go", "list", "-f", "{{.Dir}}", "./...").Output()
+	cmd := execCommand("go", "list", "-f", "{{.Dir}}", "./...")
+	out, err := cmd.Output()
 	if err != nil {
+		if ee, ok := err.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
+			return nil, errors.New("commentcheck requires a Go toolchain")
+		}
 		return nil, err
 	}
 	var dirs []string

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestPackageDirsNoGoBinary(t *testing.T) {
+	orig := execCommand
+	defer func() { execCommand = orig }()
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("nonexistent-go-binary")
+	}
+	_, err := packageDirs()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != "commentcheck requires a Go toolchain" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPackageDirsCommandError(t *testing.T) {
+	orig := execCommand
+	defer func() { execCommand = orig }()
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("sh", "-c", "exit 1")
+	}
+	_, err := packageDirs()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() == "commentcheck requires a Go toolchain" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %T", err)
+	}
+}


### PR DESCRIPTION
## Summary
- gracefully report when the `go` binary is missing
- allow mocking of `exec.Command` and add tests for missing and failing commands

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0dd298f088323a28a39dcefdda884