### PR TITLE
Add Terraform formatter strategies with auto fallback

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -37,7 +37,7 @@ func newTestRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().Bool("strict-order", false, "enforce strict attribute ordering")
 	cmd.Flags().Bool("fmt-only", false, "only format files, skip alignment")
 	cmd.Flags().Bool("no-fmt", false, "skip initial formatting")
-	cmd.Flags().String("fmt-strategy", "native", "formatting strategy to use")
+	cmd.Flags().String("fmt-strategy", "auto", "formatting strategy to use")
 	cmd.Flags().String("providers-schema", "", "path to providers schema file")
 	cmd.Flags().Bool("use-terraform-schema", false, "use terraform schema for providers")
 	cmd.Flags().Int("concurrency", runtime.GOMAXPROCS(0), "maximum concurrency")

--- a/cmd/hclalign/main.go
+++ b/cmd/hclalign/main.go
@@ -36,7 +36,7 @@ func run(args []string) int {
 	rootCmd.Flags().Bool("strict-order", false, "enforce strict attribute ordering")
 	rootCmd.Flags().Bool("fmt-only", false, "only format files, skip alignment")
 	rootCmd.Flags().Bool("no-fmt", false, "skip initial formatting")
-	rootCmd.Flags().String("fmt-strategy", "native", "formatting strategy to use")
+	rootCmd.Flags().String("fmt-strategy", "auto", "formatting strategy to use")
 	rootCmd.Flags().String("providers-schema", "", "path to providers schema file")
 	rootCmd.Flags().Bool("use-terraform-schema", false, "use terraform schema for providers")
 	rootCmd.Flags().Int("concurrency", runtime.GOMAXPROCS(0), "maximum concurrency")

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 
 	"github.com/hashicorp/hclalign/config"
-	"github.com/hashicorp/hclalign/formatter"
 	"github.com/hashicorp/hclalign/internal/diff"
+	terraformfmt "github.com/hashicorp/hclalign/internal/fmt"
 	internalfs "github.com/hashicorp/hclalign/internal/fs"
 	"github.com/hashicorp/hclalign/internal/hclalign"
 )
@@ -87,7 +87,7 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 	hadNewline := len(data) > 0 && data[len(data)-1] == '\n'
 	formatted := data
 	if !cfg.NoFmt {
-		formatted, err = formatter.Format(data, "stdin")
+		formatted, err = terraformfmt.Format(data, "stdin", cfg.FmtStrategy)
 		if err != nil {
 			return false, fmt.Errorf("parsing error: %w", err)
 		}

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 
 	"github.com/hashicorp/hclalign/config"
-	"github.com/hashicorp/hclalign/formatter"
 	"github.com/hashicorp/hclalign/internal/diff"
+	terraformfmt "github.com/hashicorp/hclalign/internal/fmt"
 	internalfs "github.com/hashicorp/hclalign/internal/fs"
 )
 
@@ -121,7 +121,7 @@ func processFile(ctx context.Context, filePath string, cfg *config.Config) (bool
 	hadNewline := len(data) > 0 && data[len(data)-1] == '\n'
 	formatted := data
 	if !cfg.NoFmt {
-		formatted, err = formatter.Format(data, filePath)
+		formatted, err = terraformfmt.Format(data, filePath, cfg.FmtStrategy)
 		if err != nil {
 			return false, nil, fmt.Errorf("parsing error in file %s: %w", filePath, err)
 		}

--- a/internal/engine/write_error_test.go
+++ b/internal/engine/write_error_test.go
@@ -37,7 +37,7 @@ func newRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().Bool("strict-order", false, "enforce strict attribute ordering")
 	cmd.Flags().Bool("fmt-only", false, "only format files, skip alignment")
 	cmd.Flags().Bool("no-fmt", false, "skip initial formatting")
-	cmd.Flags().String("fmt-strategy", "native", "formatting strategy to use")
+	cmd.Flags().String("fmt-strategy", "auto", "formatting strategy to use")
 	cmd.Flags().String("providers-schema", "", "path to providers schema file")
 	cmd.Flags().Bool("use-terraform-schema", false, "use terraform schema for providers")
 	cmd.Flags().Int("concurrency", runtime.GOMAXPROCS(0), "maximum concurrency")

--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -1,0 +1,78 @@
+package terraformfmt
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"unicode/utf8"
+
+	"github.com/hashicorp/hclalign/formatter"
+	internalfs "github.com/hashicorp/hclalign/internal/fs"
+)
+
+type Strategy string
+
+const (
+	StrategyAuto   Strategy = "auto"
+	StrategyBinary Strategy = "binary"
+	StrategyGo     Strategy = "go"
+)
+
+// Format formats HCL source using the specified strategy.
+// The filename parameter is used only for parse diagnostics.
+func Format(src []byte, filename, strat string) ([]byte, error) {
+	switch Strategy(strat) {
+	case StrategyGo:
+		return formatter.Format(src, filename)
+	case StrategyBinary:
+		return formatBinary(src)
+	case StrategyAuto, "":
+		if _, err := exec.LookPath("terraform"); err == nil {
+			return formatBinary(src)
+		}
+		return formatter.Format(src, filename)
+	default:
+		return nil, fmt.Errorf("unknown fmt strategy %q", strat)
+	}
+}
+
+func formatBinary(src []byte) ([]byte, error) {
+	hints := internalfs.DetectHintsFromBytes(src)
+	if bom := hints.BOM(); len(bom) > 0 {
+		src = src[len(bom):]
+	}
+	if len(src) > 0 && !utf8.Valid(src) {
+		return nil, fmt.Errorf("input is not valid UTF-8")
+	}
+
+	f, err := os.CreateTemp("", "hclalign-*.tf")
+	if err != nil {
+		return nil, err
+	}
+	name := f.Name()
+	if _, err := f.Write(src); err != nil {
+		f.Close()
+		os.Remove(name)
+		return nil, err
+	}
+	f.Close()
+
+	cmd := exec.Command("terraform", "fmt", name)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(name)
+		return nil, fmt.Errorf("terraform fmt failed: %v: %s", err, string(out))
+	}
+	formatted, err := os.ReadFile(name)
+	os.Remove(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(formatted) > 0 {
+		formatted = bytes.TrimRight(formatted, "\n")
+		formatted = append(formatted, '\n')
+	}
+	formatted = internalfs.ApplyHints(formatted, hints)
+	return formatted, nil
+}

--- a/internal/fmt/terraformfmt_test.go
+++ b/internal/fmt/terraformfmt_test.go
@@ -1,0 +1,29 @@
+package terraformfmt
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoMatchesBinary(t *testing.T) {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform binary not found")
+	}
+	src := []byte("variable \"a\" {\n  type = string\n}\n")
+	goFmt, err := Format(src, "test.tf", string(StrategyGo))
+	require.NoError(t, err)
+	binFmt, err := Format(src, "test.tf", string(StrategyBinary))
+	require.NoError(t, err)
+	require.Equal(t, string(binFmt), string(goFmt))
+}
+
+func TestIdempotent(t *testing.T) {
+	src := []byte("variable \"a\" {\n  type = string\n}\n")
+	first, err := Format(src, "test.tf", string(StrategyGo))
+	require.NoError(t, err)
+	second, err := Format(first, "test.tf", string(StrategyGo))
+	require.NoError(t, err)
+	require.Equal(t, string(first), string(second))
+}


### PR DESCRIPTION
## Summary
- add internal terraform formatter with binary, go, and auto strategies
- expose `--fmt-strategy` flag defaulting to auto
- use formatter in engine pipeline and cover with tests

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1c4233d908323894a53878562e48d