### PR TITLE
ci: dedupe covercheck doc comment

### DIFF
--- a/internal/ci/covercheck/doc.go
+++ b/internal/ci/covercheck/doc.go
@@ -5,26 +5,10 @@
 //
 // Example usage:
 //
-//	$ go test -coverprofile=coverage.out ./...
-//	$ covercheck
-//	Total coverage: 96.0%
+//      $ go test -coverprofile=coverage.out ./...
+//      $ covercheck
+//      Total coverage: 96.0%
 //
 // If coverage falls below the threshold, covercheck exits with a non-zero status.
-=======
-
-// Package main provides the covercheck command used in CI pipelines. It reads a
-// Go coverage profile and fails if the total coverage drops below 95 percent.
-//
-// Example
-//
-//	$ go test -coverprofile=coverage.out ./...
-//	$ covercheck
-//	Total coverage: 97.3%
-//
-// When coverage is too low, the command exits with an error:
-//
-//	$ covercheck
-//	Total coverage: 90.0%
-//	Coverage 90.0% is below 95.0%
 
 package main


### PR DESCRIPTION
## Summary
- remove duplicate documentation and divider from covercheck doc.go
- document covercheck command before package declaration

## Testing
- `go fmt internal/ci/covercheck/doc.go`
- `go build ./internal/ci/covercheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0e6b8b60083239dbe4137e97c5fb1