### PR TITLE
Run tests for command packages in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,7 +45,13 @@ jobs:
           govulncheck ./...
 
       - name: Test
-        run: go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out ./...
+        run: |
+          go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out ./...
+          go test -race -shuffle=on -covermode=atomic -coverprofile=cmd_commentcheck.out ./cmd/commentcheck
+          tail -n +2 cmd_commentcheck.out >> coverage.out
+          go test -race -shuffle=on -covermode=atomic -coverprofile=ci_covercheck.out ./internal/ci/covercheck
+          tail -n +2 ci_covercheck.out >> coverage.out
+          rm cmd_commentcheck.out ci_covercheck.out
 
       - name: Check coverage
         run: go run ./internal/ci/covercheck

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,11 @@ test-race:
 cover:
 	@echo "Running tests with race detector and coverage..."
 	go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out ./...
+	go test -race -shuffle=on -covermode=atomic -coverprofile=cmd_commentcheck.out ./cmd/commentcheck
+	tail -n +2 cmd_commentcheck.out >> coverage.out
+	go test -race -shuffle=on -covermode=atomic -coverprofile=ci_covercheck.out ./internal/ci/covercheck
+	tail -n +2 ci_covercheck.out >> coverage.out
+	rm cmd_commentcheck.out ci_covercheck.out
 	@echo "Coverage report:"
 	go tool cover -func=coverage.out
 


### PR DESCRIPTION
## Summary
- run go test on cmd/commentcheck and internal/ci/covercheck during CI and merge coverage
- include these packages when generating coverage via Makefile

## Testing
- `go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out ./...`
- `go test -race -shuffle=on -covermode=atomic -coverprofile=cmd_commentcheck.out ./cmd/commentcheck`
- `go test -race -shuffle=on -covermode=atomic -coverprofile=ci_covercheck.out ./internal/ci/covercheck`
- `go run ./internal/ci/covercheck` *(fails: Coverage 58.8% is below 95.0%)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dcfe8c848323858438aeb32a8eff