### PR TITLE
Allow unknown attributes in strict mode

### DIFF
--- a/internal/align/strict_error_test.go
+++ b/internal/align/strict_error_test.go
@@ -17,11 +17,6 @@ func TestStrictOrderErrors(t *testing.T) {
 		want string
 	}{
 		{
-			name: "unknown",
-			src:  "variable \"a\" {\n  foo = 1\n}",
-			want: "unknown attributes",
-		},
-		{
 			name: "missing",
 			src:  "variable \"a\" {\n  type = string\n}",
 			want: "missing attributes",
@@ -42,5 +37,16 @@ func TestStrictOrderErrors(t *testing.T) {
 				t.Fatalf("error %q does not contain %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestStrictOrderAllowsUnknownAttributes(t *testing.T) {
+	src := "variable \"a\" {\n  description = \"desc\"\n  type = string\n  default = 1\n  sensitive = true\n  nullable = false\n  foo = 1\n}"
+	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatalf("parse: %v", diags)
+	}
+	if err := hclalign.ReorderAttributes(f, nil, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/hclalign/hclalign.go
+++ b/internal/hclalign/hclalign.go
@@ -55,32 +55,19 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 	nestedBlocks := body.Blocks()
 
 	if strict {
-		var unknown, missing []string
-		for name := range attrs {
-			if _, ok := canonicalSet[name]; !ok {
-				unknown = append(unknown, name)
-			}
-		}
+		var missing []string
 		for name := range canonicalSet {
 			if _, ok := attrs[name]; !ok {
 				missing = append(missing, name)
 			}
 		}
-		if len(unknown) > 0 || len(missing) > 0 {
-			sort.Strings(unknown)
+		if len(missing) > 0 {
 			sort.Strings(missing)
-			var parts []string
-			if len(unknown) > 0 {
-				parts = append(parts, fmt.Sprintf("unknown attributes: %s", strings.Join(unknown, ", ")))
-			}
-			if len(missing) > 0 {
-				parts = append(parts, fmt.Sprintf("missing attributes: %s", strings.Join(missing, ", ")))
-			}
 			varName := ""
 			if labels := block.Labels(); len(labels) > 0 {
 				varName = labels[0]
 			}
-			return fmt.Errorf("variable %q: %s", varName, strings.Join(parts, "; "))
+			return fmt.Errorf("variable %q: missing attributes: %s", varName, strings.Join(missing, ", "))
 		}
 	}
 

--- a/tests/cases/unknown_attrs/in.tf
+++ b/tests/cases/unknown_attrs/in.tf
@@ -1,6 +1,9 @@
 variable "example" {
   foo = "foo"
-  default = 1
+  description = "example"
   bar = "bar"
+  default = 1
   type = number
+  sensitive = true
+  nullable = false
 }

--- a/tests/cases/unknown_attrs/out.tf
+++ b/tests/cases/unknown_attrs/out.tf
@@ -1,6 +1,9 @@
 variable "example" {
-  type    = number
-  default = 1
-  foo     = "foo"
-  bar     = "bar"
+  description = "example"
+  type        = number
+  default     = 1
+  sensitive   = true
+  nullable    = false
+  foo         = "foo"
+  bar         = "bar"
 }

--- a/tests/cases/unknown_attrs/out_strict.tf
+++ b/tests/cases/unknown_attrs/out_strict.tf
@@ -1,6 +1,9 @@
 variable "example" {
-  type    = number
-  default = 1
-  foo     = "foo"
-  bar     = "bar"
+  description = "example"
+  type        = number
+  default     = 1
+  sensitive   = true
+  nullable    = false
+  foo         = "foo"
+  bar         = "bar"
 }


### PR DESCRIPTION
## Summary
- allow unknown attributes under strict mode by only erroring on missing canonical attributes
- append unknown attributes after known ones and update test fixtures
- expand tests to cover missing attributes error and unknown attribute allowance

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b16b18a18083239ecaa797811f0b69