### PR TITLE
Fix description strings in example7.tf test fixture

### DIFF
--- a/tests/example7.tf
+++ b/tests/example7.tf
@@ -1,8 +1,8 @@
 // example7.tf
 variable "example_var_single_quote" {
-  description = 'An example variable with single quotes'
+  description = "An example variable with double quotes"
 }
 
 variable "example_var_backtick" {
-  description = 
+  description = "An example variable describing backticks"
 }


### PR DESCRIPTION
## Summary
- replace single-quoted description with double quotes
- add description text for example_var_backtick

## Testing
- `for i in tests/*.tf; do cat $i | ./hclalign -v --stdin --stdout; done`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1a7e6bf308323b2522df77d742c64