### PR TITLE
Include command packages in coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,7 +45,12 @@ jobs:
           govulncheck ./...
 
       - name: Test
-        run: go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out ./...
+        run: |
+          PKG_TEST=$(go list ./... | grep -v cmd/commentcheck | grep -v internal/ci/covercheck)
+          go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out $PKG_TEST
+          go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.tmp ./cmd/commentcheck ./internal/ci/covercheck
+          tail -n +2 coverage.tmp >> coverage.out
+          rm coverage.tmp
 
       - name: Check coverage
         run: go run ./internal/ci/covercheck

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 BINARY_NAME=hclalign
 MODULE_NAME=github.com/oferchen/hclalign
+PKG_TEST=$(shell go list ./... | grep -v cmd/commentcheck | grep -v internal/ci/covercheck)
 
 all: build
 
@@ -48,7 +49,10 @@ test-race:
 
 cover:
 	@echo "Running tests with race detector and coverage..."
-	go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out ./...
+	go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out $(PKG_TEST)
+	go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.tmp ./cmd/commentcheck ./internal/ci/covercheck
+	tail -n +2 coverage.tmp >> coverage.out
+	rm coverage.tmp
 	@echo "Coverage report:"
 	go tool cover -func=coverage.out
 


### PR DESCRIPTION
## Summary
- include cmd/commentcheck and internal/ci/covercheck in coverage collection
- merge coverage from command packages into main profile

## Testing
- `make cover`
- `go run ./internal/ci/covercheck` *(fails: coverage 67.2% is below 95.0%)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dd20a0bc83239b14f5b540aa2b89