### PR TITLE
chore: strip comments from Go files

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -167,7 +167,6 @@ func TestRunEModes(t *testing.T) {
 				args = tt.flags
 			}
 
-			// capture stdout
 			oldStdout := os.Stdout
 			rOut, wOut, err := os.Pipe()
 			require.NoError(t, err)
@@ -180,7 +179,6 @@ func TestRunEModes(t *testing.T) {
 				outChan <- buf.String()
 			}()
 
-			// set stdin if needed
 			if tt.stdin != "" {
 				oldStdin := os.Stdin
 				rIn, wIn, err := os.Pipe()

--- a/cmd/commentcheck/doc.go
+++ b/cmd/commentcheck/doc.go
@@ -1,22 +1,2 @@
 // cmd/commentcheck/doc.go
-// Package main provides the commentcheck command. It verifies that each Go
-// source file starts with a comment containing its repository-relative path.
-//
-// Example
-//
-//	$ cat hello.go
-//	// hello.go
-//	package hello
-//
-//	$ commentcheck
-//	(no output)
-//
-// If the comment is missing or incorrect:
-//
-//	$ cat bad.go
-//	package hello
-//
-//	$ commentcheck
-//	bad.go: first line must be "// bad.go"
-
 package main

--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -1,5 +1,4 @@
-// Command commentcheck verifies that each Go source file starts with a
-// comment matching its relative path.
+// cmd/commentcheck/main.go
 package main
 
 import (

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -1,3 +1,4 @@
+// cmd/commentcheck/main_test.go
 package main
 
 import (

--- a/internal/ci/covercheck/doc.go
+++ b/internal/ci/covercheck/doc.go
@@ -1,14 +1,2 @@
 // internal/ci/covercheck/doc.go
-
-// Command covercheck reads a Go coverage profile and verifies that the
-// total percentage meets a preset threshold (95% by default).
-//
-// Example usage:
-//
-//      $ go test -coverprofile=coverage.out ./...
-//      $ covercheck
-//      Total coverage: 96.0%
-//
-// If coverage falls below the threshold, covercheck exits with a non-zero status.
-
 package main

--- a/internal/ci/covercheck/main.go
+++ b/internal/ci/covercheck/main.go
@@ -1,5 +1,4 @@
 // internal/ci/covercheck/main.go
-// Command covercheck ensures test coverage meets the minimum threshold.
 package main
 
 import (

--- a/internal/ci/covercheck/main_test.go
+++ b/internal/ci/covercheck/main_test.go
@@ -1,3 +1,4 @@
+// internal/ci/covercheck/main_test.go
 package main
 
 import (

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,3 +1,4 @@
+// internal/engine/engine_test.go
 package engine
 
 import (


### PR DESCRIPTION
## Summary
- ensure Go files retain only path comments
- remove redundant comments across packages

## Testing
- `go run ./cmd/commentcheck`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0ef3c4b7883239edc233f044c6ce3