### PR TITLE
fuzz: add ProcessReader fuzz target

### DIFF
--- a/internal/engine/fuzz_process_reader_test.go
+++ b/internal/engine/fuzz_process_reader_test.go
@@ -1,0 +1,40 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/oferchen/hclalign/config"
+)
+
+func FuzzProcessReader(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Limit excessively large inputs to avoid OOMs during fuzzing.
+		const maxBytes = 1 << 12
+		if len(data) > maxBytes {
+			t.Skip()
+		}
+
+		cfg := &config.Config{Mode: config.ModeWrite, Stdout: true}
+
+		var out bytes.Buffer
+		_, err := ProcessReader(context.Background(), bytes.NewReader(data), &out, cfg)
+		if err != nil {
+			return
+		}
+		styled := out.Bytes()
+
+		var out2 bytes.Buffer
+		changed, err := ProcessReader(context.Background(), bytes.NewReader(styled), &out2, cfg)
+		if err != nil {
+			t.Fatalf("second process: %v", err)
+		}
+		if changed {
+			t.Fatalf("processing is not idempotent")
+		}
+		if !bytes.Equal(styled, out2.Bytes()) {
+			t.Fatalf("round-trip mismatch")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- fuzz ProcessReader with arbitrary data in write mode
- ensure ProcessReader output is stable on subsequent runs

## Testing
- `go test ./internal/engine -run FuzzProcessReader -fuzz=FuzzProcessReader -fuzztime=1s`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b17bd7f2fc83239bfe59102bac79c7