### PR TITLE
Fail on unknown variable attributes in strict mode

### DIFF
--- a/internal/align/strict_error_test.go
+++ b/internal/align/strict_error_test.go
@@ -40,13 +40,13 @@ func TestStrictOrderErrors(t *testing.T) {
 	}
 }
 
-func TestStrictOrderAllowsUnknownAttributes(t *testing.T) {
+func TestStrictOrderRejectsUnknownAttributes(t *testing.T) {
 	src := "variable \"a\" {\n  description = \"desc\"\n  type = string\n  default = 1\n  sensitive = true\n  nullable = false\n  foo = 1\n}"
 	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
 	if diags.HasErrors() {
 		t.Fatalf("parse: %v", diags)
 	}
-	if err := hclalign.ReorderAttributes(f, nil, true); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err := hclalign.ReorderAttributes(f, nil, true); err == nil {
+		t.Fatalf("expected error")
 	}
 }

--- a/internal/hclalign/hclalign.go
+++ b/internal/hclalign/hclalign.go
@@ -69,6 +69,20 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 			}
 			return fmt.Errorf("variable %q: missing attributes: %s", varName, strings.Join(missing, ", "))
 		}
+		var unknown []string
+		for name := range attrs {
+			if _, ok := canonicalSet[name]; !ok {
+				unknown = append(unknown, name)
+			}
+		}
+		if len(unknown) > 0 {
+			sort.Strings(unknown)
+			varName := ""
+			if labels := block.Labels(); len(labels) > 0 {
+				varName = labels[0]
+			}
+			return fmt.Errorf("variable %q: unknown attributes: %s", varName, strings.Join(unknown, ", "))
+		}
 	}
 
 	allTokens := body.BuildTokens(nil)

--- a/internal/hclalign/hclalign_test.go
+++ b/internal/hclalign/hclalign_test.go
@@ -97,6 +97,22 @@ func TestReorderAttributes_StrictUnknownAttrError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestReorderAttributes_StrictUnknownAttrWithCanonical(t *testing.T) {
+	src := `variable "example" {
+  description = "d"
+  type        = string
+  default     = "v"
+  sensitive   = true
+  nullable    = false
+  custom      = true
+}`
+	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	err := hclalign.ReorderAttributes(f, nil, true)
+	require.Error(t, err)
+}
+
 func TestReorderAttributes_LooseRetainsUnknownOrder(t *testing.T) {
 	src := `variable "example" {
   custom      = true

--- a/tests/cases/complex/out_strict.tf
+++ b/tests/cases/complex/out_strict.tf
@@ -1,10 +1,10 @@
 variable "complex" {
+  custom      = true
   description = "desc"
   type        = list(string)
   default     = ["a", "b"]
   sensitive   = true
   nullable    = false
-  custom      = true
   validation {
     condition     = true
     error_message = "msg"

--- a/tests/cases/stress/out_strict.tf
+++ b/tests/cases/stress/out_strict.tf
@@ -1,14 +1,14 @@
 variable "stress" {
-  description = "d"
-  type        = string
-  default     = 0
-  sensitive   = true
-  nullable    = false
   a1          = 1
+  description = "d"
   a2          = 2
+  type        = string
   a3          = 3
+  default     = 0
   a4          = 4
+  sensitive   = true
   a5          = 5
+  nullable    = false
   a6          = 6
   a7          = 7
   a8          = 8

--- a/tests/cases/unknown_attrs/out_strict.tf
+++ b/tests/cases/unknown_attrs/out_strict.tf
@@ -1,9 +1,9 @@
 variable "example" {
+  foo         = "foo"
   description = "example"
+  bar         = "bar"
   type        = number
   default     = 1
   sensitive   = true
   nullable    = false
-  foo         = "foo"
-  bar         = "bar"
 }


### PR DESCRIPTION
## Summary
- error if variable blocks contain attributes outside the canonical set when `strict` is enabled
- cover unknown-attribute errors with unit tests and align package tests
- update golden fixtures for strict mode cases

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b174fb4bec832383625644115b1aab