### PR TITLE
Preserve file permissions in stripcomments tool

### DIFF
--- a/hack/stripcomments/main.go
+++ b/hack/stripcomments/main.go
@@ -43,6 +43,10 @@ func processFile(path string) error {
 	if err != nil {
 		return err
 	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
 	comment := firstLineComment(src)
 	if comment == "" {
 		root, err := os.Getwd()
@@ -72,7 +76,7 @@ func processFile(path string) error {
 		return err
 	}
 	buf.WriteByte('\n')
-	return os.WriteFile(path, buf.Bytes(), 0644)
+	return os.WriteFile(path, buf.Bytes(), info.Mode())
 }
 
 func firstLineComment(src []byte) string {
@@ -85,4 +89,3 @@ func firstLineComment(src []byte) string {
 	}
 	return ""
 }
-

--- a/hack/stripcomments/main_test.go
+++ b/hack/stripcomments/main_test.go
@@ -43,3 +43,24 @@ func main() { // inline
 	}
 }
 
+func TestProcessFilePreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "perm.go")
+	if err := os.WriteFile(path, []byte("package main\n"), 0755); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if err := processFile(path); err != nil {
+		t.Fatalf("processFile: %v", err)
+	}
+	info2, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info2.Mode() != info.Mode() {
+		t.Fatalf("mode changed: got %v, want %v", info2.Mode(), info.Mode())
+	}
+}


### PR DESCRIPTION
## Summary
- Preserve existing file mode when rewriting Go files in stripcomments tool
- Add unit test ensuring permissions remain unchanged after processing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1858449b88323975914d5a2313151