### PR TITLE
Add missing errors import in commentcheck

### DIFF
--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"go/parser"
 	"go/token"


### PR DESCRIPTION
## Summary
- add errors package to commentcheck import list

## Testing
- `go test ./cmd/commentcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0ec1efa3c832392b4f7f35c95f599