### PR TITLE
chore: strip comments and document workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,12 @@ Thank you for considering a contribution to `hclalign`!
 
 ## Required Checks
 
+Run the comment stripping tool to ensure each Go file begins with a path comment:
+
+```sh
+make strip-comments
+```
+
 Before submitting a pull request, ensure the continuous integration pipeline passes:
 
 ```sh

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -16,15 +16,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newRootCmd(exclusive bool) *cobra.Command { return newTestRootCmd(exclusive) }
+func newRootCmd(exclusive bool) *cobra.Command	{ return newTestRootCmd(exclusive) }
 
 func newTestRootCmd(exclusive bool) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:          "hclalign [target file or directory]",
-		Args:         cobra.ArbitraryArgs,
-		RunE:         RunE,
-		SilenceUsage: true,
+		Use:		"hclalign [target file or directory]",
+		Args:		cobra.ArbitraryArgs,
+		RunE:		RunE,
+		SilenceUsage:	true,
 	}
 	cmd.Flags().Bool("write", false, "write result to file(s)")
 	cmd.Flags().Bool("check", false, "check if files are formatted")
@@ -150,9 +150,9 @@ func TestRunEInvalidConcurrency(t *testing.T) {
 
 func TestRunEInvalidGlob(t *testing.T) {
 	tests := []struct {
-		name    string
-		flag    string
-		message string
+		name	string
+		flag	string
+		message	string
 	}{
 		{name: "include", flag: "--include", message: "invalid include"},
 		{name: "exclude", flag: "--exclude", message: "invalid exclude"},
@@ -177,44 +177,44 @@ func TestRunEModes(t *testing.T) {
 	formatted := "variable \"a\" {\n  description = \"d\"\n  type        = string\n}\n"
 
 	tests := []struct {
-		name       string
-		flags      []string
-		stdin      string
-		wantCode   int
-		wantStdout string
-		contains   string
-		withFile   bool
-		wantFile   string
+		name		string
+		flags		[]string
+		stdin		string
+		wantCode	int
+		wantStdout	string
+		contains	string
+		withFile	bool
+		wantFile	string
 	}{
 		{
-			name:     "diff",
-			flags:    []string{"--diff"},
-			wantCode: 1,
-			contains: "@@",
-			withFile: true,
-			wantFile: unformatted,
+			name:		"diff",
+			flags:		[]string{"--diff"},
+			wantCode:	1,
+			contains:	"@@",
+			withFile:	true,
+			wantFile:	unformatted,
 		},
 		{
-			name:       "stdin",
-			flags:      []string{"--stdin", "--stdout"},
-			stdin:      unformatted,
-			wantCode:   0,
-			wantStdout: formatted,
+			name:		"stdin",
+			flags:		[]string{"--stdin", "--stdout"},
+			stdin:		unformatted,
+			wantCode:	0,
+			wantStdout:	formatted,
 		},
 		{
-			name:     "write",
-			flags:    []string{"--write"},
-			wantCode: 0,
-			withFile: true,
-			wantFile: formatted,
+			name:		"write",
+			flags:		[]string{"--write"},
+			wantCode:	0,
+			withFile:	true,
+			wantFile:	formatted,
 		},
 		{
-			name:       "stdout",
-			flags:      []string{"--stdout"},
-			wantCode:   0,
-			wantStdout: formatted,
-			withFile:   true,
-			wantFile:   formatted,
+			name:		"stdout",
+			flags:		[]string{"--stdout"},
+			wantCode:	0,
+			wantStdout:	formatted,
+			withFile:	true,
+			wantFile:	formatted,
 		},
 	}
 
@@ -296,9 +296,9 @@ func TestRunEVerbose(t *testing.T) {
 	unformatted := "variable \"a\" {\n  type = string\n  description = \"d\"\n}\n"
 
 	tests := []struct {
-		name    string
-		verbose bool
-		wantLog bool
+		name	string
+		verbose	bool
+		wantLog	bool
 	}{
 		{name: "verbose", verbose: true, wantLog: true},
 		{name: "silent", verbose: false, wantLog: false},
@@ -348,9 +348,9 @@ func TestRunEFollowSymlinks(t *testing.T) {
 	formatted := "variable \"a\" {\n  description = \"d\"\n  type        = string\n}\n"
 
 	tests := []struct {
-		name   string
-		follow bool
-		want   string
+		name	string
+		follow	bool
+		want	string
 	}{
 		{name: "follow", follow: true, want: formatted},
 		{name: "no_follow", follow: false, want: unformatted},
@@ -381,3 +381,4 @@ func TestRunEFollowSymlinks(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -26,10 +26,10 @@ import (
 )
 
 var (
-	testHookAfterParse   func()
-	testHookAfterReorder func()
-	reorderAttributes    = hclalign.ReorderAttributes
-	WriteFileAtomic      = internalfs.WriteFileAtomic
+	testHookAfterParse	func()
+	testHookAfterReorder	func()
+	reorderAttributes	= hclalign.ReorderAttributes
+	WriteFileAtomic		= internalfs.WriteFileAtomic
 )
 
 func Process(ctx context.Context, cfg *config.Config) (bool, error) {
@@ -125,8 +125,8 @@ func processFiles(ctx context.Context, cfg *config.Config) (bool, error) {
 	sort.Strings(files)
 
 	type result struct {
-		path string
-		data []byte
+		path	string
+		data	[]byte
 	}
 
 	var changed atomic.Bool
@@ -358,3 +358,4 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 	}
 	return changed, nil
 }
+

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -22,9 +22,9 @@ func TestProcessMissingTarget(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{
-		Target:      "nonexistent.hcl",
-		Include:     []string{"**/*.hcl"},
-		Concurrency: 1,
+		Target:		"nonexistent.hcl",
+		Include:	[]string{"**/*.hcl"},
+		Concurrency:	1,
 	}
 
 	changed, err := Process(context.Background(), cfg)
@@ -42,9 +42,9 @@ func TestProcessContextCancelled(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, data, 0o644))
 
 	cfg := &config.Config{
-		Target:      dir,
-		Include:     []string{"**/*.hcl"},
-		Concurrency: 1,
+		Target:		dir,
+		Include:	[]string{"**/*.hcl"},
+		Concurrency:	1,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -65,9 +65,9 @@ func TestProcessContextCancelledAfterReorder(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, data, 0o644))
 
 	cfg := &config.Config{
-		Target:      dir,
-		Include:     []string{"**/*.hcl"},
-		Concurrency: 1,
+		Target:		dir,
+		Include:	[]string{"**/*.hcl"},
+		Concurrency:	1,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -81,11 +81,11 @@ func TestProcessContextCancelledAfterReorder(t *testing.T) {
 func TestProcessScenarios(t *testing.T) {
 	casesDir := filepath.Join("..", "..", "tests", "cases")
 	tests := []struct {
-		name  string
-		setup func(t *testing.T) (*config.Config, string, bool, map[string]string)
+		name	string
+		setup	func(t *testing.T) (*config.Config, string, bool, map[string]string)
 	}{
 		{
-			name: "stdout multiple files",
+			name:	"stdout multiple files",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				in1, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -103,11 +103,11 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.WriteFile(f2, in2, 0o644))
 
 				cfg := &config.Config{
-					Target:      dir,
-					Include:     []string{"**/*.tf"},
-					Mode:        config.ModeWrite,
-					Stdout:      true,
-					Concurrency: 1,
+					Target:		dir,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
 				}
 
 				expOut := fmt.Sprintf("\n--- %s ---\n%s\n--- %s ---\n%s", f1, out1, f2, out2)
@@ -116,7 +116,7 @@ func TestProcessScenarios(t *testing.T) {
 			},
 		},
 		{
-			name: "mode diff",
+			name:	"mode diff",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inPath := filepath.Join(casesDir, "simple", "in.tf")
@@ -133,18 +133,18 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, err)
 
 				cfg := &config.Config{
-					Target:      f,
-					Include:     []string{"**/*.tf"},
-					Mode:        config.ModeDiff,
-					Stdout:      true,
-					Concurrency: 1,
+					Target:		f,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeDiff,
+					Stdout:		true,
+					Concurrency:	1,
 				}
 				files := map[string]string{f: string(inb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", f, diffText), true, files
 			},
 		},
 		{
-			name: "mode check",
+			name:	"mode check",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -155,18 +155,18 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.WriteFile(f, inb, 0o644))
 
 				cfg := &config.Config{
-					Target:      f,
-					Include:     []string{"**/*.tf"},
-					Mode:        config.ModeCheck,
-					Stdout:      true,
-					Concurrency: 1,
+					Target:		f,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeCheck,
+					Stdout:		true,
+					Concurrency:	1,
 				}
 				files := map[string]string{f: string(inb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", f, outb), true, files
 			},
 		},
 		{
-			name: "symlink follow",
+			name:	"symlink follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				target := t.TempDir()
@@ -180,19 +180,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:         base,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: true,
+					Target:		base,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	true,
 				}
 				files := map[string]string{realFile: string(outb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", filepath.Join(link, "file.tf"), outb), true, files
 			},
 		},
 		{
-			name: "symlink no follow",
+			name:	"symlink no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				target := t.TempDir()
@@ -204,19 +204,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:         base,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: false,
+					Target:		base,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	false,
 				}
 				files := map[string]string{realFile: string(inb)}
 				return cfg, "", false, files
 			},
 		},
 		{
-			name: "symlink file follow",
+			name:	"symlink file follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				realDir := t.TempDir()
@@ -230,19 +230,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:         base,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: true,
+					Target:		base,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	true,
 				}
 				files := map[string]string{link: string(outb), realFile: string(inb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", link, outb), true, files
 			},
 		},
 		{
-			name: "symlink file no follow",
+			name:	"symlink file no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				realDir := t.TempDir()
@@ -254,19 +254,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:         base,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: false,
+					Target:		base,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	false,
 				}
 				files := map[string]string{link: string(inb), realFile: string(inb)}
 				return cfg, "", false, files
 			},
 		},
 		{
-			name: "target symlink dir follow",
+			name:	"target symlink dir follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				target := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -280,19 +280,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:         link,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: true,
+					Target:		link,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	true,
 				}
 				files := map[string]string{realFile: string(outb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", filepath.Join(link, "file.tf"), outb), true, files
 			},
 		},
 		{
-			name: "target symlink dir no follow",
+			name:	"target symlink dir no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				target := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -304,19 +304,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:         link,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: false,
+					Target:		link,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	false,
 				}
 				files := map[string]string{realFile: string(inb)}
 				return cfg, "", false, files
 			},
 		},
 		{
-			name: "target symlink file follow",
+			name:	"target symlink file follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -329,19 +329,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:         link,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: true,
+					Target:		link,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	true,
 				}
 				files := map[string]string{link: string(outb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", link, outb), true, files
 			},
 		},
 		{
-			name: "target symlink file no follow",
+			name:	"target symlink file no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -354,19 +354,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:         link,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: false,
+					Target:		link,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	false,
 				}
 				files := map[string]string{link: string(outb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", link, outb), true, files
 			},
 		},
 		{
-			name: "concurrency",
+			name:	"concurrency",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				cases := []string{"simple", "trailing_commas", "comments"}
@@ -384,11 +384,11 @@ func TestProcessScenarios(t *testing.T) {
 					expected += fmt.Sprintf("\n--- %s ---\n%s", p, outb)
 				}
 				cfg := &config.Config{
-					Target:      dir,
-					Include:     []string{"**/*.tf"},
-					Mode:        config.ModeWrite,
-					Stdout:      true,
-					Concurrency: 2,
+					Target:		dir,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	2,
 				}
 				return cfg, expected, true, files
 			},
@@ -446,11 +446,11 @@ func TestProcessManyFilesDeterministic(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		Target:      dir,
-		Include:     []string{"**/*.tf"},
-		Mode:        config.ModeWrite,
-		Stdout:      true,
-		Concurrency: 4,
+		Target:		dir,
+		Include:	[]string{"**/*.tf"},
+		Mode:		config.ModeWrite,
+		Stdout:		true,
+		Concurrency:	4,
 	}
 
 	r, w, err := os.Pipe()
@@ -487,3 +487,4 @@ func TestProcessManyFilesDeterministic(t *testing.T) {
 		require.Equal(t, exp, string(got))
 	}
 }
+

--- a/internal/engine/error_test.go
+++ b/internal/engine/error_test.go
@@ -49,9 +49,9 @@ func TestProcessStopsAfterFirstError(t *testing.T) {
 	require.NoError(t, os.WriteFile(goodPath, []byte(good), 0o644))
 
 	cfg := &config.Config{
-		Target:      dir,
-		Include:     []string{"**/*.hcl"},
-		Concurrency: 1,
+		Target:		dir,
+		Include:	[]string{"**/*.hcl"},
+		Concurrency:	1,
 	}
 
 	changed, err := Process(context.Background(), cfg)

--- a/internal/engine/process_reader_test.go
+++ b/internal/engine/process_reader_test.go
@@ -97,11 +97,11 @@ func TestProcessPrintsDelimiters(t *testing.T) {
 	require.NoError(t, os.WriteFile(f2, []byte("variable \"b\" {}\n"), 0o644))
 
 	cfg := &config.Config{
-		Target:      dir,
-		Include:     []string{"**/*.tf"},
-		Mode:        config.ModeCheck,
-		Stdout:      true,
-		Concurrency: 1,
+		Target:		dir,
+		Include:	[]string{"**/*.tf"},
+		Mode:		config.ModeCheck,
+		Stdout:		true,
+		Concurrency:	1,
 	}
 
 	r, w, err := os.Pipe()
@@ -120,3 +120,4 @@ func TestProcessPrintsDelimiters(t *testing.T) {
 	require.Contains(t, s, fmt.Sprintf("\n--- %s ---\n", f1))
 	require.Contains(t, s, fmt.Sprintf("\n--- %s ---\n", f2))
 }
+

--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -13,8 +13,8 @@ import (
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
 type Hints struct {
-	HasBOM  bool
-	Newline string
+	HasBOM	bool
+	Newline	string
 }
 
 func (h Hints) BOM() []byte {
@@ -139,3 +139,4 @@ func WriteFileAtomic(ctx context.Context, path string, data []byte, perm iofs.Fi
 	defer func() { _ = dirf.Close() }()
 	return dirf.Sync()
 }
+

--- a/patternmatching/patternmatching.go
+++ b/patternmatching/patternmatching.go
@@ -1,6 +1,4 @@
-// Package patternmatching provides utilities for matching file paths against
-// include and exclude glob patterns. Matcher values are safe for concurrent use
-// by multiple goroutines.
+// patternmatching/patternmatching.go
 package patternmatching
 
 import (
@@ -13,10 +11,10 @@ import (
 )
 
 type Matcher struct {
-	include  []string
-	exclude  []string
-	rootOnce sync.Once
-	root     string
+	include		[]string
+	exclude		[]string
+	rootOnce	sync.Once
+	root		string
 }
 
 func NewMatcher(include, exclude []string) (*Matcher, error) {
@@ -79,4 +77,5 @@ func (m *Matcher) Matches(path string) bool {
 	return false
 }
 
-func ValidatePatterns(patterns []string) error { return validatePatterns(patterns) }
+func ValidatePatterns(patterns []string) error	{ return validatePatterns(patterns) }
+

--- a/patternmatching/patternmatching_test.go
+++ b/patternmatching/patternmatching_test.go
@@ -100,3 +100,4 @@ func TestMatcherMatchesConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 }
+


### PR DESCRIPTION
## Summary
- strip comments from Go files and keep only first-line path comments
- document comment stripping in contributor workflow

## Testing
- `go vet ./...`
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b18fe58b648323bbb02e5860116237