### PR TITLE
engine: validate target exists

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -33,6 +33,12 @@ func Process(ctx context.Context, cfg *config.Config) (bool, error) {
 }
 
 func processFiles(ctx context.Context, cfg *config.Config) (bool, error) {
+	if _, err := os.Stat(cfg.Target); err != nil {
+		if os.IsNotExist(err) {
+			return false, fmt.Errorf("target %q does not exist", cfg.Target)
+		}
+		return false, err
+	}
 	matcher, err := patternmatching.NewMatcher(cfg.Include, cfg.Exclude)
 	if err != nil {
 		return false, err

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -4,6 +4,7 @@ package engine
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -215,6 +216,47 @@ func TestProcessPropagatesFileError(t *testing.T) {
 	if _, err := Process(context.Background(), cfg); err == nil {
 		t.Fatalf("expected error due to invalid file")
 	}
+}
+
+func TestProcessMissingTarget(t *testing.T) {
+	t.Run("nonexistent path", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "missing.tf")
+
+		cfg := &config.Config{
+			Target:      target,
+			Mode:        config.ModeCheck,
+			Include:     config.DefaultInclude,
+			Exclude:     config.DefaultExclude,
+			Order:       config.CanonicalOrder,
+			Concurrency: 1,
+		}
+		require.NoError(t, cfg.Validate())
+		_, err := Process(context.Background(), cfg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fmt.Sprintf("target %q does not exist", target))
+	})
+
+	t.Run("broken symlink", func(t *testing.T) {
+		dir := t.TempDir()
+		link := filepath.Join(dir, "broken.tf")
+		if err := os.Symlink(filepath.Join(dir, "missing.tf"), link); err != nil {
+			t.Fatalf("symlink: %v", err)
+		}
+
+		cfg := &config.Config{
+			Target:      link,
+			Mode:        config.ModeCheck,
+			Include:     config.DefaultInclude,
+			Exclude:     config.DefaultExclude,
+			Order:       config.CanonicalOrder,
+			Concurrency: 1,
+		}
+		require.NoError(t, cfg.Validate())
+		_, err := Process(context.Background(), cfg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fmt.Sprintf("target %q does not exist", link))
+	})
 }
 
 func TestProcessSymlinkedDirTargetFollowSymlinks(t *testing.T) {


### PR DESCRIPTION
## Summary
- ensure target path exists before processing files
- test missing target and broken symlink scenarios

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0dd26dbec83238fcad2811dde6ffa