### PR TITLE
Enable gosimple, dupl, and unparam linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,9 @@ linters:
     - gosec
     - depguard
     - gocyclo
+    - gosimple
+    - dupl
+    - unparam
   disable: []  # must be an array, not null
 
 linters-settings:


### PR DESCRIPTION
## Summary
- enable gosimple, dupl, and unparam linters in golangci config

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: unknown linters: 'gosimple')*

------
https://chatgpt.com/codex/tasks/task_e_68b169b10290832389ff3ed98cdacf93