### PR TITLE
Add error handling tests for engine and CLI

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -116,6 +116,27 @@ func TestRunERuntimeError(t *testing.T) {
 	require.Equal(t, 3, exitErr.Code)
 }
 
+func TestRunEStdinRuntimeError(t *testing.T) {
+	cmd := newRootCmd(true)
+	cmd.SetArgs([]string{"--stdin", "--stdout"})
+
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	_, err = w.Write([]byte("variable \"a\" {"))
+	require.NoError(t, err)
+	w.Close()
+
+	_, err = cmd.ExecuteC()
+	require.Error(t, err)
+	var exitErr *ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 3, exitErr.Code)
+}
+
 func TestRunEInvalidConcurrency(t *testing.T) {
 	cmd := newRootCmd(true)
 	cmd.SetArgs([]string{"--stdin", "--stdout", "--concurrency", "0"})

--- a/internal/engine/error_test.go
+++ b/internal/engine/error_test.go
@@ -1,0 +1,64 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oferchen/hclalign/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessInvalidHCLFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.hcl")
+	orig := "variable \"a\" {"
+	require.NoError(t, os.WriteFile(path, []byte(orig), 0o644))
+
+	cfg := &config.Config{
+		Target:      path,
+		Include:     []string{"**/*.hcl"},
+		Concurrency: 1,
+	}
+
+	changed, err := Process(context.Background(), cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parsing error")
+	require.False(t, changed)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, orig, string(data))
+}
+
+func TestProcessReaderMalformed(t *testing.T) {
+	t.Parallel()
+
+	r := strings.NewReader("variable \"a\" {")
+	var buf bytes.Buffer
+	cfg := &config.Config{Stdout: true}
+
+	changed, err := ProcessReader(context.Background(), r, &buf, cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parsing error")
+	require.False(t, changed)
+	require.Empty(t, buf.String())
+}
+
+func TestProcessReaderEmpty(t *testing.T) {
+	t.Parallel()
+
+	r := strings.NewReader("")
+	var buf bytes.Buffer
+	cfg := &config.Config{Stdout: true}
+
+	changed, err := ProcessReader(context.Background(), r, &buf, cfg)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Empty(t, buf.String())
+}


### PR DESCRIPTION
## Summary
- add engine tests covering parsing errors and empty stdin via `ProcessReader`
- test CLI `--stdin` with malformed data returns exit code 3

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b16d68e6648323b426bd44b0a16d57