### PR TITLE
Ignore chown errors on Windows

### DIFF
--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -13,8 +13,8 @@ import (
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
 type Hints struct {
-	HasBOM	bool
-	Newline	string
+	HasBOM  bool
+	Newline string
 }
 
 func (h Hints) BOM() []byte {
@@ -97,8 +97,10 @@ func WriteFileAtomic(ctx context.Context, path string, data []byte, perm iofs.Fi
 	}
 	if uid != -1 || gid != -1 {
 		if err := os.Chown(tmpName, uid, gid); err != nil {
-			_ = tmp.Close()
-			return err
+			if !isErrWindows(err) && !os.IsPermission(err) {
+				_ = tmp.Close()
+				return err
+			}
 		}
 	}
 	if err := ctx.Err(); err != nil {
@@ -137,4 +139,3 @@ func WriteFileAtomic(ctx context.Context, path string, data []byte, perm iofs.Fi
 	defer func() { _ = dirf.Close() }()
 	return dirf.Sync()
 }
-

--- a/internal/fs/atomic_windows_test.go
+++ b/internal/fs/atomic_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package fs
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestWriteFileAtomicChownIgnored(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("prewrite: %v", err)
+	}
+
+	if err := os.Chown(path, 0, 0); !errors.Is(err, syscall.EWINDOWS) && !os.IsPermission(err) {
+		t.Fatalf("unexpected chown error: %v", err)
+	}
+
+	if err := WriteFileAtomic(context.Background(), path, []byte("new"), 0o644, Hints{}); err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+}

--- a/internal/fs/ewindows_other.go
+++ b/internal/fs/ewindows_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package fs
+
+func isErrWindows(err error) bool {
+	return false
+}

--- a/internal/fs/ewindows_windows.go
+++ b/internal/fs/ewindows_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package fs
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isErrWindows(err error) bool {
+	return errors.Is(err, syscall.EWINDOWS)
+}


### PR DESCRIPTION
## Summary
- handle unsupported `chown` calls on Windows by ignoring `syscall.EWINDOWS` and permission errors
- add Windows-specific test ensuring `WriteFileAtomic` succeeds despite failing `chown`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b185a65e448323a7e3317c7efa35fb