### PR TITLE
Ensure unknown variable attributes follow canonical order

### DIFF
--- a/internal/hclalign/hclalign.go
+++ b/internal/hclalign/hclalign.go
@@ -215,14 +215,10 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 	} else {
 
 		finalOrder := make([]string, 0, len(originalOrder))
-		idx := 0
+
+		finalOrder = append(finalOrder, orderedKnown...)
 		for _, name := range originalOrder {
-			if _, isKnown := canonicalSet[name]; isKnown {
-				if idx < len(orderedKnown) {
-					finalOrder = append(finalOrder, orderedKnown[idx])
-					idx++
-				}
-			} else {
+			if _, isKnown := canonicalSet[name]; !isKnown {
 				finalOrder = append(finalOrder, name)
 			}
 		}
@@ -262,8 +258,8 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 }
 
 type attrTokens struct {
-	leadTokens	hclwrite.Tokens
-	exprTokens	hclwrite.Tokens
+	leadTokens hclwrite.Tokens
+	exprTokens hclwrite.Tokens
 }
 
 func extractAttrTokens(attr *hclwrite.Attribute) attrTokens {
@@ -313,4 +309,3 @@ func attributeOrder(body *hclwrite.Body, attrs map[string]*hclwrite.Attribute) [
 	}
 	return order
 }
-

--- a/internal/hclalign/hclalign_test.go
+++ b/internal/hclalign/hclalign_test.go
@@ -113,7 +113,7 @@ func TestReorderAttributes_StrictUnknownAttrWithCanonical(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestReorderAttributes_LooseRetainsUnknownOrder(t *testing.T) {
+func TestReorderAttributes_LoosePlacesUnknownAfterCanonical(t *testing.T) {
 	src := `variable "example" {
   custom      = true
   type        = string
@@ -125,9 +125,9 @@ func TestReorderAttributes_LooseRetainsUnknownOrder(t *testing.T) {
 	require.NoError(t, hclalign.ReorderAttributes(f, []string{"description", "type"}, false))
 
 	expected := `variable "example" {
-  custom      = true
   description = "d"
   type        = string
+  custom      = true
 }`
 	require.Equal(t, expected, string(f.Bytes()))
 }
@@ -176,4 +176,3 @@ func TestReorderAttributes_DefaultBlockNestedType(t *testing.T) {
 }`
 	require.Equal(t, expected, string(f.Bytes()))
 }
-

--- a/tests/cases/complex/out.tf
+++ b/tests/cases/complex/out.tf
@@ -1,10 +1,10 @@
 variable "complex" {
-  custom      = true
   description = "desc"
   type        = list(string)
   default     = ["a", "b"]
   sensitive   = true
   nullable    = false
+  custom      = true
   validation {
     condition     = true
     error_message = "msg"

--- a/tests/cases/complex/out_strict.tf
+++ b/tests/cases/complex/out_strict.tf
@@ -1,10 +1,10 @@
 variable "complex" {
-  custom      = true
   description = "desc"
   type        = list(string)
   default     = ["a", "b"]
   sensitive   = true
   nullable    = false
+  custom      = true
   validation {
     condition     = true
     error_message = "msg"

--- a/tests/cases/stress/out.tf
+++ b/tests/cases/stress/out.tf
@@ -1,14 +1,14 @@
 variable "stress" {
-  a1          = 1
   description = "d"
-  a2          = 2
   type        = string
-  a3          = 3
   default     = 0
-  a4          = 4
   sensitive   = true
-  a5          = 5
   nullable    = false
+  a1          = 1
+  a2          = 2
+  a3          = 3
+  a4          = 4
+  a5          = 5
   a6          = 6
   a7          = 7
   a8          = 8

--- a/tests/cases/stress/out_strict.tf
+++ b/tests/cases/stress/out_strict.tf
@@ -1,14 +1,14 @@
 variable "stress" {
-  a1          = 1
   description = "d"
-  a2          = 2
   type        = string
-  a3          = 3
   default     = 0
-  a4          = 4
   sensitive   = true
-  a5          = 5
   nullable    = false
+  a1          = 1
+  a2          = 2
+  a3          = 3
+  a4          = 4
+  a5          = 5
   a6          = 6
   a7          = 7
   a8          = 8

--- a/tests/cases/unicode/out.tf
+++ b/tests/cases/unicode/out.tf
@@ -1,6 +1,6 @@
 variable "unicode" {
-  κ           = 1
   description = "d"
-  デフォルト       = 2
   type        = number
+  κ           = 1
+  デフォルト       = 2
 }

--- a/tests/cases/unknown_attrs/out_strict.tf
+++ b/tests/cases/unknown_attrs/out_strict.tf
@@ -1,9 +1,9 @@
 variable "example" {
-  foo         = "foo"
   description = "example"
-  bar         = "bar"
   type        = number
   default     = 1
   sensitive   = true
   nullable    = false
+  foo         = "foo"
+  bar         = "bar"
 }

--- a/tests/cases/unknown_attrs_mixed/in.tf
+++ b/tests/cases/unknown_attrs_mixed/in.tf
@@ -1,0 +1,11 @@
+variable "example" {
+  foo = "foo"
+  description = "example"
+  bar = "bar"
+  type = number
+  baz = "baz"
+  default = 1
+  qux = "qux"
+  sensitive = true
+  nullable = false
+}

--- a/tests/cases/unknown_attrs_mixed/out.tf
+++ b/tests/cases/unknown_attrs_mixed/out.tf
@@ -6,4 +6,6 @@ variable "example" {
   nullable    = false
   foo         = "foo"
   bar         = "bar"
+  baz         = "baz"
+  qux         = "qux"
 }


### PR DESCRIPTION
## Summary
- Always emit canonical variable attributes first and append unknown attributes afterward
- Add regression test for unknown attributes and adjust golden cases

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b18fcba1ec83239f15e16724e870b7