### PR TITLE
commentcheck: detect stray comments

### DIFF
--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -79,11 +79,14 @@ func checkFile(path string) error {
 		return fmt.Errorf("%s: missing file comment", path)
 	}
 	firstGroup := file.Comments[0]
-	pos := fset.Position(firstGroup.Pos())
-	if pos.Line != 1 || firstGroup.List[0].Text != expected {
-		return fmt.Errorf("%s: first comment must be %q", path, expected)
-	}
-	return nil
+        pos := fset.Position(firstGroup.Pos())
+        if pos.Line != 1 || firstGroup.List[0].Text != expected {
+                return fmt.Errorf("%s: first comment must be %q", path, expected)
+        }
+       if len(file.Comments) > 1 || len(firstGroup.List) > 1 {
+               return fmt.Errorf("%s: found additional comments", path)
+       }
+        return nil
 }
 
 func packageDirs() ([]string, error) {

--- a/internal/fs/atomic_test.go
+++ b/internal/fs/atomic_test.go
@@ -200,7 +200,7 @@ func TestWriteFileAtomicContextCanceledBeforeRename(t *testing.T) {
 		t.Fatalf("prewrite: %v", err)
 	}
 
-	data := bytes.Repeat([]byte{'x'}, 100<<20) // 100MB to slow down write
+       data := bytes.Repeat([]byte{'x'}, 100<<20)
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
## Summary
- enforce commentcheck to fail when Go files contain any comments beyond the required top path comment
- remove stray comment from internal/fs/atomic_test.go

## Testing
- `go test ./cmd/commentcheck`
- `go run ./cmd/commentcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b156ca0ea083238b46f770f6e5aebe