### PR TITLE
Remove SPDX headers and tighten comment checking

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,4 +1,4 @@
-// cli/cli.go — SPDX-License-Identifier: Apache-2.0
+// cli/cli.go
 package cli
 
 import (
@@ -11,11 +11,11 @@ import (
 )
 
 type ExitCodeError struct {
-	Err  error
-	Code int
+	Err	error
+	Code	int
 }
 
-func (e *ExitCodeError) Error() string { return e.Err.Error() }
+func (e *ExitCodeError) Error() string	{ return e.Err.Error() }
 
 func RunE(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
@@ -113,17 +113,17 @@ func RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := &config.Config{
-		Target:         target,
-		Mode:           mode,
-		Stdin:          stdin,
-		Stdout:         stdout,
-		Include:        include,
-		Exclude:        exclude,
-		Order:          order,
-		StrictOrder:    strictOrder,
-		Concurrency:    concurrency,
-		Verbose:        verbose,
-		FollowSymlinks: followSymlinks,
+		Target:		target,
+		Mode:		mode,
+		Stdin:		stdin,
+		Stdout:		stdout,
+		Include:	include,
+		Exclude:	exclude,
+		Order:		order,
+		StrictOrder:	strictOrder,
+		Concurrency:	concurrency,
+		Verbose:	verbose,
+		FollowSymlinks:	followSymlinks,
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -141,3 +141,4 @@ func RunE(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
+

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,4 +1,4 @@
-// cli/cli_test.go — SPDX-License-Identifier: Apache-2.0
+// cli/cli_test.go
 package cli
 
 import (
@@ -16,15 +16,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newRootCmd(exclusive bool) *cobra.Command { return newTestRootCmd(exclusive) }
+func newRootCmd(exclusive bool) *cobra.Command	{ return newTestRootCmd(exclusive) }
 
 func newTestRootCmd(exclusive bool) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:          "hclalign [target file or directory]",
-		Args:         cobra.ArbitraryArgs,
-		RunE:         RunE,
-		SilenceUsage: true,
+		Use:		"hclalign [target file or directory]",
+		Args:		cobra.ArbitraryArgs,
+		RunE:		RunE,
+		SilenceUsage:	true,
 	}
 	cmd.Flags().Bool("write", false, "write result to file(s)")
 	cmd.Flags().Bool("check", false, "check if files are formatted")
@@ -150,9 +150,9 @@ func TestRunEInvalidConcurrency(t *testing.T) {
 
 func TestRunEInvalidGlob(t *testing.T) {
 	tests := []struct {
-		name    string
-		flag    string
-		message string
+		name	string
+		flag	string
+		message	string
 	}{
 		{name: "include", flag: "--include", message: "invalid include"},
 		{name: "exclude", flag: "--exclude", message: "invalid exclude"},
@@ -177,44 +177,44 @@ func TestRunEModes(t *testing.T) {
 	formatted := "variable \"a\" {\n  description = \"d\"\n  type        = string\n}\n"
 
 	tests := []struct {
-		name       string
-		flags      []string
-		stdin      string
-		wantCode   int
-		wantStdout string
-		contains   string
-		withFile   bool
-		wantFile   string
+		name		string
+		flags		[]string
+		stdin		string
+		wantCode	int
+		wantStdout	string
+		contains	string
+		withFile	bool
+		wantFile	string
 	}{
 		{
-			name:     "diff",
-			flags:    []string{"--diff"},
-			wantCode: 1,
-			contains: "@@",
-			withFile: true,
-			wantFile: unformatted,
+			name:		"diff",
+			flags:		[]string{"--diff"},
+			wantCode:	1,
+			contains:	"@@",
+			withFile:	true,
+			wantFile:	unformatted,
 		},
 		{
-			name:       "stdin",
-			flags:      []string{"--stdin", "--stdout"},
-			stdin:      unformatted,
-			wantCode:   0,
-			wantStdout: formatted,
+			name:		"stdin",
+			flags:		[]string{"--stdin", "--stdout"},
+			stdin:		unformatted,
+			wantCode:	0,
+			wantStdout:	formatted,
 		},
 		{
-			name:     "write",
-			flags:    []string{"--write"},
-			wantCode: 0,
-			withFile: true,
-			wantFile: formatted,
+			name:		"write",
+			flags:		[]string{"--write"},
+			wantCode:	0,
+			withFile:	true,
+			wantFile:	formatted,
 		},
 		{
-			name:       "stdout",
-			flags:      []string{"--stdout"},
-			wantCode:   0,
-			wantStdout: formatted,
-			withFile:   true,
-			wantFile:   formatted,
+			name:		"stdout",
+			flags:		[]string{"--stdout"},
+			wantCode:	0,
+			wantStdout:	formatted,
+			withFile:	true,
+			wantFile:	formatted,
 		},
 	}
 
@@ -296,9 +296,9 @@ func TestRunEVerbose(t *testing.T) {
 	unformatted := "variable \"a\" {\n  type = string\n  description = \"d\"\n}\n"
 
 	tests := []struct {
-		name    string
-		verbose bool
-		wantLog bool
+		name	string
+		verbose	bool
+		wantLog	bool
 	}{
 		{name: "verbose", verbose: true, wantLog: true},
 		{name: "silent", verbose: false, wantLog: false},
@@ -348,9 +348,9 @@ func TestRunEFollowSymlinks(t *testing.T) {
 	formatted := "variable \"a\" {\n  description = \"d\"\n  type        = string\n}\n"
 
 	tests := []struct {
-		name   string
-		follow bool
-		want   string
+		name	string
+		follow	bool
+		want	string
 	}{
 		{name: "follow", follow: true, want: formatted},
 		{name: "no_follow", follow: false, want: unformatted},
@@ -381,3 +381,4 @@ func TestRunEFollowSymlinks(t *testing.T) {
 		})
 	}
 }
+

--- a/cmd/commentcheck/doc.go
+++ b/cmd/commentcheck/doc.go
@@ -1,2 +1,3 @@
-// cmd/commentcheck/doc.go — SPDX-License-Identifier: Apache-2.0
+// cmd/commentcheck/doc.go
 package main
+

--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -1,4 +1,4 @@
-// cmd/commentcheck/main.go — SPDX-License-Identifier: Apache-2.0
+// cmd/commentcheck/main.go
 package main
 
 import (
@@ -59,7 +59,7 @@ func main() {
 
 func checkFileFunc(path string) error {
 	rel := filepath.ToSlash(path)
-	expected := "// " + rel + " — SPDX-License-Identifier: Apache-2.0"
+	expected := "// " + rel
 	fh, err := os.Open(path)
 	if err != nil {
 		return err

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -1,4 +1,4 @@
-// cmd/commentcheck/main_test.go — SPDX-License-Identifier: Apache-2.0
+// cmd/commentcheck/main_test.go
 package main
 
 import (
@@ -21,7 +21,7 @@ func write(t *testing.T, path, content string) {
 func TestCheckFileOK(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "foo.go")
-	comment := fmt.Sprintf("// %s — SPDX-License-Identifier: Apache-2.0\n", filepath.ToSlash(path))
+	comment := fmt.Sprintf("// %s\n", filepath.ToSlash(path))
 	write(t, path, comment+"package main\n")
 	if err := checkFile(path); err != nil {
 		t.Fatalf("check file: %v", err)
@@ -31,7 +31,7 @@ func TestCheckFileOK(t *testing.T) {
 func TestCheckFileWithBuildTag(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "foo.go")
-	comment := fmt.Sprintf("// %s — SPDX-License-Identifier: Apache-2.0\n", filepath.ToSlash(path))
+	comment := fmt.Sprintf("// %s\n", filepath.ToSlash(path))
 	content := "//go:build windows\n\n" + comment + "package main\n"
 	write(t, path, content)
 	if err := checkFile(path); err != nil {
@@ -51,7 +51,8 @@ func TestCheckFileMissingComment(t *testing.T) {
 func TestCheckFileMalformedComment(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "foo.go")
-	write(t, path, "// wrong\npackage main\n")
+	comment := fmt.Sprintf("// %s extra\n", filepath.ToSlash(path))
+	write(t, path, comment+"package main\n")
 	if err := checkFile(path); err == nil || !strings.Contains(err.Error(), "first line must be") {
 		t.Fatalf("expected malformed comment error, got %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// config/config.go — SPDX-License-Identifier: Apache-2.0
+// config/config.go
 package config
 
 import (
@@ -11,7 +11,7 @@ import (
 type Mode int
 
 const (
-	ModeWrite Mode = iota
+	ModeWrite	Mode	= iota
 
 	ModeCheck
 
@@ -19,23 +19,23 @@ const (
 )
 
 type Config struct {
-	Target         string
-	Mode           Mode
-	Stdin          bool
-	Stdout         bool
-	Include        []string
-	Exclude        []string
-	Order          []string
-	StrictOrder    bool
-	Concurrency    int
-	Verbose        bool
-	FollowSymlinks bool
+	Target		string
+	Mode		Mode
+	Stdin		bool
+	Stdout		bool
+	Include		[]string
+	Exclude		[]string
+	Order		[]string
+	StrictOrder	bool
+	Concurrency	int
+	Verbose		bool
+	FollowSymlinks	bool
 }
 
 var (
-	DefaultInclude = []string{"**/*.tf"}
-	DefaultExclude = []string{"**/.terraform/**", "**/vendor/**", "**/.git/**", "**/node_modules/**"}
-	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
+	DefaultInclude	= []string{"**/*.tf"}
+	DefaultExclude	= []string{"**/.terraform/**", "**/vendor/**", "**/.git/**", "**/node_modules/**"}
+	CanonicalOrder	= []string{"description", "type", "default", "sensitive", "nullable"}
 )
 
 const (
@@ -89,3 +89,4 @@ func ValidateOrder(order []string, strict bool) error {
 	}
 	return nil
 }
+

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,4 +1,4 @@
-// config/config_test.go — SPDX-License-Identifier: Apache-2.0
+// config/config_test.go
 package config
 
 import (
@@ -85,11 +85,11 @@ func TestValidate_InvalidExcludePattern(t *testing.T) {
 
 func TestValidate_ValidConfig(t *testing.T) {
 	c := Config{
-		Concurrency: 1,
-		Include:     DefaultInclude,
-		Exclude:     DefaultExclude,
-		Order:       CanonicalOrder,
-		StrictOrder: true,
+		Concurrency:	1,
+		Include:	DefaultInclude,
+		Exclude:	DefaultExclude,
+		Order:		CanonicalOrder,
+		StrictOrder:	true,
 	}
 	if err := c.Validate(); err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -98,12 +98,13 @@ func TestValidate_ValidConfig(t *testing.T) {
 
 func TestValidate_DuplicateOrderAttribute(t *testing.T) {
 	c := Config{
-		Concurrency: 1,
-		Include:     DefaultInclude,
-		Exclude:     DefaultExclude,
-		Order:       []string{"description", "description"},
+		Concurrency:	1,
+		Include:	DefaultInclude,
+		Exclude:	DefaultExclude,
+		Order:		[]string{"description", "description"},
 	}
 	if err := c.Validate(); err == nil {
 		t.Fatalf("expected error for duplicate order attribute")
 	}
 }
+

--- a/hack/stripcomments/main.go
+++ b/hack/stripcomments/main.go
@@ -1,4 +1,4 @@
-// hack/stripcomments/main.go — SPDX-License-Identifier: Apache-2.0
+// hack/stripcomments/main.go
 package main
 
 import (
@@ -59,7 +59,7 @@ func processFile(path string) error {
 	if err != nil {
 		return err
 	}
-	comment := "// " + filepath.ToSlash(rel) + " — SPDX-License-Identifier: Apache-2.0"
+	comment := "// " + filepath.ToSlash(rel)
 
 	tags := extractBuildTags(src)
 

--- a/hack/stripcomments/main_test.go
+++ b/hack/stripcomments/main_test.go
@@ -1,4 +1,4 @@
-// hack/stripcomments/main_test.go — SPDX-License-Identifier: Apache-2.0
+// hack/stripcomments/main_test.go
 package main
 
 import (
@@ -38,7 +38,8 @@ func main() { // inline
 	if err != nil {
 		t.Fatalf("rel: %v", err)
 	}
-	expected := "// " + filepath.ToSlash(rel) + " — SPDX-License-Identifier: Apache-2.0\npackage main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hi\")\n}\n\n"
+	expected := "// " + filepath.ToSlash(rel) + "\n" +
+		"package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hi\")\n}\n\n"
 	if string(out) != expected {
 		t.Fatalf("unexpected output:\n%s", out)
 	}
@@ -67,7 +68,8 @@ func TestStripWithBuildTag(t *testing.T) {
 		t.Fatalf("rel: %v", err)
 	}
 	outStr := strings.ReplaceAll(string(out), "\t", "")
-	need := "//go:build windows\n\n// " + filepath.ToSlash(rel) + " — SPDX-License-Identifier: Apache-2.0\npackage main\n\nfunc main(){}\n"
+	need := "//go:build windows\n\n// " + filepath.ToSlash(rel) + "\n" +
+		"package main\n\nfunc main(){}\n"
 	if !strings.Contains(outStr, need) {
 		t.Fatalf("unexpected output:\n%s", out)
 	}

--- a/internal/align/fuzz_test.go
+++ b/internal/align/fuzz_test.go
@@ -1,4 +1,4 @@
-// internal/align/fuzz_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/align/fuzz_test.go
 package align
 
 import (
@@ -68,3 +68,4 @@ func addRandomPadding(buf *bytes.Buffer, r *rand.Rand) {
 		}
 	}
 }
+

--- a/internal/align/golden_test.go
+++ b/internal/align/golden_test.go
@@ -1,4 +1,4 @@
-// internal/align/golden_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/align/golden_test.go
 package align
 
 import (
@@ -127,3 +127,4 @@ func TestUnknownAttributesAfterCanonical(t *testing.T) {
 		t.Fatalf("output mismatch:\n-- got --\n%s\n-- want --\n%s", got, exp)
 	}
 }
+

--- a/internal/align/strict_error_test.go
+++ b/internal/align/strict_error_test.go
@@ -1,4 +1,4 @@
-// internal/align/strict_error_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/align/strict_error_test.go
 package align
 
 import (
@@ -12,14 +12,14 @@ import (
 
 func TestStrictOrderErrors(t *testing.T) {
 	cases := []struct {
-		name string
-		src  string
-		want string
+		name	string
+		src	string
+		want	string
 	}{
 		{
-			name: "missing",
-			src:  "variable \"a\" {\n  type = string\n}",
-			want: "missing attributes",
+			name:	"missing",
+			src:	"variable \"a\" {\n  type = string\n}",
+			want:	"missing attributes",
 		},
 	}
 
@@ -50,3 +50,4 @@ func TestStrictOrderRejectsUnknownAttributes(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
+

--- a/internal/ci/covercheck/doc.go
+++ b/internal/ci/covercheck/doc.go
@@ -1,2 +1,3 @@
-// internal/ci/covercheck/doc.go — SPDX-License-Identifier: Apache-2.0
+// internal/ci/covercheck/doc.go
 package main
+

--- a/internal/ci/covercheck/main.go
+++ b/internal/ci/covercheck/main.go
@@ -1,4 +1,4 @@
-// internal/ci/covercheck/main.go — SPDX-License-Identifier: Apache-2.0
+// internal/ci/covercheck/main.go
 package main
 
 import (
@@ -78,3 +78,4 @@ func main() {
 		os.Exit(1)
 	}
 }
+

--- a/internal/ci/covercheck/main_test.go
+++ b/internal/ci/covercheck/main_test.go
@@ -1,4 +1,4 @@
-// internal/ci/covercheck/main_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/ci/covercheck/main_test.go
 package main
 
 import (
@@ -24,28 +24,28 @@ func runCovercheck(t *testing.T) (string, int) {
 
 func TestCovercheck(t *testing.T) {
 	tests := []struct {
-		name     string
-		profile  string
-		wantExit int
-		wantMsg  string
+		name		string
+		profile		string
+		wantExit	int
+		wantMsg		string
 	}{
 		{
-			name:     "above",
-			profile:  "mode: set\nfile.go:1.1,1.2 1 1\n",
-			wantExit: 0,
-			wantMsg:  "Total coverage: 100.0%",
+			name:		"above",
+			profile:	"mode: set\nfile.go:1.1,1.2 1 1\n",
+			wantExit:	0,
+			wantMsg:	"Total coverage: 100.0%",
 		},
 		{
-			name:     "below",
-			profile:  "mode: set\nfile.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
-			wantExit: 1,
-			wantMsg:  "Coverage 50.0% is below 95.0%",
+			name:		"below",
+			profile:	"mode: set\nfile.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
+			wantExit:	1,
+			wantMsg:	"Coverage 50.0% is below 95.0%",
 		},
 		{
-			name:     "ignored path",
-			profile:  "mode: set\ncmd/commentcheck/file.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
-			wantExit: 0,
-			wantMsg:  "Total coverage: 100.0%",
+			name:		"ignored path",
+			profile:	"mode: set\ncmd/commentcheck/file.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
+			wantExit:	0,
+			wantMsg:	"Total coverage: 100.0%",
 		},
 	}
 	for _, tc := range tests {
@@ -64,3 +64,4 @@ func TestCovercheck(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,4 +1,4 @@
-// internal/diff/diff.go — SPDX-License-Identifier: Apache-2.0
+// internal/diff/diff.go
 package diff
 
 import "github.com/pmezard/go-difflib/difflib"
@@ -7,12 +7,13 @@ const diffContext = 3
 
 func Unified(fromFile, toFile string, original, styled []byte, eol string) (string, error) {
 	ud := difflib.UnifiedDiff{
-		A:        difflib.SplitLines(string(original)),
-		B:        difflib.SplitLines(string(styled)),
-		FromFile: fromFile,
-		ToFile:   toFile,
-		Context:  diffContext,
-		Eol:      eol,
+		A:		difflib.SplitLines(string(original)),
+		B:		difflib.SplitLines(string(styled)),
+		FromFile:	fromFile,
+		ToFile:		toFile,
+		Context:	diffContext,
+		Eol:		eol,
 	}
 	return difflib.GetUnifiedDiffString(ud)
 }
+

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,4 +1,4 @@
-// internal/diff/diff_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/diff/diff_test.go
 package diff
 
 import (
@@ -38,3 +38,4 @@ func TestUnifiedDiffUsesEOL(t *testing.T) {
 		t.Fatalf("expected CRLF line endings in diff, got: %q", diffStr)
 	}
 }
+

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,4 +1,4 @@
-// internal/engine/engine.go — SPDX-License-Identifier: Apache-2.0
+// internal/engine/engine.go
 package engine
 
 import (
@@ -26,10 +26,10 @@ import (
 )
 
 var (
-	testHookAfterParse   func()
-	testHookAfterReorder func()
-	reorderAttributes    = hclalign.ReorderAttributes
-	WriteFileAtomic      = internalfs.WriteFileAtomic
+	testHookAfterParse	func()
+	testHookAfterReorder	func()
+	reorderAttributes	= hclalign.ReorderAttributes
+	WriteFileAtomic		= internalfs.WriteFileAtomic
 )
 
 func Process(ctx context.Context, cfg *config.Config) (bool, error) {
@@ -125,8 +125,8 @@ func processFiles(ctx context.Context, cfg *config.Config) (bool, error) {
 	sort.Strings(files)
 
 	type result struct {
-		path string
-		data []byte
+		path	string
+		data	[]byte
 	}
 
 	var changed atomic.Bool
@@ -358,3 +358,4 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 	}
 	return changed, nil
 }
+

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,4 +1,4 @@
-// internal/engine/engine_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/engine/engine_test.go
 package engine
 
 import (
@@ -22,9 +22,9 @@ func TestProcessMissingTarget(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{
-		Target:      "nonexistent.hcl",
-		Include:     []string{"**/*.hcl"},
-		Concurrency: 1,
+		Target:		"nonexistent.hcl",
+		Include:	[]string{"**/*.hcl"},
+		Concurrency:	1,
 	}
 
 	changed, err := Process(context.Background(), cfg)
@@ -42,9 +42,9 @@ func TestProcessContextCancelled(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, data, 0o644))
 
 	cfg := &config.Config{
-		Target:      dir,
-		Include:     []string{"**/*.hcl"},
-		Concurrency: 1,
+		Target:		dir,
+		Include:	[]string{"**/*.hcl"},
+		Concurrency:	1,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -65,9 +65,9 @@ func TestProcessContextCancelledAfterReorder(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, data, 0o644))
 
 	cfg := &config.Config{
-		Target:      dir,
-		Include:     []string{"**/*.hcl"},
-		Concurrency: 1,
+		Target:		dir,
+		Include:	[]string{"**/*.hcl"},
+		Concurrency:	1,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -81,11 +81,11 @@ func TestProcessContextCancelledAfterReorder(t *testing.T) {
 func TestProcessScenarios(t *testing.T) {
 	casesDir := filepath.Join("..", "..", "tests", "cases")
 	tests := []struct {
-		name  string
-		setup func(t *testing.T) (*config.Config, string, bool, map[string]string)
+		name	string
+		setup	func(t *testing.T) (*config.Config, string, bool, map[string]string)
 	}{
 		{
-			name: "stdout multiple files",
+			name:	"stdout multiple files",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				in1, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -103,11 +103,11 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.WriteFile(f2, in2, 0o644))
 
 				cfg := &config.Config{
-					Target:      dir,
-					Include:     []string{"**/*.tf"},
-					Mode:        config.ModeWrite,
-					Stdout:      true,
-					Concurrency: 1,
+					Target:		dir,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
 				}
 
 				expOut := fmt.Sprintf("\n--- %s ---\n%s\n--- %s ---\n%s", f1, out1, f2, out2)
@@ -116,7 +116,7 @@ func TestProcessScenarios(t *testing.T) {
 			},
 		},
 		{
-			name: "mode diff",
+			name:	"mode diff",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inPath := filepath.Join(casesDir, "simple", "in.tf")
@@ -133,18 +133,18 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, err)
 
 				cfg := &config.Config{
-					Target:      f,
-					Include:     []string{"**/*.tf"},
-					Mode:        config.ModeDiff,
-					Stdout:      true,
-					Concurrency: 1,
+					Target:		f,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeDiff,
+					Stdout:		true,
+					Concurrency:	1,
 				}
 				files := map[string]string{f: string(inb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", f, diffText), true, files
 			},
 		},
 		{
-			name: "mode check",
+			name:	"mode check",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -155,18 +155,18 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.WriteFile(f, inb, 0o644))
 
 				cfg := &config.Config{
-					Target:      f,
-					Include:     []string{"**/*.tf"},
-					Mode:        config.ModeCheck,
-					Stdout:      true,
-					Concurrency: 1,
+					Target:		f,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeCheck,
+					Stdout:		true,
+					Concurrency:	1,
 				}
 				files := map[string]string{f: string(inb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", f, outb), true, files
 			},
 		},
 		{
-			name: "symlink follow",
+			name:	"symlink follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				target := t.TempDir()
@@ -180,19 +180,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:         base,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: true,
+					Target:		base,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	true,
 				}
 				files := map[string]string{realFile: string(outb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", filepath.Join(link, "file.tf"), outb), true, files
 			},
 		},
 		{
-			name: "symlink no follow",
+			name:	"symlink no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				target := t.TempDir()
@@ -204,19 +204,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:         base,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: false,
+					Target:		base,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	false,
 				}
 				files := map[string]string{realFile: string(inb)}
 				return cfg, "", false, files
 			},
 		},
 		{
-			name: "symlink file follow",
+			name:	"symlink file follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				realDir := t.TempDir()
@@ -230,19 +230,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:         base,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: true,
+					Target:		base,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	true,
 				}
 				files := map[string]string{link: string(outb), realFile: string(inb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", link, outb), true, files
 			},
 		},
 		{
-			name: "symlink file no follow",
+			name:	"symlink file no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				realDir := t.TempDir()
@@ -254,19 +254,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:         base,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: false,
+					Target:		base,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	false,
 				}
 				files := map[string]string{link: string(inb), realFile: string(inb)}
 				return cfg, "", false, files
 			},
 		},
 		{
-			name: "target symlink dir follow",
+			name:	"target symlink dir follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				target := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -280,19 +280,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:         link,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: true,
+					Target:		link,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	true,
 				}
 				files := map[string]string{realFile: string(outb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", filepath.Join(link, "file.tf"), outb), true, files
 			},
 		},
 		{
-			name: "target symlink dir no follow",
+			name:	"target symlink dir no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				target := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -304,19 +304,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:         link,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: false,
+					Target:		link,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	false,
 				}
 				files := map[string]string{realFile: string(inb)}
 				return cfg, "", false, files
 			},
 		},
 		{
-			name: "target symlink file follow",
+			name:	"target symlink file follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -329,19 +329,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:         link,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: true,
+					Target:		link,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	true,
 				}
 				files := map[string]string{link: string(outb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", link, outb), true, files
 			},
 		},
 		{
-			name: "target symlink file no follow",
+			name:	"target symlink file no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -354,19 +354,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:         link,
-					Include:        []string{"**/*.tf"},
-					Mode:           config.ModeWrite,
-					Stdout:         true,
-					Concurrency:    1,
-					FollowSymlinks: false,
+					Target:		link,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	1,
+					FollowSymlinks:	false,
 				}
 				files := map[string]string{link: string(outb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", link, outb), true, files
 			},
 		},
 		{
-			name: "concurrency",
+			name:	"concurrency",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				cases := []string{"simple", "trailing_commas", "comments"}
@@ -384,11 +384,11 @@ func TestProcessScenarios(t *testing.T) {
 					expected += fmt.Sprintf("\n--- %s ---\n%s", p, outb)
 				}
 				cfg := &config.Config{
-					Target:      dir,
-					Include:     []string{"**/*.tf"},
-					Mode:        config.ModeWrite,
-					Stdout:      true,
-					Concurrency: 2,
+					Target:		dir,
+					Include:	[]string{"**/*.tf"},
+					Mode:		config.ModeWrite,
+					Stdout:		true,
+					Concurrency:	2,
 				}
 				return cfg, expected, true, files
 			},
@@ -446,11 +446,11 @@ func TestProcessManyFilesDeterministic(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		Target:      dir,
-		Include:     []string{"**/*.tf"},
-		Mode:        config.ModeWrite,
-		Stdout:      true,
-		Concurrency: 4,
+		Target:		dir,
+		Include:	[]string{"**/*.tf"},
+		Mode:		config.ModeWrite,
+		Stdout:		true,
+		Concurrency:	4,
 	}
 
 	r, w, err := os.Pipe()
@@ -487,3 +487,4 @@ func TestProcessManyFilesDeterministic(t *testing.T) {
 		require.Equal(t, exp, string(got))
 	}
 }
+

--- a/internal/engine/error_test.go
+++ b/internal/engine/error_test.go
@@ -1,4 +1,4 @@
-// internal/engine/error_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/engine/error_test.go
 package engine
 
 import (
@@ -22,9 +22,9 @@ func TestProcessInvalidHCLFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(orig), 0o644))
 
 	cfg := &config.Config{
-		Target:      path,
-		Include:     []string{"**/*.hcl"},
-		Concurrency: 1,
+		Target:		path,
+		Include:	[]string{"**/*.hcl"},
+		Concurrency:	1,
 	}
 
 	changed, err := Process(context.Background(), cfg)
@@ -49,9 +49,9 @@ func TestProcessStopsAfterFirstError(t *testing.T) {
 	require.NoError(t, os.WriteFile(goodPath, []byte(good), 0o644))
 
 	cfg := &config.Config{
-		Target:      dir,
-		Include:     []string{"**/*.hcl"},
-		Concurrency: 1,
+		Target:		dir,
+		Include:	[]string{"**/*.hcl"},
+		Concurrency:	1,
 	}
 
 	changed, err := Process(context.Background(), cfg)
@@ -90,3 +90,4 @@ func TestProcessReaderEmpty(t *testing.T) {
 	require.False(t, changed)
 	require.Empty(t, buf.String())
 }
+

--- a/internal/engine/fuzz_process_reader_test.go
+++ b/internal/engine/fuzz_process_reader_test.go
@@ -1,4 +1,4 @@
-// internal/engine/fuzz_process_reader_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/engine/fuzz_process_reader_test.go
 package engine
 
 import (
@@ -38,3 +38,4 @@ func FuzzProcessReader(f *testing.F) {
 		}
 	})
 }
+

--- a/internal/engine/process_reader_test.go
+++ b/internal/engine/process_reader_test.go
@@ -1,4 +1,4 @@
-// internal/engine/process_reader_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/engine/process_reader_test.go
 package engine_test
 
 import (
@@ -97,11 +97,11 @@ func TestProcessPrintsDelimiters(t *testing.T) {
 	require.NoError(t, os.WriteFile(f2, []byte("variable \"b\" {}\n"), 0o644))
 
 	cfg := &config.Config{
-		Target:      dir,
-		Include:     []string{"**/*.tf"},
-		Mode:        config.ModeCheck,
-		Stdout:      true,
-		Concurrency: 1,
+		Target:		dir,
+		Include:	[]string{"**/*.tf"},
+		Mode:		config.ModeCheck,
+		Stdout:		true,
+		Concurrency:	1,
 	}
 
 	r, w, err := os.Pipe()
@@ -120,3 +120,4 @@ func TestProcessPrintsDelimiters(t *testing.T) {
 	require.Contains(t, s, fmt.Sprintf("\n--- %s ---\n", f1))
 	require.Contains(t, s, fmt.Sprintf("\n--- %s ---\n", f2))
 }
+

--- a/internal/engine/reader.go
+++ b/internal/engine/reader.go
@@ -1,4 +1,4 @@
-// internal/engine/reader.go — SPDX-License-Identifier: Apache-2.0
+// internal/engine/reader.go
 package engine
 
 import (
@@ -11,3 +11,4 @@ import (
 func ProcessReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Config) (bool, error) {
 	return processReader(ctx, r, w, cfg)
 }
+

--- a/internal/engine/write_error_test.go
+++ b/internal/engine/write_error_test.go
@@ -1,4 +1,4 @@
-// internal/engine/write_error_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/engine/write_error_test.go
 package engine_test
 
 import (
@@ -21,10 +21,10 @@ import (
 
 func newRootCmd(exclusive bool) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "hclalign [target file or directory]",
-		Args:         cobra.ArbitraryArgs,
-		RunE:         cli.RunE,
-		SilenceUsage: true,
+		Use:		"hclalign [target file or directory]",
+		Args:		cobra.ArbitraryArgs,
+		RunE:		cli.RunE,
+		SilenceUsage:	true,
 	}
 	cmd.Flags().Bool("write", false, "write result to file(s)")
 	cmd.Flags().Bool("check", false, "check if files are formatted")
@@ -72,3 +72,4 @@ func TestProcessWriteFileError(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, string(data), string(got))
 }
+

--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -1,4 +1,4 @@
-// internal/fs/atomic.go — SPDX-License-Identifier: Apache-2.0
+// internal/fs/atomic.go
 package fs
 
 import (
@@ -13,8 +13,8 @@ import (
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
 type Hints struct {
-	HasBOM  bool
-	Newline string
+	HasBOM	bool
+	Newline	string
 }
 
 func (h Hints) BOM() []byte {
@@ -139,3 +139,4 @@ func WriteFileAtomic(ctx context.Context, path string, data []byte, perm iofs.Fi
 	defer func() { _ = dirf.Close() }()
 	return dirf.Sync()
 }
+

--- a/internal/fs/atomic_test.go
+++ b/internal/fs/atomic_test.go
@@ -1,4 +1,4 @@
-// internal/fs/atomic_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/fs/atomic_test.go
 package fs
 
 import (
@@ -19,18 +19,18 @@ type validateFunc func(t *testing.T, dir, path string, ctx any)
 func TestWriteFileAtomic(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name     string
-		data     []byte
-		perm     os.FileMode
-		hints    Hints
-		setup    setupFunc
-		validate validateFunc
+		name		string
+		data		[]byte
+		perm		os.FileMode
+		hints		Hints
+		setup		setupFunc
+		validate	validateFunc
 	}{
 		{
-			name:  "bom and crlf",
-			data:  []byte("one\ntwo\n"),
-			perm:  0o644,
-			hints: Hints{HasBOM: true, Newline: "\r\n"},
+			name:	"bom and crlf",
+			data:	[]byte("one\ntwo\n"),
+			perm:	0o644,
+			hints:	Hints{HasBOM: true, Newline: "\r\n"},
 			validate: func(t *testing.T, dir, path string, _ any) {
 				got, err := os.ReadFile(path)
 				if err != nil {
@@ -50,9 +50,9 @@ func TestWriteFileAtomic(t *testing.T) {
 			},
 		},
 		{
-			name: "same dir temp",
-			data: []byte("x"),
-			perm: 0o600,
+			name:	"same dir temp",
+			data:	[]byte("x"),
+			perm:	0o600,
 			setup: func(t *testing.T, dir, path string) any {
 				entries, err := os.ReadDir(os.TempDir())
 				if err != nil {
@@ -87,9 +87,9 @@ func TestWriteFileAtomic(t *testing.T) {
 			},
 		},
 		{
-			name: "permission retained",
-			data: []byte("secret"),
-			perm: 0o751,
+			name:	"permission retained",
+			data:	[]byte("secret"),
+			perm:	0o751,
 			validate: func(t *testing.T, dir, path string, _ any) {
 				info, err := os.Stat(path)
 				if err != nil {
@@ -108,9 +108,9 @@ func TestWriteFileAtomic(t *testing.T) {
 			},
 		},
 		{
-			name: "ownership retained",
-			data: []byte("new"),
-			perm: 0o600,
+			name:	"ownership retained",
+			data:	[]byte("new"),
+			perm:	0o600,
 			setup: func(t *testing.T, dir, path string) any {
 				if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
 					t.Fatalf("prewrite: %v", err)
@@ -144,9 +144,9 @@ func TestWriteFileAtomic(t *testing.T) {
 			},
 		},
 		{
-			name: "rename semantics",
-			data: []byte("new"),
-			perm: 0o644,
+			name:	"rename semantics",
+			data:	[]byte("new"),
+			perm:	0o644,
 			setup: func(t *testing.T, dir, path string) any {
 				if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
 					t.Fatalf("prewrite: %v", err)
@@ -263,3 +263,4 @@ func BenchmarkApplyHints(b *testing.B) {
 		ApplyHints(data, hints)
 	}
 }
+

--- a/internal/fs/atomic_windows_test.go
+++ b/internal/fs/atomic_windows_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-// internal/fs/atomic_windows_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/fs/atomic_windows_test.go
 package fs
 
 import (
@@ -30,3 +30,4 @@ func TestWriteFileAtomicChownIgnored(t *testing.T) {
 		t.Fatalf("WriteFileAtomic: %v", err)
 	}
 }
+

--- a/internal/fs/ewindows_other.go
+++ b/internal/fs/ewindows_other.go
@@ -1,8 +1,9 @@
 //go:build !windows
 
-// internal/fs/ewindows_other.go — SPDX-License-Identifier: Apache-2.0
+// internal/fs/ewindows_other.go
 package fs
 
 func isErrWindows(err error) bool {
 	return false
 }
+

--- a/internal/fs/ewindows_windows.go
+++ b/internal/fs/ewindows_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-// internal/fs/ewindows_windows.go — SPDX-License-Identifier: Apache-2.0
+// internal/fs/ewindows_windows.go
 package fs
 
 import (
@@ -11,3 +11,4 @@ import (
 func isErrWindows(err error) bool {
 	return errors.Is(err, syscall.EWINDOWS)
 }
+

--- a/internal/fs/hints_test.go
+++ b/internal/fs/hints_test.go
@@ -1,4 +1,4 @@
-// internal/fs/hints_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/fs/hints_test.go
 package fs
 
 import (
@@ -13,29 +13,29 @@ import (
 func TestDetectHintsFromBytes(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name  string
-		input []byte
-		want  Hints
+		name	string
+		input	[]byte
+		want	Hints
 	}{
 		{
-			name:  "lf",
-			input: []byte("one\ntwo\n"),
-			want:  Hints{Newline: "\n"},
+			name:	"lf",
+			input:	[]byte("one\ntwo\n"),
+			want:	Hints{Newline: "\n"},
 		},
 		{
-			name:  "crlf",
-			input: []byte("one\r\ntwo\r\n"),
-			want:  Hints{Newline: "\r\n"},
+			name:	"crlf",
+			input:	[]byte("one\r\ntwo\r\n"),
+			want:	Hints{Newline: "\r\n"},
 		},
 		{
-			name:  "bom_lf",
-			input: append(append([]byte{}, utf8BOM...), []byte("one\ntwo\n")...),
-			want:  Hints{HasBOM: true, Newline: "\n"},
+			name:	"bom_lf",
+			input:	append(append([]byte{}, utf8BOM...), []byte("one\ntwo\n")...),
+			want:	Hints{HasBOM: true, Newline: "\n"},
 		},
 		{
-			name:  "bom_crlf",
-			input: append(append([]byte{}, utf8BOM...), []byte("one\r\ntwo\r\n")...),
-			want:  Hints{HasBOM: true, Newline: "\r\n"},
+			name:	"bom_crlf",
+			input:	append(append([]byte{}, utf8BOM...), []byte("one\r\ntwo\r\n")...),
+			want:	Hints{HasBOM: true, Newline: "\r\n"},
 		},
 	}
 	for _, tc := range tests {
@@ -52,25 +52,25 @@ func TestDetectHintsFromBytes(t *testing.T) {
 func TestReadFileWithHints(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name     string
-		content  []byte
-		mode     os.FileMode
-		wantData []byte
-		wantHint Hints
+		name		string
+		content		[]byte
+		mode		os.FileMode
+		wantData	[]byte
+		wantHint	Hints
 	}{
 		{
-			name:     "bom_crlf",
-			content:  append(append([]byte{}, utf8BOM...), []byte("one\r\ntwo\r\n")...),
-			mode:     0o600,
-			wantData: []byte("one\r\ntwo\r\n"),
-			wantHint: Hints{HasBOM: true, Newline: "\r\n"},
+			name:		"bom_crlf",
+			content:	append(append([]byte{}, utf8BOM...), []byte("one\r\ntwo\r\n")...),
+			mode:		0o600,
+			wantData:	[]byte("one\r\ntwo\r\n"),
+			wantHint:	Hints{HasBOM: true, Newline: "\r\n"},
 		},
 		{
-			name:     "plain",
-			content:  []byte("one\ntwo\n"),
-			mode:     0o644,
-			wantData: []byte("one\ntwo\n"),
-			wantHint: Hints{Newline: "\n"},
+			name:		"plain",
+			content:	[]byte("one\ntwo\n"),
+			mode:		0o644,
+			wantData:	[]byte("one\ntwo\n"),
+			wantHint:	Hints{Newline: "\n"},
 		},
 	}
 	for _, tc := range tests {
@@ -113,19 +113,19 @@ func TestReadFileWithHintsCanceledContext(t *testing.T) {
 func TestHintsBOM(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name  string
-		hints Hints
-		want  []byte
+		name	string
+		hints	Hints
+		want	[]byte
 	}{
 		{
-			name:  "with_bom",
-			hints: Hints{HasBOM: true},
-			want:  utf8BOM,
+			name:	"with_bom",
+			hints:	Hints{HasBOM: true},
+			want:	utf8BOM,
 		},
 		{
-			name:  "without_bom",
-			hints: Hints{HasBOM: false},
-			want:  nil,
+			name:	"without_bom",
+			hints:	Hints{HasBOM: false},
+			want:	nil,
 		},
 	}
 	for _, tc := range tests {
@@ -144,3 +144,4 @@ func TestHintsBOM(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/hclalign/benchmark_test.go
+++ b/internal/hclalign/benchmark_test.go
@@ -1,4 +1,4 @@
-// internal/hclalign/benchmark_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/hclalign/benchmark_test.go
 package hclalign
 
 import (
@@ -26,3 +26,4 @@ func BenchmarkReorderAttributes(b *testing.B) {
 		}
 	}
 }
+

--- a/internal/hclalign/hclalign.go
+++ b/internal/hclalign/hclalign.go
@@ -1,4 +1,4 @@
-// internal/hclalign/hclalign.go — SPDX-License-Identifier: Apache-2.0
+// internal/hclalign/hclalign.go
 package hclalign
 
 import (
@@ -258,8 +258,8 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 }
 
 type attrTokens struct {
-	leadTokens hclwrite.Tokens
-	exprTokens hclwrite.Tokens
+	leadTokens	hclwrite.Tokens
+	exprTokens	hclwrite.Tokens
 }
 
 func extractAttrTokens(attr *hclwrite.Attribute) attrTokens {
@@ -309,3 +309,4 @@ func attributeOrder(body *hclwrite.Body, attrs map[string]*hclwrite.Attribute) [
 	}
 	return order
 }
+

--- a/internal/hclalign/hclalign_test.go
+++ b/internal/hclalign/hclalign_test.go
@@ -1,4 +1,4 @@
-// internal/hclalign/hclalign_test.go — SPDX-License-Identifier: Apache-2.0
+// internal/hclalign/hclalign_test.go
 package hclalign_test
 
 import (
@@ -176,3 +176,4 @@ func TestReorderAttributes_DefaultBlockNestedType(t *testing.T) {
 }`
 	require.Equal(t, expected, string(f.Bytes()))
 }
+

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// main.go — SPDX-License-Identifier: Apache-2.0
+// main.go
 package main
 
 import (
@@ -13,11 +13,11 @@ import (
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:          "hclalign [target file or directory]",
-		Short:        "Aligns HCL files based on given criteria",
-		Args:         cobra.ArbitraryArgs,
-		RunE:         cli.RunE,
-		SilenceUsage: true,
+		Use:		"hclalign [target file or directory]",
+		Short:		"Aligns HCL files based on given criteria",
+		Args:		cobra.ArbitraryArgs,
+		RunE:		cli.RunE,
+		SilenceUsage:	true,
 	}
 
 	rootCmd.Flags().Bool("write", false, "write result to file(s)")
@@ -41,3 +41,4 @@ func main() {
 		os.Exit(1)
 	}
 }
+

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-// main_test.go — SPDX-License-Identifier: Apache-2.0
+// main_test.go
 package main
 
 import (
@@ -30,47 +30,47 @@ func createTempHCLFile(t *testing.T, content string) string {
 
 func TestMainFunctionality(t *testing.T) {
 	tests := []struct {
-		name    string
-		setup   func(*testing.T) []string
-		wantErr bool
-		errMsg  string
+		name	string
+		setup	func(*testing.T) []string
+		wantErr	bool
+		errMsg	string
 	}{
 		{
-			name: "Missing Target Argument",
+			name:	"Missing Target Argument",
 			setup: func(t *testing.T) []string {
 				return []string{}
 			},
-			wantErr: true,
-			errMsg:  config.ErrMissingTarget,
+			wantErr:	true,
+			errMsg:		config.ErrMissingTarget,
 		},
 		{
-			name: "Valid Single File",
+			name:	"Valid Single File",
 			setup: func(t *testing.T) []string {
 
 				filePath := createTempHCLFile(t, `variable "test" {}`)
 				return []string{filePath}
 			},
-			wantErr: false,
+			wantErr:	false,
 		},
 		{
-			name: "Multiple Files",
+			name:	"Multiple Files",
 			setup: func(t *testing.T) []string {
 
 				filePath1 := createTempHCLFile(t, `variable "test1" {}`)
 				filePath2 := createTempHCLFile(t, `variable "test2" {}`)
 				return []string{filePath1, filePath2}
 			},
-			wantErr: true,
-			errMsg:  "accepts at most 1 arg(s)",
+			wantErr:	true,
+			errMsg:		"accepts at most 1 arg(s)",
 		},
 		{
-			name: "Mutually Exclusive Flags",
+			name:	"Mutually Exclusive Flags",
 			setup: func(t *testing.T) []string {
 				filePath := createTempHCLFile(t, `variable "test" {}`)
 				return []string{filePath, "--check", "--diff"}
 			},
-			wantErr: true,
-			errMsg:  "if any flags in the group [write check diff] are set none of the others can be",
+			wantErr:	true,
+			errMsg:		"if any flags in the group [write check diff] are set none of the others can be",
 		},
 	}
 
@@ -80,11 +80,11 @@ func TestMainFunctionality(t *testing.T) {
 			args := tc.setup(t)
 
 			rootCmd := &cobra.Command{
-				Use:          "hclalign [target file or directory]",
-				Short:        "Aligns HCL files based on given criteria",
-				Args:         cobra.ArbitraryArgs,
-				RunE:         cli.RunE,
-				SilenceUsage: true,
+				Use:		"hclalign [target file or directory]",
+				Short:		"Aligns HCL files based on given criteria",
+				Args:		cobra.ArbitraryArgs,
+				RunE:		cli.RunE,
+				SilenceUsage:	true,
 			}
 			rootCmd.Flags().Bool("write", false, "write result to file(s)")
 			rootCmd.Flags().Bool("check", false, "check if files are formatted")
@@ -123,11 +123,11 @@ func TestCLIOrderFlagInfluencesProcessing(t *testing.T) {
 	filePath := createTempHCLFile(t, content)
 
 	rootCmd := &cobra.Command{
-		Use:          "hclalign [target file or directory]",
-		Short:        "Aligns HCL files based on given criteria",
-		Args:         cobra.ArbitraryArgs,
-		RunE:         cli.RunE,
-		SilenceUsage: true,
+		Use:		"hclalign [target file or directory]",
+		Short:		"Aligns HCL files based on given criteria",
+		Args:		cobra.ArbitraryArgs,
+		RunE:		cli.RunE,
+		SilenceUsage:	true,
 	}
 	rootCmd.Flags().Bool("write", false, "write result to file(s)")
 	rootCmd.Flags().Bool("check", false, "check if files are formatted")
@@ -159,11 +159,11 @@ func TestCLIStrictOrderUnknownAttribute(t *testing.T) {
 	filePath := createTempHCLFile(t, `variable "test" {}`)
 
 	rootCmd := &cobra.Command{
-		Use:          "hclalign [target file or directory]",
-		Short:        "Aligns HCL files based on given criteria",
-		Args:         cobra.ArbitraryArgs,
-		RunE:         cli.RunE,
-		SilenceUsage: true,
+		Use:		"hclalign [target file or directory]",
+		Short:		"Aligns HCL files based on given criteria",
+		Args:		cobra.ArbitraryArgs,
+		RunE:		cli.RunE,
+		SilenceUsage:	true,
 	}
 	rootCmd.Flags().Bool("write", false, "write result to file(s)")
 	rootCmd.Flags().Bool("check", false, "check if files are formatted")
@@ -184,3 +184,4 @@ func TestCLIStrictOrderUnknownAttribute(t *testing.T) {
 	_, err := rootCmd.ExecuteC()
 	require.Error(t, err)
 }
+

--- a/patternmatching/patternmatching.go
+++ b/patternmatching/patternmatching.go
@@ -1,4 +1,4 @@
-// patternmatching/patternmatching.go — SPDX-License-Identifier: Apache-2.0
+// patternmatching/patternmatching.go
 package patternmatching
 
 import (
@@ -11,10 +11,10 @@ import (
 )
 
 type Matcher struct {
-	include  []string
-	exclude  []string
-	rootOnce sync.Once
-	root     string
+	include		[]string
+	exclude		[]string
+	rootOnce	sync.Once
+	root		string
 }
 
 func NewMatcher(include, exclude []string) (*Matcher, error) {
@@ -77,4 +77,5 @@ func (m *Matcher) Matches(path string) bool {
 	return false
 }
 
-func ValidatePatterns(patterns []string) error { return validatePatterns(patterns) }
+func ValidatePatterns(patterns []string) error	{ return validatePatterns(patterns) }
+

--- a/patternmatching/patternmatching_test.go
+++ b/patternmatching/patternmatching_test.go
@@ -1,4 +1,4 @@
-// patternmatching/patternmatching_test.go — SPDX-License-Identifier: Apache-2.0
+// patternmatching/patternmatching_test.go
 package patternmatching_test
 
 import (
@@ -125,3 +125,4 @@ func TestMatcherMatchesConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 }
+

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -1,4 +1,4 @@
-// tests/cli/cli_test.go — SPDX-License-Identifier: Apache-2.0
+// tests/cli/cli_test.go
 package cli_test
 
 import (
@@ -160,3 +160,4 @@ func TestCLI(t *testing.T) {
 		require.NotEmpty(t, stderr.String())
 	})
 }
+


### PR DESCRIPTION
## Summary
- strip injected comments down to just `// <relpath>`
- update comment checker to expect path-only headers and reject extra text
- refresh repository files with new header format

## Testing
- `go run ./cmd/commentcheck`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1a060df78832398cf57f99e3c511d