### PR TITLE
Handle missing target path

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -33,6 +33,12 @@ func Process(ctx context.Context, cfg *config.Config) (bool, error) {
 }
 
 func processFiles(ctx context.Context, cfg *config.Config) (bool, error) {
+	if _, err := os.Stat(cfg.Target); err != nil {
+		if os.IsNotExist(err) {
+			return false, fmt.Errorf("target %q does not exist", cfg.Target)
+		}
+		return false, err
+	}
 	matcher, err := patternmatching.NewMatcher(cfg.Include, cfg.Exclude)
 	if err != nil {
 		return false, err

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -4,6 +4,7 @@ package engine
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -186,6 +187,22 @@ func TestProcessContextCanceledNoLog(t *testing.T) {
 	if buf.Len() != 0 {
 		t.Fatalf("expected no logs, got %q", buf.String())
 	}
+}
+
+func TestProcessMissingTarget(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "missing.tf")
+	cfg := &config.Config{
+		Target:      missing,
+		Mode:        config.ModeCheck,
+		Include:     config.DefaultInclude,
+		Exclude:     config.DefaultExclude,
+		Order:       config.CanonicalOrder,
+		Concurrency: 1,
+	}
+	require.NoError(t, cfg.Validate())
+	_, err := Process(context.Background(), cfg)
+	require.EqualError(t, err, fmt.Sprintf("target %q does not exist", missing))
 }
 
 func TestProcessPropagatesFileError(t *testing.T) {


### PR DESCRIPTION
## Summary
- return clear error when target path is missing before traversing files
- add test covering missing target

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0dd033cb08323a9a26a6e2fc9fef9