### PR TITLE
docs: remove HTML comment from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # hclalign
 
-<!--
-WHAT: Document atomic write guarantees, default patterns, symlink handling, strict order, exit codes, and integration examples.
-WHY: Provide clearer usage guidance and highlight safety features for users.
--->
-
 `hclalign` is a Command Line Interface (CLI) tool for reordering attributes inside HCL variable blocks. It helps maintain a consistent style across Terraform and other HCL files.
 
 ## Features


### PR DESCRIPTION
## Summary
- remove obsolete HTML comment at top of README

## Testing
- `go test ./...` *(fails: no output after waiting; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b16237da6083239a51c8cfa8d6f461