### PR TITLE
Append unknown attributes after canonical in non-strict mode

### DIFF
--- a/internal/hclalign/hclalign.go
+++ b/internal/hclalign/hclalign.go
@@ -213,17 +213,14 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 		}
 	} else {
 
-		idx := 0
+		for _, name := range orderedKnown {
+			if tok, ok := attrTokensMap[name]; ok {
+				body.AppendUnstructuredTokens(tok.leadTokens)
+				body.SetAttributeRaw(name, tok.exprTokens)
+			}
+		}
 		for _, name := range originalOrder {
 			if _, isKnown := canonicalSet[name]; isKnown {
-				if idx < len(orderedKnown) {
-					k := orderedKnown[idx]
-					idx++
-					if tok, ok := attrTokensMap[k]; ok {
-						body.AppendUnstructuredTokens(tok.leadTokens)
-						body.SetAttributeRaw(k, tok.exprTokens)
-					}
-				}
 				continue
 			}
 			if tok, ok := attrTokensMap[name]; ok {

--- a/internal/hclalign/hclalign_test.go
+++ b/internal/hclalign/hclalign_test.go
@@ -97,7 +97,7 @@ func TestReorderAttributes_StrictUnknownAttrError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestReorderAttributes_LooseKeepsUnknownAtTop(t *testing.T) {
+func TestReorderAttributes_LooseAppendsUnknownAtEnd(t *testing.T) {
 	src := `variable "example" {
   custom      = true
   description = "d"
@@ -109,9 +109,9 @@ func TestReorderAttributes_LooseKeepsUnknownAtTop(t *testing.T) {
 	require.NoError(t, hclalign.ReorderAttributes(f, []string{"description", "type"}, false))
 
 	expected := `variable "example" {
-  custom      = true
   description = "d"
   type        = string
+  custom      = true
 }`
 	require.Equal(t, expected, string(f.Bytes()))
 }

--- a/tests/cases/complex/out.tf
+++ b/tests/cases/complex/out.tf
@@ -1,10 +1,10 @@
 variable "complex" {
-  custom      = true
   description = "desc"
   type        = list(string)
   default     = ["a", "b"]
   sensitive   = true
   nullable    = false
+  custom      = true
   validation {
     condition     = true
     error_message = "msg"

--- a/tests/cases/stress/out.tf
+++ b/tests/cases/stress/out.tf
@@ -1,14 +1,14 @@
 variable "stress" {
-  a1          = 1
   description = "d"
-  a2          = 2
   type        = string
-  a3          = 3
   default     = 0
-  a4          = 4
   sensitive   = true
-  a5          = 5
   nullable    = false
+  a1          = 1
+  a2          = 2
+  a3          = 3
+  a4          = 4
+  a5          = 5
   a6          = 6
   a7          = 7
   a8          = 8

--- a/tests/cases/unicode/out.tf
+++ b/tests/cases/unicode/out.tf
@@ -1,6 +1,6 @@
 variable "unicode" {
-  κ           = 1
   description = "d"
-  デフォルト       = 2
   type        = number
+  κ           = 1
+  デフォルト       = 2
 }

--- a/tests/cases/unknown_attrs/out.tf
+++ b/tests/cases/unknown_attrs/out.tf
@@ -1,6 +1,6 @@
 variable "example" {
-  foo     = "foo"
   type    = number
-  bar     = "bar"
   default = 1
+  foo     = "foo"
+  bar     = "bar"
 }


### PR DESCRIPTION
## Summary
- ensure reorderVariableBlock appends unknown attributes after ordered canonical fields even in loose mode
- update tests and fixtures for the new ordering behaviour

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b14b86bf7883238c792e3b1553a324