### PR TITLE
Clean up commentcheck documentation

### DIFF
--- a/cmd/commentcheck/doc.go
+++ b/cmd/commentcheck/doc.go
@@ -1,20 +1,9 @@
 // cmd/commentcheck/doc.go
 
-// Command commentcheck verifies that each Go source file in the module starts with a
-// comment matching its relative path.
+// Command commentcheck verifies that each Go source file in the module
+// starts with a comment containing its repository-relative path.
 //
-// Example usage:
-//
-//	$ commentcheck
-//	internal/foo/bar.go: first line must be "// internal/foo/bar.go"
-//
-// The tool exits with status 1 when mismatches are found.
-=======
-
-// Package main provides the commentcheck command. It verifies that each Go
-// source file starts with a comment containing its repository-relative path.
-//
-// Example
+// Example:
 //
 //	$ cat hello.go
 //	// hello.go
@@ -23,12 +12,11 @@
 //	$ commentcheck
 //	(no output)
 //
-// If the comment is missing:
+// If the comment is missing or incorrect:
 //
 //	$ cat bad.go
 //	package hello
 //
 //	$ commentcheck
 //	bad.go: first line must be "// bad.go"
-
 package main


### PR DESCRIPTION
## Summary
- remove leftover merge marker from `cmd/commentcheck/doc.go`
- consolidate package comment for the `commentcheck` command

## Testing
- `go fmt cmd/commentcheck/doc.go`
- `go test ./...` *(fails: expected statement, found '==' in other packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e69fa2208323904abaf8ff322d5b