### PR TITLE
Validate concurrency against GOMAXPROCS

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/oferchen/hclalign/patternmatching"
 )
@@ -44,6 +45,9 @@ const (
 func (c *Config) Validate() error {
 	if c.Concurrency < 1 {
 		return fmt.Errorf("concurrency must be at least 1")
+	}
+	if c.Concurrency > runtime.GOMAXPROCS(0) {
+		return fmt.Errorf("concurrency cannot exceed GOMAXPROCS (%d)", runtime.GOMAXPROCS(0))
 	}
 	if err := patternmatching.ValidatePatterns(c.Include); err != nil {
 		return fmt.Errorf("invalid include: %w", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -58,6 +59,13 @@ func TestValidate_ConcurrencyLessThanOne(t *testing.T) {
 	c := Config{Concurrency: 0}
 	if err := c.Validate(); err == nil {
 		t.Fatalf("expected error for concurrency <1")
+	}
+}
+
+func TestValidate_ConcurrencyGreaterThanGOMAXPROCS(t *testing.T) {
+	c := Config{Concurrency: runtime.GOMAXPROCS(0) + 1}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("expected error for concurrency > GOMAXPROCS")
 	}
 }
 


### PR DESCRIPTION
## Summary
- prevent using more workers than runtime.GOMAXPROCS in config validation
- cover too-high concurrency with new unit test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b16a45f0808323b42f308684d3330e