### PR TITLE
test(cli): invalid glob exits with code 2

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -117,6 +117,30 @@ func TestRunEInvalidConcurrency(t *testing.T) {
 	require.Equal(t, 2, exitErr.Code)
 }
 
+func TestRunEInvalidGlob(t *testing.T) {
+	tests := []struct {
+		name    string
+		flag    string
+		message string
+	}{
+		{name: "include", flag: "--include", message: "invalid include"},
+		{name: "exclude", flag: "--exclude", message: "invalid exclude"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRootCmd(true)
+			cmd.SetArgs([]string{"--stdin", tt.flag, "["})
+			_, err := cmd.ExecuteC()
+			require.Error(t, err)
+			var exitErr *ExitCodeError
+			require.ErrorAs(t, err, &exitErr)
+			require.Equal(t, 2, exitErr.Code)
+			require.Contains(t, exitErr.Error(), tt.message)
+		})
+	}
+}
+
 func TestRunEModes(t *testing.T) {
 	unformatted := "variable \"a\" {\n  type = string\n  description = \"d\"\n}\n"
 	formatted := "variable \"a\" {\n  description = \"d\"\n  type        = string\n}\n"


### PR DESCRIPTION
## Summary
- test CLI behavior for invalid --include/--exclude patterns

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1535eac388323b4260f1004aac27b