### PR TITLE
Use git to discover files for comment check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,7 @@ jobs:
         run: go vet ./...
 
       - name: Comment policy
-        run: go run ./cmd/commentcheck
+        run: make comments
 
       - name: Vulnerability check (non-blocking)
         continue-on-error: true

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -46,7 +46,7 @@ func TestCheckFileMalformedComment(t *testing.T) {
 	}
 }
 
-func TestPackageDirs_GoNotFound(t *testing.T) {
+func TestPackageDirs_GitNotFound(t *testing.T) {
 	originalLookPath := lookPath
 	t.Cleanup(func() { lookPath = originalLookPath })
 	lookPath = func(string) (string, error) {
@@ -64,12 +64,41 @@ func TestPackageDirs_CommandFailure(t *testing.T) {
 		lookPath = originalLookPath
 		execCommand = originalExecCommand
 	})
-	lookPath = func(string) (string, error) { return "go", nil }
+	lookPath = func(string) (string, error) { return "git", nil }
 	execCommand = func(string, ...string) *exec.Cmd {
 		return exec.Command("bash", "-c", "exit 1")
 	}
 	if _, err := packageDirs(); err == nil {
 		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestPackageDirs_TestOnlyDir(t *testing.T) {
+	dir := t.TempDir()
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(originalWd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	if err := exec.Command("git", "init").Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if err := os.Mkdir("foo", 0755); err != nil {
+		t.Fatalf("mkdir foo: %v", err)
+	}
+	write(t, filepath.Join("foo", "bar_test.go"), "package foo\n")
+	if err := exec.Command("git", "add", ".").Run(); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	dirs, err := packageDirs()
+	if err != nil {
+		t.Fatalf("packageDirs: %v", err)
+	}
+	if len(dirs) != 1 || dirs[0] != "foo" {
+		t.Fatalf("expected [foo], got %v", dirs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- list Go sources with `git ls-files` so test-only dirs are covered
- expand commentcheck tests for git-based discovery
- call commentcheck via `make comments` in CI

## Testing
- `go run ./cmd/commentcheck`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b172857eac8323aca6c0d33839efbe