### PR TITLE
test: add invalid pattern matcher test

### DIFF
--- a/patternmatching/patternmatching_test.go
+++ b/patternmatching/patternmatching_test.go
@@ -71,3 +71,8 @@ func TestValidatePatterns(t *testing.T) {
 	err = ValidatePatterns([]string{"["})
 	assert.Error(t, err)
 }
+
+func TestNewMatcherInvalidPattern(t *testing.T) {
+	_, err := NewMatcher([]string{"["}, nil)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- add test verifying NewMatcher returns an error when passed invalid pattern

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b14a41912c832381ce45c56883fca2