### PR TITLE
test: add ProcessReader tests for BOM and diff

### DIFF
--- a/internal/engine/process_reader_test.go
+++ b/internal/engine/process_reader_test.go
@@ -1,0 +1,52 @@
+package engine_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/oferchen/hclalign/config"
+	"github.com/oferchen/hclalign/internal/diff"
+	"github.com/oferchen/hclalign/internal/engine"
+	internalfs "github.com/oferchen/hclalign/internal/fs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessReaderPreservesHints(t *testing.T) {
+	t.Parallel()
+
+	bom := string([]byte{0xEF, 0xBB, 0xBF})
+	input := bom + "variable \"simple\" {\r\n  default = 1\r\n  type = number\r\n}"
+	expected := bom + "variable \"simple\" {\r\n  type    = number\r\n  default = 1\r\n}"
+
+	var out bytes.Buffer
+	cfg := &config.Config{Mode: config.ModeWrite, Stdout: true}
+	changed, err := engine.ProcessReader(context.Background(), strings.NewReader(input), &out, cfg)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, expected, out.String())
+
+	hints := internalfs.DetectHintsFromBytes(out.Bytes())
+	require.True(t, hints.HasBOM)
+	require.Equal(t, "\r\n", hints.Newline)
+}
+
+func TestProcessReaderModeDiff(t *testing.T) {
+	t.Parallel()
+
+	bom := string([]byte{0xEF, 0xBB, 0xBF})
+	input := bom + "variable \"simple\" {\r\n  default = 1\r\n  type = number\r\n}"
+	styled := bom + "variable \"simple\" {\r\n  type    = number\r\n  default = 1\r\n}"
+
+	var out bytes.Buffer
+	cfg := &config.Config{Mode: config.ModeDiff}
+	changed, err := engine.ProcessReader(context.Background(), strings.NewReader(input), &out, cfg)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	hints := internalfs.DetectHintsFromBytes([]byte(input))
+	diffText, err := diff.Unified("stdin", "stdin", []byte(input), []byte(styled), hints.Newline)
+	require.NoError(t, err)
+	require.Equal(t, diffText, out.String())
+}

--- a/internal/engine/reader.go
+++ b/internal/engine/reader.go
@@ -1,0 +1,14 @@
+package engine
+
+import (
+	"context"
+	"io"
+
+	"github.com/oferchen/hclalign/config"
+)
+
+// ProcessReader processes HCL content from r and writes the result to w.
+// It exposes the unexported processReader for external callers and tests.
+func ProcessReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Config) (bool, error) {
+	return processReader(ctx, r, w, cfg)
+}


### PR DESCRIPTION
## Summary
- expose `ProcessReader` wrapper to allow direct testing
- verify reader handling of BOM and CRLF hints
- ensure ModeDiff prints expected unified diff to stdout

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b144598f8883238dd25bf45802e4bd