### PR TITLE
ci: run comment policy before tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Comment policy
+        run: go run ./cmd/commentcheck
+
       - name: Vulnerability check (non-blocking)
         continue-on-error: true
         run: |


### PR DESCRIPTION
## Summary
- check comment policy before tests to fail fast on comment violations

## Testing
- `go vet ./... && echo vet-ok`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b16d5f69408323b118498018a28c2b