### PR TITLE
Preserve unknown attribute positions in loose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Symbolic links are ignored by default to avoid unexpected traversals. Use `--fol
 ## Strict Order Enforcement
 
 Specify attribute order with `--order`. When `--strict-order` is set, all attributes must appear exactly once in the given order and no other attributes are allowed.
+Without `--strict-order`, attributes not in the canonical list remain in their original positions relative to the reordered attributes.
 
 ## Exit Codes
 

--- a/internal/hclalign/hclalign.go
+++ b/internal/hclalign/hclalign.go
@@ -200,16 +200,20 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 		}
 	} else {
 
-		for _, name := range orderedKnown {
-			if tok, ok := attrTokensMap[name]; ok {
-				body.AppendUnstructuredTokens(tok.leadTokens)
-				body.SetAttributeRaw(name, tok.exprTokens)
-			}
-		}
+		finalOrder := make([]string, 0, len(originalOrder))
+		idx := 0
 		for _, name := range originalOrder {
 			if _, isKnown := canonicalSet[name]; isKnown {
-				continue
+				if idx < len(orderedKnown) {
+					finalOrder = append(finalOrder, orderedKnown[idx])
+					idx++
+				}
+			} else {
+				finalOrder = append(finalOrder, name)
 			}
+		}
+
+		for _, name := range finalOrder {
 			if tok, ok := attrTokensMap[name]; ok {
 				body.AppendUnstructuredTokens(tok.leadTokens)
 				body.SetAttributeRaw(name, tok.exprTokens)

--- a/internal/hclalign/hclalign_test.go
+++ b/internal/hclalign/hclalign_test.go
@@ -97,11 +97,11 @@ func TestReorderAttributes_StrictUnknownAttrError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestReorderAttributes_LooseAppendsUnknownAtEnd(t *testing.T) {
+func TestReorderAttributes_LooseRetainsUnknownOrder(t *testing.T) {
 	src := `variable "example" {
   custom      = true
-  description = "d"
   type        = string
+  description = "d"
 }`
 	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
 	require.False(t, diags.HasErrors())
@@ -109,9 +109,9 @@ func TestReorderAttributes_LooseAppendsUnknownAtEnd(t *testing.T) {
 	require.NoError(t, hclalign.ReorderAttributes(f, []string{"description", "type"}, false))
 
 	expected := `variable "example" {
+  custom      = true
   description = "d"
   type        = string
-  custom      = true
 }`
 	require.Equal(t, expected, string(f.Bytes()))
 }

--- a/tests/cases/complex/out.tf
+++ b/tests/cases/complex/out.tf
@@ -1,10 +1,10 @@
 variable "complex" {
+  custom      = true
   description = "desc"
   type        = list(string)
   default     = ["a", "b"]
   sensitive   = true
   nullable    = false
-  custom      = true
   validation {
     condition     = true
     error_message = "msg"

--- a/tests/cases/stress/out.tf
+++ b/tests/cases/stress/out.tf
@@ -1,14 +1,14 @@
 variable "stress" {
-  description = "d"
-  type        = string
-  default     = 0
-  sensitive   = true
-  nullable    = false
   a1          = 1
+  description = "d"
   a2          = 2
+  type        = string
   a3          = 3
+  default     = 0
   a4          = 4
+  sensitive   = true
   a5          = 5
+  nullable    = false
   a6          = 6
   a7          = 7
   a8          = 8

--- a/tests/cases/unicode/out.tf
+++ b/tests/cases/unicode/out.tf
@@ -1,6 +1,6 @@
 variable "unicode" {
-  description = "d"
-  type        = number
   κ           = 1
+  description = "d"
   デフォルト       = 2
+  type        = number
 }

--- a/tests/cases/unknown_attrs/out.tf
+++ b/tests/cases/unknown_attrs/out.tf
@@ -1,9 +1,9 @@
 variable "example" {
+  foo         = "foo"
   description = "example"
+  bar         = "bar"
   type        = number
   default     = 1
   sensitive   = true
   nullable    = false
-  foo         = "foo"
-  bar         = "bar"
 }


### PR DESCRIPTION
## Summary
- Keep unknown attributes at their original locations when not using `--strict-order`
- Document loose mode behavior and add tests for unknown attribute positioning
- Update golden fixtures for cases containing unknown attributes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1704cf29c832392ea4c211c49fd08