### PR TITLE
Aggregate file processing errors and continue

### DIFF
--- a/internal/engine/error_test.go
+++ b/internal/engine/error_test.go
@@ -37,6 +37,38 @@ func TestProcessInvalidHCLFile(t *testing.T) {
 	require.Equal(t, orig, string(data))
 }
 
+func TestProcessFilesAggregatesErrors(t *testing.T) {
+	dir := t.TempDir()
+	goodPath := filepath.Join(dir, "good.hcl")
+	bad1Path := filepath.Join(dir, "bad1.hcl")
+	bad2Path := filepath.Join(dir, "bad2.hcl")
+
+	good := "variable \"good\" {\n  default     = 1\n  description = \"foo\"\n}\n"
+	require.NoError(t, os.WriteFile(goodPath, []byte(good), 0o644))
+
+	bad1 := "variable \"bad1\" {"
+	bad2 := "variable \"bad2\" { default = [ }"
+	require.NoError(t, os.WriteFile(bad1Path, []byte(bad1), 0o644))
+	require.NoError(t, os.WriteFile(bad2Path, []byte(bad2), 0o644))
+
+	cfg := &config.Config{
+		Target:      dir,
+		Include:     []string{"**/*.hcl"},
+		Concurrency: 2,
+	}
+
+	changed, err := Process(context.Background(), cfg)
+	require.Error(t, err)
+	require.True(t, changed)
+	require.Contains(t, err.Error(), "bad1.hcl")
+	require.Contains(t, err.Error(), "bad2.hcl")
+
+	data, readErr := os.ReadFile(goodPath)
+	require.NoError(t, readErr)
+	expected := "variable \"good\" {\n  description = \"foo\"\n  default     = 1\n}\n"
+	require.Equal(t, expected, string(data))
+}
+
 func TestProcessReaderMalformed(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- keep processing other files after a processing error
- collect errors from all files and return them joined with newlines
- add test ensuring partial failures still process remaining files

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b17712419c8323a7b9f69f1294c964