### PR TITLE
Skip non-directory symlink targets unless followed

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -110,8 +110,10 @@ func processFiles(ctx context.Context, cfg *config.Config) (bool, error) {
 					return false, err
 				}
 			}
-		} else if matcher.Matches(cfg.Target) {
-			files = append(files, cfg.Target)
+		} else if cfg.FollowSymlinks {
+			if matcher.Matches(cfg.Target) {
+				files = append(files, cfg.Target)
+			}
 		}
 	} else if info.IsDir() {
 		if err := walk(ctx, cfg.Target); err != nil {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -22,9 +22,9 @@ func TestProcessMissingTarget(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{
-		Target:		"nonexistent.hcl",
-		Include:	[]string{"**/*.hcl"},
-		Concurrency:	1,
+		Target:      "nonexistent.hcl",
+		Include:     []string{"**/*.hcl"},
+		Concurrency: 1,
 	}
 
 	changed, err := Process(context.Background(), cfg)
@@ -42,9 +42,9 @@ func TestProcessContextCancelled(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, data, 0o644))
 
 	cfg := &config.Config{
-		Target:		dir,
-		Include:	[]string{"**/*.hcl"},
-		Concurrency:	1,
+		Target:      dir,
+		Include:     []string{"**/*.hcl"},
+		Concurrency: 1,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -65,9 +65,9 @@ func TestProcessContextCancelledAfterReorder(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, data, 0o644))
 
 	cfg := &config.Config{
-		Target:		dir,
-		Include:	[]string{"**/*.hcl"},
-		Concurrency:	1,
+		Target:      dir,
+		Include:     []string{"**/*.hcl"},
+		Concurrency: 1,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -81,11 +81,11 @@ func TestProcessContextCancelledAfterReorder(t *testing.T) {
 func TestProcessScenarios(t *testing.T) {
 	casesDir := filepath.Join("..", "..", "tests", "cases")
 	tests := []struct {
-		name	string
-		setup	func(t *testing.T) (*config.Config, string, bool, map[string]string)
+		name  string
+		setup func(t *testing.T) (*config.Config, string, bool, map[string]string)
 	}{
 		{
-			name:	"stdout multiple files",
+			name: "stdout multiple files",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				in1, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -103,11 +103,11 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.WriteFile(f2, in2, 0o644))
 
 				cfg := &config.Config{
-					Target:		dir,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeWrite,
-					Stdout:		true,
-					Concurrency:	1,
+					Target:      dir,
+					Include:     []string{"**/*.tf"},
+					Mode:        config.ModeWrite,
+					Stdout:      true,
+					Concurrency: 1,
 				}
 
 				expOut := fmt.Sprintf("\n--- %s ---\n%s\n--- %s ---\n%s", f1, out1, f2, out2)
@@ -116,7 +116,7 @@ func TestProcessScenarios(t *testing.T) {
 			},
 		},
 		{
-			name:	"mode diff",
+			name: "mode diff",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inPath := filepath.Join(casesDir, "simple", "in.tf")
@@ -133,18 +133,18 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, err)
 
 				cfg := &config.Config{
-					Target:		f,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeDiff,
-					Stdout:		true,
-					Concurrency:	1,
+					Target:      f,
+					Include:     []string{"**/*.tf"},
+					Mode:        config.ModeDiff,
+					Stdout:      true,
+					Concurrency: 1,
 				}
 				files := map[string]string{f: string(inb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", f, diffText), true, files
 			},
 		},
 		{
-			name:	"mode check",
+			name: "mode check",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -155,18 +155,18 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.WriteFile(f, inb, 0o644))
 
 				cfg := &config.Config{
-					Target:		f,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeCheck,
-					Stdout:		true,
-					Concurrency:	1,
+					Target:      f,
+					Include:     []string{"**/*.tf"},
+					Mode:        config.ModeCheck,
+					Stdout:      true,
+					Concurrency: 1,
 				}
 				files := map[string]string{f: string(inb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", f, outb), true, files
 			},
 		},
 		{
-			name:	"symlink follow",
+			name: "symlink follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				target := t.TempDir()
@@ -180,19 +180,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:		base,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeWrite,
-					Stdout:		true,
-					Concurrency:	1,
-					FollowSymlinks:	true,
+					Target:         base,
+					Include:        []string{"**/*.tf"},
+					Mode:           config.ModeWrite,
+					Stdout:         true,
+					Concurrency:    1,
+					FollowSymlinks: true,
 				}
 				files := map[string]string{realFile: string(outb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", filepath.Join(link, "file.tf"), outb), true, files
 			},
 		},
 		{
-			name:	"symlink no follow",
+			name: "symlink no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				target := t.TempDir()
@@ -204,19 +204,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:		base,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeWrite,
-					Stdout:		true,
-					Concurrency:	1,
-					FollowSymlinks:	false,
+					Target:         base,
+					Include:        []string{"**/*.tf"},
+					Mode:           config.ModeWrite,
+					Stdout:         true,
+					Concurrency:    1,
+					FollowSymlinks: false,
 				}
 				files := map[string]string{realFile: string(inb)}
 				return cfg, "", false, files
 			},
 		},
 		{
-			name:	"symlink file follow",
+			name: "symlink file follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				realDir := t.TempDir()
@@ -230,19 +230,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:		base,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeWrite,
-					Stdout:		true,
-					Concurrency:	1,
-					FollowSymlinks:	true,
+					Target:         base,
+					Include:        []string{"**/*.tf"},
+					Mode:           config.ModeWrite,
+					Stdout:         true,
+					Concurrency:    1,
+					FollowSymlinks: true,
 				}
 				files := map[string]string{link: string(outb), realFile: string(inb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", link, outb), true, files
 			},
 		},
 		{
-			name:	"symlink file no follow",
+			name: "symlink file no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				base := t.TempDir()
 				realDir := t.TempDir()
@@ -254,19 +254,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:		base,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeWrite,
-					Stdout:		true,
-					Concurrency:	1,
-					FollowSymlinks:	false,
+					Target:         base,
+					Include:        []string{"**/*.tf"},
+					Mode:           config.ModeWrite,
+					Stdout:         true,
+					Concurrency:    1,
+					FollowSymlinks: false,
 				}
 				files := map[string]string{link: string(inb), realFile: string(inb)}
 				return cfg, "", false, files
 			},
 		},
 		{
-			name:	"target symlink dir follow",
+			name: "target symlink dir follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				target := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -280,19 +280,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:		link,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeWrite,
-					Stdout:		true,
-					Concurrency:	1,
-					FollowSymlinks:	true,
+					Target:         link,
+					Include:        []string{"**/*.tf"},
+					Mode:           config.ModeWrite,
+					Stdout:         true,
+					Concurrency:    1,
+					FollowSymlinks: true,
 				}
 				files := map[string]string{realFile: string(outb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", filepath.Join(link, "file.tf"), outb), true, files
 			},
 		},
 		{
-			name:	"target symlink dir no follow",
+			name: "target symlink dir no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				target := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -304,19 +304,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(target, link))
 
 				cfg := &config.Config{
-					Target:		link,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeWrite,
-					Stdout:		true,
-					Concurrency:	1,
-					FollowSymlinks:	false,
+					Target:         link,
+					Include:        []string{"**/*.tf"},
+					Mode:           config.ModeWrite,
+					Stdout:         true,
+					Concurrency:    1,
+					FollowSymlinks: false,
 				}
 				files := map[string]string{realFile: string(inb)}
 				return cfg, "", false, files
 			},
 		},
 		{
-			name:	"target symlink file follow",
+			name: "target symlink file follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
@@ -329,24 +329,22 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:		link,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeWrite,
-					Stdout:		true,
-					Concurrency:	1,
-					FollowSymlinks:	true,
+					Target:         link,
+					Include:        []string{"**/*.tf"},
+					Mode:           config.ModeWrite,
+					Stdout:         true,
+					Concurrency:    1,
+					FollowSymlinks: true,
 				}
 				files := map[string]string{link: string(outb)}
 				return cfg, fmt.Sprintf("\n--- %s ---\n%s", link, outb), true, files
 			},
 		},
 		{
-			name:	"target symlink file no follow",
+			name: "target symlink file no follow",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				inb, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
-				require.NoError(t, err)
-				outb, err := os.ReadFile(filepath.Join(casesDir, "simple", "out.tf"))
 				require.NoError(t, err)
 				realFile := filepath.Join(dir, "real.tf")
 				require.NoError(t, os.WriteFile(realFile, inb, 0o644))
@@ -354,19 +352,19 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.Symlink(realFile, link))
 
 				cfg := &config.Config{
-					Target:		link,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeWrite,
-					Stdout:		true,
-					Concurrency:	1,
-					FollowSymlinks:	false,
+					Target:         link,
+					Include:        []string{"**/*.tf"},
+					Mode:           config.ModeWrite,
+					Stdout:         true,
+					Concurrency:    1,
+					FollowSymlinks: false,
 				}
-				files := map[string]string{link: string(outb)}
-				return cfg, fmt.Sprintf("\n--- %s ---\n%s", link, outb), true, files
+				files := map[string]string{link: string(inb), realFile: string(inb)}
+				return cfg, "", false, files
 			},
 		},
 		{
-			name:	"concurrency",
+			name: "concurrency",
 			setup: func(t *testing.T) (*config.Config, string, bool, map[string]string) {
 				dir := t.TempDir()
 				cases := []string{"simple", "trailing_commas", "comments"}
@@ -384,11 +382,11 @@ func TestProcessScenarios(t *testing.T) {
 					expected += fmt.Sprintf("\n--- %s ---\n%s", p, outb)
 				}
 				cfg := &config.Config{
-					Target:		dir,
-					Include:	[]string{"**/*.tf"},
-					Mode:		config.ModeWrite,
-					Stdout:		true,
-					Concurrency:	2,
+					Target:      dir,
+					Include:     []string{"**/*.tf"},
+					Mode:        config.ModeWrite,
+					Stdout:      true,
+					Concurrency: 2,
 				}
 				return cfg, expected, true, files
 			},
@@ -446,11 +444,11 @@ func TestProcessManyFilesDeterministic(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		Target:		dir,
-		Include:	[]string{"**/*.tf"},
-		Mode:		config.ModeWrite,
-		Stdout:		true,
-		Concurrency:	4,
+		Target:      dir,
+		Include:     []string{"**/*.tf"},
+		Mode:        config.ModeWrite,
+		Stdout:      true,
+		Concurrency: 4,
 	}
 
 	r, w, err := os.Pipe()
@@ -487,4 +485,3 @@ func TestProcessManyFilesDeterministic(t *testing.T) {
 		require.Equal(t, exp, string(got))
 	}
 }
-


### PR DESCRIPTION
## Summary
- Skip processing symlinked files when `--follow-symlinks` is not set
- Add regression test to ensure file symlinks are ignored by default

## Testing
- `go test ./internal/engine -count=1`
- `go test ./... -count=1` *(fails: output mismatch in internal/align golden test)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b93d70448323a5fb59a2604e0028