### PR TITLE
cli: honor write flag

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -102,6 +102,8 @@ func RunE(cmd *cobra.Command, args []string) error {
 
 	var mode config.Mode
 	switch {
+	case writeMode:
+		mode = config.ModeWrite
 	case checkMode:
 		mode = config.ModeCheck
 	case diffMode:

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -181,6 +181,13 @@ func TestRunEModes(t *testing.T) {
 			wantStdout: formatted,
 		},
 		{
+			name:     "write",
+			flags:    []string{"--write"},
+			wantCode: 0,
+			withFile: true,
+			wantFile: formatted,
+		},
+		{
 			name:       "stdout",
 			flags:      []string{"--stdout"},
 			wantCode:   0,


### PR DESCRIPTION
## Summary
- respect the --write flag when selecting execution mode
- test --write flag formatting an unformatted file

## Testing
- `go vet ./...`
- `go test ./cli -run TestRunEModes -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b16067f01083239d112b63d19688ff