### PR TITLE
Refactor covercheck tests and cleanup

### DIFF
--- a/internal/ci/covercheck/doc.go
+++ b/internal/ci/covercheck/doc.go
@@ -5,26 +5,10 @@
 //
 // Example usage:
 //
-//	$ go test -coverprofile=coverage.out ./...
-//	$ covercheck
-//	Total coverage: 96.0%
+//      $ go test -coverprofile=coverage.out ./...
+//      $ covercheck
+//      Total coverage: 96.0%
 //
 // If coverage falls below the threshold, covercheck exits with a non-zero status.
-=======
-
-// Package main provides the covercheck command used in CI pipelines. It reads a
-// Go coverage profile and fails if the total coverage drops below 95 percent.
-//
-// Example
-//
-//	$ go test -coverprofile=coverage.out ./...
-//	$ covercheck
-//	Total coverage: 97.3%
-//
-// When coverage is too low, the command exits with an error:
-//
-//	$ covercheck
-//	Total coverage: 90.0%
-//	Coverage 90.0% is below 95.0%
 
 package main

--- a/internal/ci/covercheck/main_test.go
+++ b/internal/ci/covercheck/main_test.go
@@ -55,35 +55,5 @@ func TestCovercheck(t *testing.T) {
 				t.Fatalf("output %q does not contain %q", out, tc.wantMsg)
 			}
 		})
-=======
-func writeProfile(t *testing.T, content string) {
-	t.Helper()
-	if err := os.WriteFile("coverage.out", []byte(content), 0o644); err != nil {
-		t.Fatalf("write profile: %v", err)
-	}
-	t.Cleanup(func() { os.Remove("coverage.out") })
-}
-
-func TestCoverageAboveThreshold(t *testing.T) {
-	writeProfile(t, "mode: set\nfoo.go:1.1,1.10 1 1\n")
-	cmd := exec.Command("go", "run", ".")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
-	}
-	if !strings.Contains(string(out), "Total coverage: 100.0%") {
-		t.Fatalf("unexpected output: %s", out)
-	}
-}
-
-func TestCoverageBelowThreshold(t *testing.T) {
-	writeProfile(t, "mode: set\nfoo.go:1.1,1.10 1 0\n")
-	cmd := exec.Command("go", "run", ".")
-	out, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected error, got none: %s", out)
-	}
-	if !strings.Contains(string(out), "Coverage 0.0% is below 95.0%") {
-		t.Fatalf("unexpected output: %s", out)
 	}
 }


### PR DESCRIPTION
## Summary
- Replace conflicting doc comment with final description of covercheck
- Consolidate covercheck tests into a table-driven style and drop unused helpers

## Testing
- `go test ./internal/ci/covercheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0e6c0c68083239b46e03050fffb8a