### PR TITLE
Ensure sequential file processing respects cancellation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/sync v0.16.0
 )
 
 require (
@@ -21,6 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/zclconf/go-cty v1.16.4 // indirect
 	golang.org/x/mod v0.17.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -11,9 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"sync/atomic"
-
-	"golang.org/x/sync/errgroup"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -110,61 +107,47 @@ func processFiles(ctx context.Context, cfg *config.Config) (bool, error) {
 	}
 	sort.Strings(files)
 
-	sem := make(chan struct{}, cfg.Concurrency)
-	g, ctx := errgroup.WithContext(ctx)
-	var changed atomic.Bool
-	type result struct {
-		path string
-		data []byte
-	}
-	results := make(chan result, len(files))
-	for _, f := range files {
-		f := f
-		select {
-		case sem <- struct{}{}:
-		case <-ctx.Done():
-			return changed.Load(), ctx.Err()
-		}
-		g.Go(func() error {
-			defer func() { <-sem }()
-			ch, out, err := processSingleFile(ctx, f, cfg)
-			if err != nil {
-				if !errors.Is(err, context.Canceled) {
-					log.Printf("error processing file %s: %v", f, err)
-				}
-				return fmt.Errorf("%s: %w", f, err)
-			}
-			if ch {
-				changed.Store(true)
-			}
-			if len(out) > 0 {
-				results <- result{path: f, data: out}
-			}
-			if cfg.Verbose {
-				log.Printf("processed file: %s", f)
-			}
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
-		close(results)
-		return false, err
-	}
-	close(results)
-
+	var changed bool
 	outs := make(map[string][]byte, len(files))
-	for r := range results {
-		outs[r.path] = r.data
+	for _, f := range files {
+		if err := ctx.Err(); err != nil {
+			return changed, err
+		}
+		ch, out, err := processSingleFile(ctx, f, cfg)
+		if err != nil {
+			if !errors.Is(err, context.Canceled) {
+				log.Printf("error processing file %s: %v", f, err)
+			}
+			return false, fmt.Errorf("%s: %w", f, err)
+		}
+		if ch {
+			changed = true
+		}
+		if len(out) > 0 {
+			outs[f] = out
+		}
+		if cfg.Verbose {
+			if err := ctx.Err(); err != nil {
+				return changed, err
+			}
+			log.Printf("processed file: %s", f)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return changed, err
 	}
 	for _, f := range files {
 		if out, ok := outs[f]; ok && len(out) > 0 {
+			if err := ctx.Err(); err != nil {
+				return changed, err
+			}
 			if _, err := os.Stdout.Write(out); err != nil {
-				return changed.Load(), err
+				return changed, err
 			}
 		}
 	}
 
-	return changed.Load(), nil
+	return changed, nil
 }
 
 func processSingleFile(ctx context.Context, filePath string, cfg *config.Config) (bool, []byte, error) {


### PR DESCRIPTION
## Summary
- process files one at a time and stop on first error
- check context cancellation before logging and writing output
- test that files after malformed ones are skipped and not logged

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0dcefdb3883239850145bca99a4c8