### PR TITLE
feat: add strip comments tool and integrate into CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Download modules
         run: go mod download
 
+      - name: Strip comments
+        run: make strip-comments
+
+      - name: Format
+        run: make fmt
+
       - name: Lint (golangci-lint)
         uses: golangci/golangci-lint-action@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,17 @@ lint:
 	golangci-lint run
 
 comments:
-	@echo "Checking file comments..."
-	go run ./cmd/commentcheck
+        @echo "Checking file comments..."
+        go run ./cmd/commentcheck
+
+strip-comments:
+        @echo "Stripping comments..."
+        go run ./hack/stripcomments
 
 fmt:
-	@echo "Formatting code..."
-	go fmt ./...
+        @echo "Formatting code..."
+        go install mvdan.cc/gofumpt@v0.8.0
+        gofumpt -w .
 
 vet:
 	@echo "Running go vet..."
@@ -79,8 +84,8 @@ init:
 	@echo "Initializing Go module..."
 	go mod init ${MODULE_NAME}
 
-ci: fmt vet lint comments test-race fuzz-short build
-	@echo "Running CI pipeline..."
+ci: strip-comments fmt vet lint comments test-race fuzz-short build
+        @echo "Running CI pipeline..."
 
 help:
 	@echo "Makefile commands:"
@@ -91,9 +96,10 @@ help:
 	@echo "tidy      - Tidies and verifies the module dependencies."
 	@echo "fmt       - Formats the code."
 	@echo "vet       - Runs go vet."
-	@echo "lint      - Runs golangci-lint."
-	@echo "comments  - Checks file header comments."
-	@echo "test      - Runs all the tests."
+        @echo "lint      - Runs golangci-lint."
+        @echo "comments  - Checks file header comments."
+        @echo "strip-comments - Removes all comments except the first-line path comment."
+        @echo "test      - Runs all the tests."
 	@echo "test-race - Runs tests with the race detector."
 	@echo "cover     - Runs tests with the race detector and generates a coverage report."
 	@echo "fuzz      - Runs fuzz tests."

--- a/hack/stripcomments/main.go
+++ b/hack/stripcomments/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	if err := strip("."); err != nil {
+		panic(err)
+	}
+}
+
+func strip(root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if strings.HasPrefix(name, ".") || name == "vendor" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+		return processFile(path)
+	})
+}
+
+func processFile(path string) error {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	comment := firstLineComment(src)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, src, 0)
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	if comment != "" {
+		buf.WriteString(comment)
+		buf.WriteByte('\n')
+	}
+	if err := printer.Fprint(&buf, fset, file); err != nil {
+		return err
+	}
+	buf.WriteByte('\n')
+	return os.WriteFile(path, buf.Bytes(), 0644)
+}
+
+func firstLineComment(src []byte) string {
+	scanner := bufio.NewScanner(bytes.NewReader(src))
+	if scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "//") {
+			return line
+		}
+	}
+	return ""
+}

--- a/hack/stripcomments/main_test.go
+++ b/hack/stripcomments/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStrip(t *testing.T) {
+	dir := t.TempDir()
+	src := []byte(`// sample.go
+package main
+
+import "fmt"
+
+// extra comment
+func main() { // inline
+    fmt.Println("hi") // trailing
+}
+`)
+	path := filepath.Join(dir, "sample.go")
+	if err := os.WriteFile(path, src, 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := strip(dir); err != nil {
+		t.Fatalf("strip: %v", err)
+	}
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	expected := "// sample.go\npackage main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hi\")\n}\n\n"
+	if string(out) != expected {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add `hack/stripcomments` utility to remove all comments except the path header
- format with `gofumpt` and provide `strip-comments` Makefile target and CI wiring
- add unit tests for the stripping tool

## Testing
- `go test ./hack/stripcomments -count=1`
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b178bf06f88323aa0010dcc5aa0137