### PR TITLE
Fix commentcheck tests and packageDirs implementation

### DIFF
--- a/cmd/commentcheck/doc.go
+++ b/cmd/commentcheck/doc.go
@@ -1,5 +1,3 @@
-// cmd/commentcheck/doc.go
-
 // Command commentcheck verifies that each Go source file in the module starts with a
 // comment matching its relative path.
 //
@@ -9,26 +7,4 @@
 //	internal/foo/bar.go: first line must be "// internal/foo/bar.go"
 //
 // The tool exits with status 1 when mismatches are found.
-=======
-
-// Package main provides the commentcheck command. It verifies that each Go
-// source file starts with a comment containing its repository-relative path.
-//
-// Example
-//
-//	$ cat hello.go
-//	// hello.go
-//	package hello
-//
-//	$ commentcheck
-//	(no output)
-//
-// If the comment is missing:
-//
-//	$ cat bad.go
-//	package hello
-//
-//	$ commentcheck
-//	bad.go: first line must be "// bad.go"
-
 package main

--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -1,4 +1,3 @@
-// cmd/commentcheck/main.go
 // Command commentcheck verifies that each Go source file starts with a
 // comment matching its relative path.
 package main
@@ -6,7 +5,6 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"go/parser"
 	"go/token"
@@ -89,22 +87,10 @@ func checkFile(path string) error {
 }
 
 func packageDirs() ([]string, error) {
-
 	if _, err := lookPath("go"); err != nil {
 		return nil, fmt.Errorf("commentcheck requires a Go toolchain: %w", err)
 	}
 	out, err := execCommand("go", "list", "-f", "{{.Dir}}", "./...").Output()
-=======
-	cmd := execCommand("go", "list", "-f", "{{.Dir}}", "./...")
-	out, err := cmd.Output()
-	if err != nil {
-		if ee, ok := err.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
-			return nil, errors.New("commentcheck requires a Go toolchain")
-		}
-		return nil, err
-	}
-	cwd, err := os.Getwd()
-
 	if err != nil {
 		return nil, err
 	}
@@ -116,11 +102,7 @@ func packageDirs() ([]string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(out))
 	for scanner.Scan() {
 		dir := scanner.Text()
-
 		rel, err := filepath.Rel(wd, dir)
-=======
-		rel, err := filepath.Rel(cwd, dir)
-
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,80 +23,27 @@ func TestCheckFileOK(t *testing.T) {
 	comment := fmt.Sprintf("// %s\n", filepath.ToSlash(path))
 	write(t, path, comment+"package main\n")
 	if err := checkFile(path); err != nil {
-=======
+		t.Fatalf("check file: %v", err)
+	}
+}
 
-	"os"
-	"path/filepath"
-	"testing"
-)
+func TestCheckFileMissingComment(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foo.go")
+	write(t, path, "package main\n")
+	if err := checkFile(path); err == nil || !strings.Contains(err.Error(), "first line must be") {
+		t.Fatalf("expected missing comment error, got %v", err)
+	}
+}
 
-func TestCheckFile(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
-		dir := t.TempDir()
-		path := filepath.Join(dir, "file.go")
-		wd, err := os.Getwd()
-		if err != nil {
-			t.Fatalf("wd: %v", err)
-		}
-		rel, err := filepath.Rel(wd, path)
-		if err != nil {
-			t.Fatalf("rel: %v", err)
-		}
-		content := "// " + filepath.ToSlash(rel) + "\npackage main\n"
-		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-			t.Fatalf("write: %v", err)
-		}
-		if err := checkFile(rel); err != nil {
-			t.Fatalf("checkFile returned error: %v", err)
-		}
-	})
-
-	t.Run("missing comment", func(t *testing.T) {
-		dir := t.TempDir()
-		path := filepath.Join(dir, "file.go")
-		wd, err := os.Getwd()
-		if err != nil {
-			t.Fatalf("wd: %v", err)
-		}
-		rel, err := filepath.Rel(wd, path)
-		if err != nil {
-			t.Fatalf("rel: %v", err)
-		}
-		// write file without leading comment
-		if err := os.WriteFile(path, []byte("package main\n"), 0o644); err != nil {
-			t.Fatalf("write: %v", err)
-		}
-		if err := checkFile(rel); err == nil {
-			t.Fatal("expected error for missing comment")
-		}
-	})
-
-	t.Run("wrong comment", func(t *testing.T) {
-		dir := t.TempDir()
-		path := filepath.Join(dir, "file.go")
-		wd, err := os.Getwd()
-		if err != nil {
-			t.Fatalf("wd: %v", err)
-		}
-		rel, err := filepath.Rel(wd, path)
-		if err != nil {
-			t.Fatalf("rel: %v", err)
-		}
-		content := "// wrong\npackage main\n"
-		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-			t.Fatalf("write: %v", err)
-		}
-		if err := checkFile(rel); err == nil {
-			t.Fatal("expected error for wrong comment")
-		}
-	})
-
-
-	"errors"
-	"os/exec"
-	"testing"
-)
-
+func TestCheckFileMalformedComment(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foo.go")
+	write(t, path, "// wrong\npackage main\n")
+	if err := checkFile(path); err == nil || !strings.Contains(err.Error(), "first line must be") {
+		t.Fatalf("expected malformed comment error, got %v", err)
+	}
+}
 
 func TestPackageDirs_GoNotFound(t *testing.T) {
 	originalLookPath := lookPath
@@ -121,57 +70,4 @@ func TestPackageDirs_CommandFailure(t *testing.T) {
 	if _, err := packageDirs(); err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-=======
-func TestPackageDirsNoGoBinary(t *testing.T) {
-	orig := execCommand
-	defer func() { execCommand = orig }()
-	execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("nonexistent-go-binary")
-	}
-	_, err := packageDirs()
-	if err == nil {
-		t.Fatalf("expected error")
-	}
-	if err.Error() != "commentcheck requires a Go toolchain" {
-
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-
-func TestCheckFileMissingComment(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "foo.go")
-	write(t, path, "package main\n")
-	if err := checkFile(path); err == nil || !strings.Contains(err.Error(), "first line must be") {
-		t.Fatalf("expected missing comment error, got %v", err)
-	}
-}
-
-func TestCheckFileMalformedComment(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "foo.go")
-	write(t, path, "// wrong\npackage main\n")
-	if err := checkFile(path); err == nil || !strings.Contains(err.Error(), "first line must be") {
-		t.Fatalf("expected malformed comment error, got %v", err)
-	}
-=======
-func TestPackageDirsCommandError(t *testing.T) {
-	orig := execCommand
-	defer func() { execCommand = orig }()
-	execCommand = func(name string, args ...string) *exec.Cmd {
-		return exec.Command("sh", "-c", "exit 1")
-	}
-	_, err := packageDirs()
-	if err == nil {
-		t.Fatalf("expected error")
-	}
-	if err.Error() == "commentcheck requires a Go toolchain" {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected ExitError, got %T", err)
-	}
-
 }


### PR DESCRIPTION
## Summary
- restore packageDirs implementation and clean main.go
- rewrite commentcheck tests for checkFile and packageDirs
- tidy doc.go comment

## Testing
- `go test ./cmd/commentcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0e6a9ab088323ad82ca28d79d07d3