### PR TITLE
Add strict subset validation test

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -77,9 +77,6 @@ func ValidateOrder(order []string, strict bool) error {
 				return fmt.Errorf("unknown attribute '%s' in order", item)
 			}
 		}
-		if len(providedSet) != len(CanonicalOrder) {
-			return fmt.Errorf("provided order length %d doesn't match expected %d", len(providedSet), len(CanonicalOrder))
-		}
 		for _, item := range CanonicalOrder {
 			if _, exists := providedSet[item]; !exists {
 				return fmt.Errorf("missing expected attribute '%s' in provided order", item)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -22,6 +23,14 @@ func TestValidateOrder_NonStrictUnknownAttribute(t *testing.T) {
 func TestValidateOrder_StrictCanonicalOrder(t *testing.T) {
 	if err := ValidateOrder(CanonicalOrder, true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateOrder_StrictMissingAttribute(t *testing.T) {
+	subset := CanonicalOrder[:len(CanonicalOrder)-1]
+	err := ValidateOrder(subset, true)
+	if err == nil || !strings.Contains(err.Error(), "missing expected attribute") {
+		t.Fatalf("expected missing expected attribute error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Ensure `ValidateOrder` flags missing attributes when given a canonical subset in strict mode
- Add a unit test for strict mode to assert the missing attribute error

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b164736338832381a07c639846c8a6