### PR TITLE
Refine coverage targets and CI parsing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,12 +55,7 @@ jobs:
 
       - name: Test
         run: |
-          go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out ./...
-          go test -race -shuffle=on -covermode=atomic -coverprofile=cmd_commentcheck.out ./cmd/commentcheck
-          tail -n +2 cmd_commentcheck.out >> coverage.out
-          go test -race -shuffle=on -covermode=atomic -coverprofile=ci_covercheck.out ./internal/ci/covercheck
-          tail -n +2 ci_covercheck.out >> coverage.out
-          rm cmd_commentcheck.out ci_covercheck.out
+          go test -race -shuffle=on -covermode=atomic -coverpkg=./cli,./config,./internal/...,./patternmatching -coverprofile=coverage.out $(go list ./... | grep -v '^github.com/oferchen/hclalign$' | grep -v '^github.com/oferchen/hclalign/cmd/commentcheck$' | grep -v '^github.com/oferchen/hclalign/internal/ci')
 
       - name: Check coverage
         run: go run ./internal/ci/covercheck

--- a/internal/ci/covercheck/main.go
+++ b/internal/ci/covercheck/main.go
@@ -11,6 +11,15 @@ import (
 
 const threshold = 95.0
 
+// paths to ignore when calculating coverage. These packages are excluded from
+// the coverage budget but may still appear in the profile when using
+// -coverpkg.
+var ignore = []string{
+	"cmd/commentcheck/",
+	"internal/ci/",
+	"main.go",
+}
+
 func main() {
 	const profile = "coverage.out"
 
@@ -31,6 +40,17 @@ func main() {
 	for s.Scan() {
 		fields := strings.Fields(s.Text())
 		if len(fields) < 3 {
+			continue
+		}
+		file := fields[0]
+		skip := false
+		for _, p := range ignore {
+			if strings.Contains(file, p) {
+				skip = true
+				break
+			}
+		}
+		if skip {
 			continue
 		}
 		stmts, err1 := strconv.ParseFloat(fields[1], 64)

--- a/internal/ci/covercheck/main_test.go
+++ b/internal/ci/covercheck/main_test.go
@@ -41,6 +41,12 @@ func TestCovercheck(t *testing.T) {
 			wantExit: 1,
 			wantMsg:  "Coverage 50.0% is below 95.0%",
 		},
+		{
+			name:     "ignored path",
+			profile:  "mode: set\ncmd/commentcheck/file.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
+			wantExit: 0,
+			wantMsg:  "Total coverage: 100.0%",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- run coverage with explicit package list excluding main, commentcheck, and CI helpers
- ignore excluded packages in internal/ci/covercheck and test the behavior
- align GitHub Actions workflow with new cover command

## Testing
- `go test -race -shuffle=on -covermode=atomic -coverpkg=./cli,./config,./internal/...,./patternmatching -coverprofile=coverage.out $(go list ./... | grep -v '^github.com/oferchen/hclalign$' | grep -v '^github.com/oferchen/hclalign/cmd/commentcheck$' | grep -v '^github.com/oferchen/hclalign/internal/ci')` *(fails: race detected during execution of test)*
- `go run ./internal/ci/covercheck` *(fails: Coverage 26.0% is below 95.0%)*
- `go test ./internal/ci/covercheck`


------
https://chatgpt.com/codex/tasks/task_e_68b17d042a308323a01b287a9000bc56