### PR TITLE
feat: centralize BOM and newline handling

### DIFF
--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -133,13 +133,7 @@ func processFile(ctx context.Context, filePath string, cfg *config.Config, schem
 		}
 	}
 
-	parseData := formatted
-	if !cfg.NoFmt {
-		if bom := hints.BOM(); len(bom) > 0 && bytes.HasPrefix(parseData, bom) {
-			parseData = parseData[len(bom):]
-		}
-	}
-	parseData = bytes.ReplaceAll(parseData, []byte("\r\n"), []byte("\n"))
+	parseData := internalfs.PrepareForParse(formatted, hints)
 
 	if !cfg.FmtOnly {
 		file, diags := hclwrite.ParseConfig(parseData, filePath, hcl.InitialPos)

--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -39,9 +39,7 @@ func Format(src []byte, filename, strat string) ([]byte, error) {
 
 func formatBinary(src []byte) ([]byte, error) {
 	hints := internalfs.DetectHintsFromBytes(src)
-	if bom := hints.BOM(); len(bom) > 0 {
-		src = src[len(bom):]
-	}
+	src = internalfs.PrepareForParse(src, hints)
 	if len(src) > 0 && !utf8.Valid(src) {
 		return nil, fmt.Errorf("input is not valid UTF-8")
 	}


### PR DESCRIPTION
## Summary
- centralize BOM/CRLF stripping and stdin/stdout helpers in internal fs
- normalize data before parse and apply hints consistently across pipeline
- ensure atomic writes always sync and rename in place

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1cd83941c8323a7fd06e458b8a1d9