### PR TITLE
Ensure path comments and remove extraneous comments

### DIFF
--- a/hack/stripcomments/main.go
+++ b/hack/stripcomments/main.go
@@ -1,3 +1,4 @@
+// hack/stripcomments/main.go
 package main
 
 import (

--- a/hack/stripcomments/main_test.go
+++ b/hack/stripcomments/main_test.go
@@ -1,3 +1,4 @@
+// hack/stripcomments/main_test.go
 package main
 
 import (

--- a/internal/ci/covercheck/main.go
+++ b/internal/ci/covercheck/main.go
@@ -11,9 +11,6 @@ import (
 
 const threshold = 95.0
 
-// paths to ignore when calculating coverage. These packages are excluded from
-// the coverage budget but may still appear in the profile when using
-// -coverpkg.
 var ignore = []string{
 	"cmd/commentcheck/",
 	"internal/ci/",

--- a/internal/engine/fuzz_process_reader_test.go
+++ b/internal/engine/fuzz_process_reader_test.go
@@ -1,3 +1,4 @@
+// internal/engine/fuzz_process_reader_test.go
 package engine
 
 import (
@@ -10,7 +11,6 @@ import (
 
 func FuzzProcessReader(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		// Limit excessively large inputs to avoid OOMs during fuzzing.
 		const maxBytes = 1 << 12
 		if len(data) > maxBytes {
 			t.Skip()


### PR DESCRIPTION
## Summary
- add file path comments to hack/stripcomments and fuzz process reader test files
- strip non-path comments from fuzz process reader and coverage checker

## Testing
- `go run ./hack/stripcomments`
- `go run ./cmd/commentcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b18128d8708323987cf5a6a794f2bd