### PR TITLE
Skip symlink files unless follow flag is set

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -73,11 +73,12 @@ func processFiles(ctx context.Context, cfg *config.Config) (bool, error) {
 				if err != nil {
 					return err
 				}
+				if !cfg.FollowSymlinks {
+					continue
+				}
 				if info.IsDir() {
-					if cfg.FollowSymlinks {
-						if err := walk(ctx, path); err != nil {
-							return err
-						}
+					if err := walk(ctx, path); err != nil {
+						return err
 					}
 					continue
 				}

--- a/tests/cases/symlink/in.tf
+++ b/tests/cases/symlink/in.tf
@@ -1,0 +1,1 @@
+../simple/in.tf

--- a/tests/cases/symlink/out.tf
+++ b/tests/cases/symlink/out.tf
@@ -1,0 +1,1 @@
+../simple/out.tf


### PR DESCRIPTION
## Summary
- avoid processing symlinked files when FollowSymlinks is false
- add tests for symlinked file handling
- cover symlink scenario in golden tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b18885dce8832380019d158c1f2f56