### PR TITLE
Restrict CLI to single arg

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -11,18 +11,14 @@ import (
 )
 
 type ExitCodeError struct {
-	Err	error
-	Code	int
+	Err  error
+	Code int
 }
 
-func (e *ExitCodeError) Error() string	{ return e.Err.Error() }
+func (e *ExitCodeError) Error() string { return e.Err.Error() }
 
 func RunE(cmd *cobra.Command, args []string) error {
-	if len(args) > 1 {
-		return &ExitCodeError{Err: fmt.Errorf("accepts at most 1 arg(s), received %d", len(args)), Code: 2}
-	}
-
-	target := ""
+	var target string
 	if len(args) == 1 {
 		target = args[0]
 	}
@@ -113,17 +109,17 @@ func RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := &config.Config{
-		Target:		target,
-		Mode:		mode,
-		Stdin:		stdin,
-		Stdout:		stdout,
-		Include:	include,
-		Exclude:	exclude,
-		Order:		order,
-		StrictOrder:	strictOrder,
-		Concurrency:	concurrency,
-		Verbose:	verbose,
-		FollowSymlinks:	followSymlinks,
+		Target:         target,
+		Mode:           mode,
+		Stdin:          stdin,
+		Stdout:         stdout,
+		Include:        include,
+		Exclude:        exclude,
+		Order:          order,
+		StrictOrder:    strictOrder,
+		Concurrency:    concurrency,
+		Verbose:        verbose,
+		FollowSymlinks: followSymlinks,
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -141,4 +137,3 @@ func RunE(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
-

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -16,15 +16,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newRootCmd(exclusive bool) *cobra.Command	{ return newTestRootCmd(exclusive) }
+func newRootCmd(exclusive bool) *cobra.Command { return newTestRootCmd(exclusive) }
 
 func newTestRootCmd(exclusive bool) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:		"hclalign [target file or directory]",
-		Args:		cobra.ArbitraryArgs,
-		RunE:		RunE,
-		SilenceUsage:	true,
+		Use:          "hclalign [target file or directory]",
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         RunE,
+		SilenceUsage: true,
 	}
 	cmd.Flags().Bool("write", false, "write result to file(s)")
 	cmd.Flags().Bool("check", false, "check if files are formatted")
@@ -52,6 +52,14 @@ func TestRunEUsageError(t *testing.T) {
 	var exitErr *ExitCodeError
 	require.ErrorAs(t, err, &exitErr)
 	require.Equal(t, 2, exitErr.Code)
+}
+
+func TestRunETooManyArgs(t *testing.T) {
+	cmd := newRootCmd(true)
+	cmd.SetArgs([]string{"one", "two"})
+	_, err := cmd.ExecuteC()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "accepts at most 1 arg(s)")
 }
 
 func TestRunETargetWithStdin(t *testing.T) {
@@ -150,9 +158,9 @@ func TestRunEInvalidConcurrency(t *testing.T) {
 
 func TestRunEInvalidGlob(t *testing.T) {
 	tests := []struct {
-		name	string
-		flag	string
-		message	string
+		name    string
+		flag    string
+		message string
 	}{
 		{name: "include", flag: "--include", message: "invalid include"},
 		{name: "exclude", flag: "--exclude", message: "invalid exclude"},
@@ -177,44 +185,44 @@ func TestRunEModes(t *testing.T) {
 	formatted := "variable \"a\" {\n  description = \"d\"\n  type        = string\n}\n"
 
 	tests := []struct {
-		name		string
-		flags		[]string
-		stdin		string
-		wantCode	int
-		wantStdout	string
-		contains	string
-		withFile	bool
-		wantFile	string
+		name       string
+		flags      []string
+		stdin      string
+		wantCode   int
+		wantStdout string
+		contains   string
+		withFile   bool
+		wantFile   string
 	}{
 		{
-			name:		"diff",
-			flags:		[]string{"--diff"},
-			wantCode:	1,
-			contains:	"@@",
-			withFile:	true,
-			wantFile:	unformatted,
+			name:     "diff",
+			flags:    []string{"--diff"},
+			wantCode: 1,
+			contains: "@@",
+			withFile: true,
+			wantFile: unformatted,
 		},
 		{
-			name:		"stdin",
-			flags:		[]string{"--stdin", "--stdout"},
-			stdin:		unformatted,
-			wantCode:	0,
-			wantStdout:	formatted,
+			name:       "stdin",
+			flags:      []string{"--stdin", "--stdout"},
+			stdin:      unformatted,
+			wantCode:   0,
+			wantStdout: formatted,
 		},
 		{
-			name:		"write",
-			flags:		[]string{"--write"},
-			wantCode:	0,
-			withFile:	true,
-			wantFile:	formatted,
+			name:     "write",
+			flags:    []string{"--write"},
+			wantCode: 0,
+			withFile: true,
+			wantFile: formatted,
 		},
 		{
-			name:		"stdout",
-			flags:		[]string{"--stdout"},
-			wantCode:	0,
-			wantStdout:	formatted,
-			withFile:	true,
-			wantFile:	formatted,
+			name:       "stdout",
+			flags:      []string{"--stdout"},
+			wantCode:   0,
+			wantStdout: formatted,
+			withFile:   true,
+			wantFile:   formatted,
 		},
 	}
 
@@ -296,9 +304,9 @@ func TestRunEVerbose(t *testing.T) {
 	unformatted := "variable \"a\" {\n  type = string\n  description = \"d\"\n}\n"
 
 	tests := []struct {
-		name	string
-		verbose	bool
-		wantLog	bool
+		name    string
+		verbose bool
+		wantLog bool
 	}{
 		{name: "verbose", verbose: true, wantLog: true},
 		{name: "silent", verbose: false, wantLog: false},
@@ -348,9 +356,9 @@ func TestRunEFollowSymlinks(t *testing.T) {
 	formatted := "variable \"a\" {\n  description = \"d\"\n  type        = string\n}\n"
 
 	tests := []struct {
-		name	string
-		follow	bool
-		want	string
+		name   string
+		follow bool
+		want   string
 	}{
 		{name: "follow", follow: true, want: formatted},
 		{name: "no_follow", follow: false, want: unformatted},
@@ -381,4 +389,3 @@ func TestRunEFollowSymlinks(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/engine/write_error_test.go
+++ b/internal/engine/write_error_test.go
@@ -21,10 +21,10 @@ import (
 
 func newRootCmd(exclusive bool) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:		"hclalign [target file or directory]",
-		Args:		cobra.ArbitraryArgs,
-		RunE:		cli.RunE,
-		SilenceUsage:	true,
+		Use:          "hclalign [target file or directory]",
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         cli.RunE,
+		SilenceUsage: true,
 	}
 	cmd.Flags().Bool("write", false, "write result to file(s)")
 	cmd.Flags().Bool("check", false, "check if files are formatted")
@@ -70,4 +70,3 @@ func TestProcessWriteFileError(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, string(data), string(got))
 }
-

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func run(args []string) int {
 	rootCmd := &cobra.Command{
 		Use:          "hclalign [target file or directory]",
 		Short:        "Aligns HCL files based on given criteria",
-		Args:         cobra.ArbitraryArgs,
+		Args:         cobra.MaximumNArgs(1),
 		RunE:         cli.RunE,
 		SilenceUsage: true,
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -79,7 +79,7 @@ func TestMainFunctionality(t *testing.T) {
 			rootCmd := &cobra.Command{
 				Use:          "hclalign [target file or directory]",
 				Short:        "Aligns HCL files based on given criteria",
-				Args:         cobra.ArbitraryArgs,
+				Args:         cobra.MaximumNArgs(1),
 				RunE:         cli.RunE,
 				SilenceUsage: true,
 			}
@@ -122,7 +122,7 @@ func TestCLIOrderFlagInfluencesProcessing(t *testing.T) {
 	rootCmd := &cobra.Command{
 		Use:          "hclalign [target file or directory]",
 		Short:        "Aligns HCL files based on given criteria",
-		Args:         cobra.ArbitraryArgs,
+		Args:         cobra.MaximumNArgs(1),
 		RunE:         cli.RunE,
 		SilenceUsage: true,
 	}
@@ -158,7 +158,7 @@ func TestCLIStrictOrderUnknownAttribute(t *testing.T) {
 	rootCmd := &cobra.Command{
 		Use:          "hclalign [target file or directory]",
 		Short:        "Aligns HCL files based on given criteria",
-		Args:         cobra.ArbitraryArgs,
+		Args:         cobra.MaximumNArgs(1),
 		RunE:         cli.RunE,
 		SilenceUsage: true,
 	}


### PR DESCRIPTION
## Summary
- limit `hclalign` to at most one positional argument
- remove manual arg-count validation and rely on Cobra
- add unit tests for argument validation

## Testing
- `go test ./...` *(fails: TestGolden/inline_comment_after_brace)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b96b90b88323891a5ab94410c4a1