### PR TITLE
test: add inline comment after brace case

### DIFF
--- a/tests/cases/inline_comment_after_brace/in.tf
+++ b/tests/cases/inline_comment_after_brace/in.tf
@@ -1,0 +1,9 @@
+// example8.tf
+variable "example_var_inline_comment" { # Problematic corner case inline comment
+default = "corner { } case"
+/* multi line
+comment */
+  description = "An example variable with an inline comment" # Just another inline 
+// different tyoe of comment
+type = string
+}

--- a/tests/cases/inline_comment_after_brace/out.tf
+++ b/tests/cases/inline_comment_after_brace/out.tf
@@ -1,0 +1,9 @@
+// example8.tf
+variable "example_var_inline_comment" { # Problematic corner case inline comment
+  /* multi line
+  comment */
+  description = "An example variable with an inline comment" # Just another inline
+  // different tyoe of comment
+  type        = string
+  default     = "corner { } case"
+}


### PR DESCRIPTION
## Summary
- add golden test case for inline comments after an opening brace

## Testing
- `go test ./...` *(fails: output mismatch for inline_comment_after_brace)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b2d795e483239a745ea74d9e3d4a