### PR TITLE
Preserve path comments with build tags

### DIFF
--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -28,6 +28,17 @@ func TestCheckFileOK(t *testing.T) {
 	}
 }
 
+func TestCheckFileWithBuildTag(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foo.go")
+	comment := fmt.Sprintf("// %s\n", filepath.ToSlash(path))
+	content := "//go:build windows\n\n" + comment + "package main\n"
+	write(t, path, content)
+	if err := checkFile(path); err != nil {
+		t.Fatalf("check file: %v", err)
+	}
+}
+
 func TestCheckFileMissingComment(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "foo.go")

--- a/hack/stripcomments/main_test.go
+++ b/hack/stripcomments/main_test.go
@@ -4,6 +4,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -43,6 +44,35 @@ func main() { // inline
 	}
 }
 
+func TestStripWithBuildTag(t *testing.T) {
+	dir := t.TempDir()
+	src := []byte("//go:build windows\n\npackage main\n\n// extra comment\nfunc main() {}\n")
+	path := filepath.Join(dir, "sample.go")
+	if err := os.WriteFile(path, src, 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := strip(dir); err != nil {
+		t.Fatalf("strip: %v", err)
+	}
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("wd: %v", err)
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		t.Fatalf("rel: %v", err)
+	}
+	outStr := strings.ReplaceAll(string(out), "\t", "")
+	need := "//go:build windows\n\n// " + filepath.ToSlash(rel) + "\npackage main\n\nfunc main(){}\n"
+	if !strings.Contains(outStr, need) {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+}
+
 func TestProcessFilePreservesMode(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "perm.go")
@@ -64,3 +94,4 @@ func TestProcessFilePreservesMode(t *testing.T) {
 		t.Fatalf("mode changed: got %v, want %v", info2.Mode(), info.Mode())
 	}
 }
+

--- a/internal/fs/atomic_windows_test.go
+++ b/internal/fs/atomic_windows_test.go
@@ -1,5 +1,6 @@
 //go:build windows
 
+// internal/fs/atomic_windows_test.go
 package fs
 
 import (
@@ -29,3 +30,4 @@ func TestWriteFileAtomicChownIgnored(t *testing.T) {
 		t.Fatalf("WriteFileAtomic: %v", err)
 	}
 }
+

--- a/internal/fs/ewindows_other.go
+++ b/internal/fs/ewindows_other.go
@@ -1,7 +1,9 @@
 //go:build !windows
 
+// internal/fs/ewindows_other.go
 package fs
 
 func isErrWindows(err error) bool {
 	return false
 }
+

--- a/internal/fs/ewindows_windows.go
+++ b/internal/fs/ewindows_windows.go
@@ -1,5 +1,6 @@
 //go:build windows
 
+// internal/fs/ewindows_windows.go
 package fs
 
 import (
@@ -10,3 +11,4 @@ import (
 func isErrWindows(err error) bool {
 	return errors.Is(err, syscall.EWINDOWS)
 }
+


### PR DESCRIPTION
## Summary
- support build tags followed by path comments in commentcheck and stripcomments
- ensure build-tagged files keep path comments

## Testing
- `go test ./cmd/commentcheck ./hack/stripcomments`
- `go test ./internal/fs`
- `go run ./hack/stripcomments`
- `go run ./cmd/commentcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b18a400ad883238654de7e91b42d27