### PR TITLE
Detect missing Go toolchain for commentcheck

### DIFF
--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -13,6 +13,11 @@ import (
 	"strings"
 )
 
+var (
+	execCommand = exec.Command
+	lookPath    = exec.LookPath
+)
+
 func main() {
 	dirs, err := packageDirs()
 	if err != nil {
@@ -84,7 +89,10 @@ func checkFile(path string) error {
 }
 
 func packageDirs() ([]string, error) {
-	out, err := exec.Command("go", "list", "-f", "{{.Dir}}", "./...").Output()
+	if _, err := lookPath("go"); err != nil {
+		return nil, fmt.Errorf("commentcheck requires a Go toolchain: %w", err)
+	}
+	out, err := execCommand("go", "list", "-f", "{{.Dir}}", "./...").Output()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestPackageDirs_GoNotFound(t *testing.T) {
+	originalLookPath := lookPath
+	t.Cleanup(func() { lookPath = originalLookPath })
+	lookPath = func(string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+	if _, err := packageDirs(); err == nil || !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("expected exec.ErrNotFound, got %v", err)
+	}
+}
+
+func TestPackageDirs_CommandFailure(t *testing.T) {
+	originalLookPath := lookPath
+	originalExecCommand := execCommand
+	t.Cleanup(func() {
+		lookPath = originalLookPath
+		execCommand = originalExecCommand
+	})
+	lookPath = func(string) (string, error) { return "go", nil }
+	execCommand = func(string, ...string) *exec.Cmd {
+		return exec.Command("bash", "-c", "exit 1")
+	}
+	if _, err := packageDirs(); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- verify a Go toolchain exists before running `commentcheck`
- allow mocking exec helpers and add tests for missing toolchain and command failures

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0dd0457148323aba5eaaec81fa7e4