### PR TITLE
Add tests for comment and coverage checking tools

### DIFF
--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckFile(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "file.go")
+		wd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("wd: %v", err)
+		}
+		rel, err := filepath.Rel(wd, path)
+		if err != nil {
+			t.Fatalf("rel: %v", err)
+		}
+		content := "// " + filepath.ToSlash(rel) + "\npackage main\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := checkFile(rel); err != nil {
+			t.Fatalf("checkFile returned error: %v", err)
+		}
+	})
+
+	t.Run("missing comment", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "file.go")
+		wd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("wd: %v", err)
+		}
+		rel, err := filepath.Rel(wd, path)
+		if err != nil {
+			t.Fatalf("rel: %v", err)
+		}
+		// write file without leading comment
+		if err := os.WriteFile(path, []byte("package main\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := checkFile(rel); err == nil {
+			t.Fatal("expected error for missing comment")
+		}
+	})
+
+	t.Run("wrong comment", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "file.go")
+		wd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("wd: %v", err)
+		}
+		rel, err := filepath.Rel(wd, path)
+		if err != nil {
+			t.Fatalf("rel: %v", err)
+		}
+		content := "// wrong\npackage main\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := checkFile(rel); err == nil {
+			t.Fatal("expected error for wrong comment")
+		}
+	})
+}

--- a/internal/ci/covercheck/main_test.go
+++ b/internal/ci/covercheck/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func writeProfile(t *testing.T, content string) {
+	t.Helper()
+	if err := os.WriteFile("coverage.out", []byte(content), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	t.Cleanup(func() { os.Remove("coverage.out") })
+}
+
+func TestCoverageAboveThreshold(t *testing.T) {
+	writeProfile(t, "mode: set\nfoo.go:1.1,1.10 1 1\n")
+	cmd := exec.Command("go", "run", ".")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "Total coverage: 100.0%") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestCoverageBelowThreshold(t *testing.T) {
+	writeProfile(t, "mode: set\nfoo.go:1.1,1.10 1 0\n")
+	cmd := exec.Command("go", "run", ".")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error, got none: %s", out)
+	}
+	if !strings.Contains(string(out), "Coverage 0.0% is below 95.0%") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for commentcheck to validate required file-level comments
- add tests for covercheck to verify coverage threshold handling

## Testing
- `go test ./cmd/commentcheck -v`
- `go test ./internal/ci/covercheck -v`


------
https://chatgpt.com/codex/tasks/task_e_68b0dd1c5ab483239739eac304c8c157