### PR TITLE
Remove inline comments

### DIFF
--- a/internal/engine/process_reader_test.go
+++ b/internal/engine/process_reader_test.go
@@ -1,3 +1,4 @@
+// internal/engine/process_reader_test.go
 package engine_test
 
 import (

--- a/internal/engine/reader.go
+++ b/internal/engine/reader.go
@@ -1,5 +1,4 @@
 // internal/engine/reader.go
-
 package engine
 
 import (


### PR DESCRIPTION
## Summary
- add missing file path comment to process_reader_test.go
- standardize file header spacing in reader.go

## Testing
- `go run ./cmd/commentcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b1480ac1b4832399ae340de2761d0a