### PR TITLE
engine: abort processing when context canceled

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -183,8 +183,14 @@ func processSingleFile(ctx context.Context, filePath string, cfg *config.Config)
 	if diags.HasErrors() {
 		return false, nil, fmt.Errorf("parsing error in file %s: %v", filePath, diags.Errs())
 	}
+	if err := ctx.Err(); err != nil {
+		return false, nil, err
+	}
 
 	if err := hclalign.ReorderAttributes(file, cfg.Order, cfg.StrictOrder); err != nil {
+		return false, nil, err
+	}
+	if err := ctx.Err(); err != nil {
 		return false, nil, err
 	}
 


### PR DESCRIPTION
## Summary
- add context cancellation checks after parsing and after attribute reordering
- cover cancellation path in new processSingleFile test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0dd0037f88323a53321a611acbeb1