### PR TITLE
ci: validate Terraform formatting for golden cases

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,3 +55,19 @@ jobs:
         with:
           name: hclalign-${{ matrix.os }}-${{ matrix.go }}
           path: hclalign
+
+  terraform:
+    runs-on: ubuntu-latest
+    container:
+      image: hashicorp/terraform:1.5.7
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Verify terraform fmt on golden cases
+        run: |
+          set -euo pipefail
+          for file in $(find tests/cases -type f -name 'out*.tf'); do
+            echo "Checking $file"
+            terraform fmt -check -diff "$file"
+          done


### PR DESCRIPTION
## Summary
- add Terraform job in CI to run `terraform fmt` on golden outputs

## Testing
- `go test ./... -count=1` *(fails: output mismatch for inline_comment_after_brace)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bb8b1d2c832387eeb7309f32a3eb