### PR TITLE
Reject empty attribute names in order validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 type Mode int
 
 const (
-	ModeWrite	Mode	= iota
+	ModeWrite Mode = iota
 
 	ModeCheck
 
@@ -19,23 +19,23 @@ const (
 )
 
 type Config struct {
-	Target		string
-	Mode		Mode
-	Stdin		bool
-	Stdout		bool
-	Include		[]string
-	Exclude		[]string
-	Order		[]string
-	StrictOrder	bool
-	Concurrency	int
-	Verbose		bool
-	FollowSymlinks	bool
+	Target         string
+	Mode           Mode
+	Stdin          bool
+	Stdout         bool
+	Include        []string
+	Exclude        []string
+	Order          []string
+	StrictOrder    bool
+	Concurrency    int
+	Verbose        bool
+	FollowSymlinks bool
 }
 
 var (
-	DefaultInclude	= []string{"**/*.tf"}
-	DefaultExclude	= []string{"**/.terraform/**", "**/vendor/**", "**/.git/**", "**/node_modules/**"}
-	CanonicalOrder	= []string{"description", "type", "default", "sensitive", "nullable"}
+	DefaultInclude = []string{"**/*.tf"}
+	DefaultExclude = []string{"**/.terraform/**", "**/vendor/**", "**/.git/**", "**/node_modules/**"}
+	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
 )
 
 const (
@@ -69,6 +69,9 @@ func ValidateOrder(order []string, strict bool) error {
 	}
 
 	for _, item := range order {
+		if item == "" {
+			return fmt.Errorf("attribute name cannot be empty")
+		}
 		if _, exists := providedSet[item]; exists {
 			return fmt.Errorf("duplicate attribute '%s' found in order", item)
 		}
@@ -89,4 +92,3 @@ func ValidateOrder(order []string, strict bool) error {
 	}
 	return nil
 }
-

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,6 +48,13 @@ func TestValidateOrder_StrictValidationBlock(t *testing.T) {
 	}
 }
 
+func TestValidateOrder_EmptyAttributeName(t *testing.T) {
+	err := ValidateOrder([]string{"description", ""}, false)
+	if err == nil || err.Error() != "attribute name cannot be empty" {
+		t.Fatalf("expected error for empty attribute name, got %v", err)
+	}
+}
+
 func TestDefaultExcludeMatchesExpected(t *testing.T) {
 	expected := []string{"**/.terraform/**", "**/vendor/**", "**/.git/**", "**/node_modules/**"}
 	if !reflect.DeepEqual(DefaultExclude, expected) {
@@ -85,11 +92,11 @@ func TestValidate_InvalidExcludePattern(t *testing.T) {
 
 func TestValidate_ValidConfig(t *testing.T) {
 	c := Config{
-		Concurrency:	1,
-		Include:	DefaultInclude,
-		Exclude:	DefaultExclude,
-		Order:		CanonicalOrder,
-		StrictOrder:	true,
+		Concurrency: 1,
+		Include:     DefaultInclude,
+		Exclude:     DefaultExclude,
+		Order:       CanonicalOrder,
+		StrictOrder: true,
 	}
 	if err := c.Validate(); err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -98,13 +105,24 @@ func TestValidate_ValidConfig(t *testing.T) {
 
 func TestValidate_DuplicateOrderAttribute(t *testing.T) {
 	c := Config{
-		Concurrency:	1,
-		Include:	DefaultInclude,
-		Exclude:	DefaultExclude,
-		Order:		[]string{"description", "description"},
+		Concurrency: 1,
+		Include:     DefaultInclude,
+		Exclude:     DefaultExclude,
+		Order:       []string{"description", "description"},
 	}
 	if err := c.Validate(); err == nil {
 		t.Fatalf("expected error for duplicate order attribute")
 	}
 }
 
+func TestValidate_EmptyOrderAttribute(t *testing.T) {
+	c := Config{
+		Concurrency: 1,
+		Include:     DefaultInclude,
+		Exclude:     DefaultExclude,
+		Order:       []string{"description", ""},
+	}
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "attribute name cannot be empty") {
+		t.Fatalf("expected error for empty attribute name in order, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- error on empty attribute names in order validation
- add tests to ensure empty attributes are rejected both directly and via Config.Validate

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1acf3797c832384b7aa9248872da8