### PR TITLE
Add tests for comment and coverage checks

### DIFF
--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func TestCheckFileOK(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foo.go")
+	comment := fmt.Sprintf("// %s\n", filepath.ToSlash(path))
+	write(t, path, comment+"package main\n")
+	if err := checkFile(path); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCheckFileMissingComment(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foo.go")
+	write(t, path, "package main\n")
+	if err := checkFile(path); err == nil || !strings.Contains(err.Error(), "first line must be") {
+		t.Fatalf("expected missing comment error, got %v", err)
+	}
+}
+
+func TestCheckFileMalformedComment(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foo.go")
+	write(t, path, "// wrong\npackage main\n")
+	if err := checkFile(path); err == nil || !strings.Contains(err.Error(), "first line must be") {
+		t.Fatalf("expected malformed comment error, got %v", err)
+	}
+}

--- a/internal/ci/covercheck/main_test.go
+++ b/internal/ci/covercheck/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func runCovercheck(t *testing.T) (string, int) {
+	t.Helper()
+	cmd := exec.Command("go", "run", ".")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return string(out), 0
+	}
+	if ee, ok := err.(*exec.ExitError); ok {
+		return string(out), ee.ExitCode()
+	}
+	t.Fatalf("unexpected error: %v", err)
+	return "", 0
+}
+
+func TestCovercheck(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  string
+		wantExit int
+		wantMsg  string
+	}{
+		{
+			name:     "above",
+			profile:  "mode: set\nfile.go:1.1,1.2 1 1\n",
+			wantExit: 0,
+			wantMsg:  "Total coverage: 100.0%",
+		},
+		{
+			name:     "below",
+			profile:  "mode: set\nfile.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
+			wantExit: 1,
+			wantMsg:  "Coverage 50.0% is below 95.0%",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile("coverage.out", []byte(tc.profile), 0644); err != nil {
+				t.Fatalf("write profile: %v", err)
+			}
+			defer os.Remove("coverage.out")
+			out, code := runCovercheck(t)
+			if code != tc.wantExit {
+				t.Fatalf("exit %d, want %d; output: %s", code, tc.wantExit, out)
+			}
+			if !strings.Contains(out, tc.wantMsg) {
+				t.Fatalf("output %q does not contain %q", out, tc.wantMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add tests verifying commentcheck detects missing or malformed file comments
- add tests to covercheck for coverage above and below the threshold

## Testing
- `go test ./cmd/commentcheck`
- `go test ./internal/ci/covercheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0dcf2b6188323979e760d092f2bb2