### PR TITLE
Ensure comment policy and test isolation

### DIFF
--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -120,11 +120,10 @@ func TestMainModes(t *testing.T) {
 		t.Fatalf("fix via main failed: %q", data)
 	}
 
-	// run in ci mode on fixed file
-	code = 0
-	os.Args = []string{"cmd", "--mode=ci"}
-	main()
-	if code != 0 {
+       code = 0
+       os.Args = []string{"cmd", "--mode=ci"}
+       main()
+       if code != 0 {
 		t.Fatalf("unexpected exit %d", code)
 	}
 }

--- a/internal/engine/write_error_test.go
+++ b/internal/engine/write_error_test.go
@@ -45,8 +45,6 @@ func newRootCmd(exclusive bool) *cobra.Command {
 }
 
 func TestProcessWriteFileError(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	casesDir := filepath.Join("..", "..", "tests", "cases")
 	data, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))


### PR DESCRIPTION
## Summary
- remove stray comment from commentcheck tests
- avoid WriteFileAtomic race by not running error test in parallel

## Testing
- `go test ./...`
- `make commentcheck`
- `make cover` *(fails: Coverage 76.9% < 95%)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a6edb4988323bddfa7f45d5c92cc