### PR TITLE
Allow processReader to write to arbitrary writers

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -27,7 +27,7 @@ import (
 
 func Process(ctx context.Context, cfg *config.Config) (bool, error) {
 	if cfg.Stdin {
-		return processReader(ctx, os.Stdin, cfg)
+		return processReader(ctx, os.Stdin, os.Stdout, cfg)
 	}
 	return processFiles(ctx, cfg)
 }
@@ -229,7 +229,11 @@ func processSingleFile(ctx context.Context, filePath string, cfg *config.Config)
 	return changed, out, nil
 }
 
-func processReader(ctx context.Context, r io.Reader, cfg *config.Config) (bool, error) {
+func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Config) (bool, error) {
+	if w == nil {
+		w = os.Stdout
+	}
+
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return false, err
@@ -262,13 +266,13 @@ func processReader(ctx context.Context, r io.Reader, cfg *config.Config) (bool, 
 			if err != nil {
 				return false, err
 			}
-			if _, err := fmt.Fprint(os.Stdout, text); err != nil {
+			if _, err := fmt.Fprint(w, text); err != nil {
 				return false, err
 			}
 		}
 	default:
 		if cfg.Stdout {
-			if _, err := os.Stdout.Write(styled); err != nil {
+			if _, err := w.Write(styled); err != nil {
 				return changed, err
 			}
 		}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -361,24 +361,13 @@ func TestProcessReaderPreservesNewlineAndBOM(t *testing.T) {
 
 	cfg := &config.Config{Mode: config.ModeWrite, Stdout: true, Order: config.CanonicalOrder}
 
-	oldStdout := os.Stdout
-	rOut, wOut, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stdout = wOut
-	defer func() { os.Stdout = oldStdout }()
-
-	if _, err := processReader(context.Background(), bytes.NewReader([]byte(input)), cfg); err != nil {
+	var out bytes.Buffer
+	if _, err := processReader(context.Background(), bytes.NewReader([]byte(input)), &out, cfg); err != nil {
 		t.Fatalf("processReader: %v", err)
 	}
-	_ = wOut.Close()
-	out, err := io.ReadAll(rOut)
-	if err != nil {
-		t.Fatalf("read stdout: %v", err)
-	}
+	data := out.Bytes()
 
-	hints := internalfs.DetectHintsFromBytes(out)
+	hints := internalfs.DetectHintsFromBytes(data)
 	if !hints.HasBOM {
 		t.Fatalf("bom not preserved")
 	}
@@ -392,8 +381,8 @@ func TestProcessReaderPreservesNewlineAndBOM(t *testing.T) {
 	}
 	require.NoError(t, hclalign.ReorderAttributes(expectedFile, config.CanonicalOrder, false))
 	expected := internalfs.ApplyHints(expectedFile.Bytes(), internalfs.Hints{HasBOM: true, Newline: "\r\n"})
-	if string(out) != string(expected) {
-		t.Fatalf("unexpected output: got %q, want %q", out, expected)
+	if string(data) != string(expected) {
+		t.Fatalf("unexpected output: got %q, want %q", data, expected)
 	}
 }
 
@@ -403,27 +392,15 @@ func TestProcessReaderDiffPreservesNewline(t *testing.T) {
 
 	cfg := &config.Config{Mode: config.ModeDiff, Order: config.CanonicalOrder}
 
-	oldStdout := os.Stdout
-	rOut, wOut, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stdout = wOut
-	defer func() { os.Stdout = oldStdout }()
-
-	changed, err := processReader(context.Background(), bytes.NewReader([]byte(input)), cfg)
+	var out bytes.Buffer
+	changed, err := processReader(context.Background(), bytes.NewReader([]byte(input)), &out, cfg)
 	if err != nil {
 		t.Fatalf("processReader: %v", err)
 	}
 	if !changed {
 		t.Fatalf("expected changes")
 	}
-	_ = wOut.Close()
-	out, err := io.ReadAll(rOut)
-	if err != nil {
-		t.Fatalf("read stdout: %v", err)
-	}
-	hints := internalfs.DetectHintsFromBytes(out)
+	hints := internalfs.DetectHintsFromBytes(out.Bytes())
 	if hints.Newline != "\r\n" {
 		t.Fatalf("expected CRLF in diff output")
 	}
@@ -559,17 +536,14 @@ func TestProcessStdoutError(t *testing.T) {
 
 func TestProcessReaderStdoutError(t *testing.T) {
 	cfg := &config.Config{Mode: config.ModeWrite, Stdout: true, Order: config.CanonicalOrder}
-	oldStdout := os.Stdout
+
+	input := "variable \"a\" {}\n"
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
 	}
 	_ = w.Close()
-	os.Stdout = w
-	defer func() { os.Stdout = oldStdout }()
-
-	input := "variable \"a\" {}\n"
-	if _, err := processReader(context.Background(), bytes.NewReader([]byte(input)), cfg); err == nil {
+	if _, err := processReader(context.Background(), bytes.NewReader([]byte(input)), w, cfg); err == nil {
 		t.Fatalf("expected error")
 	}
 	_ = r.Close()


### PR DESCRIPTION
## Summary
- extend `processReader` to accept an `io.Writer` allowing output to be directed anywhere
- update `Process` and tests to use the new writer parameter, enabling buffer-based assertions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0dd2c7aa48323999acc7708901e36