### PR TITLE
feat: add covercheck tool and simplify coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,7 @@ test-race:
 	$(GO) test $(PKG) -race -shuffle=on
 
 cover: test
-	$(GO) tool cover -func=$(COVERPROFILE) | tee $(BUILD_DIR)/coverage.txt
-	@cov=$$(grep total: $(BUILD_DIR)/coverage.txt | awk '{print $$3}' | sed 's/%//'); \
-	awk 'BEGIN{exit !('"$$cov"' >= 95)}' </dev/null || { echo "Coverage $$cov% < 95%"; exit 1; }
+	$(GO) run ./internal/ci/covercheck
 
 build:
 	mkdir -p $(BUILD_DIR)

--- a/internal/ci/covercheck/main.go
+++ b/internal/ci/covercheck/main.go
@@ -18,7 +18,7 @@ var ignore = []string{
 }
 
 func main() {
-	const profile = "coverage.out"
+	const profile = ".build/coverage.out"
 
 	f, err := os.Open(profile)
 	if err != nil {

--- a/internal/ci/covercheck/main_test.go
+++ b/internal/ci/covercheck/main_test.go
@@ -2,66 +2,70 @@
 package main
 
 import (
-	"os"
-	"os/exec"
-	"strings"
-	"testing"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "testing"
 )
 
 func runCovercheck(t *testing.T) (string, int) {
-	t.Helper()
-	cmd := exec.Command("go", "run", ".")
-	out, err := cmd.CombinedOutput()
-	if err == nil {
-		return string(out), 0
-	}
-	if ee, ok := err.(*exec.ExitError); ok {
-		return string(out), ee.ExitCode()
-	}
-	t.Fatalf("unexpected error: %v", err)
-	return "", 0
+    t.Helper()
+    cmd := exec.Command("go", "run", ".")
+    out, err := cmd.CombinedOutput()
+    if err == nil {
+        return string(out), 0
+    }
+    if ee, ok := err.(*exec.ExitError); ok {
+        return string(out), ee.ExitCode()
+    }
+    t.Fatalf("unexpected error: %v", err)
+    return "", 0
 }
 
 func TestCovercheck(t *testing.T) {
-	tests := []struct {
-		name		string
-		profile		string
-		wantExit	int
-		wantMsg		string
-	}{
-		{
-			name:		"above",
-			profile:	"mode: set\nfile.go:1.1,1.2 1 1\n",
-			wantExit:	0,
-			wantMsg:	"Total coverage: 100.0%",
-		},
-		{
-			name:		"below",
-			profile:	"mode: set\nfile.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
-			wantExit:	1,
-			wantMsg:	"Coverage 50.0% is below 95.0%",
-		},
-		{
-			name:		"ignored path",
-			profile:	"mode: set\ncmd/commentcheck/file.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
-			wantExit:	0,
-			wantMsg:	"Total coverage: 100.0%",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := os.WriteFile("coverage.out", []byte(tc.profile), 0644); err != nil {
-				t.Fatalf("write profile: %v", err)
-			}
-			defer os.Remove("coverage.out")
-			out, code := runCovercheck(t)
-			if code != tc.wantExit {
-				t.Fatalf("exit %d, want %d; output: %s", code, tc.wantExit, out)
-			}
-			if !strings.Contains(out, tc.wantMsg) {
-				t.Fatalf("output %q does not contain %q", out, tc.wantMsg)
-			}
-		})
-	}
+    tests := []struct {
+        name     string
+        profile  string
+        wantExit int
+        wantMsg  string
+    }{
+        {
+            name:    "above",
+            profile: "mode: set\nfile.go:1.1,1.2 1 1\n",
+            wantExit: 0,
+            wantMsg: "Total coverage: 100.0%",
+        },
+        {
+            name:    "below",
+            profile: "mode: set\nfile.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
+            wantExit: 1,
+            wantMsg: "Coverage 50.0% is below 95.0%",
+        },
+        {
+            name:    "ignored path",
+            profile: "mode: set\ncmd/commentcheck/file.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
+            wantExit: 0,
+            wantMsg: "Total coverage: 100.0%",
+        },
+    }
+    for _, tc := range tests {
+        t.Run(tc.name, func(t *testing.T) {
+            if err := os.MkdirAll(".build", 0755); err != nil {
+                t.Fatalf("mkdir .build: %v", err)
+            }
+            profile := filepath.Join(".build", "coverage.out")
+            if err := os.WriteFile(profile, []byte(tc.profile), 0644); err != nil {
+                t.Fatalf("write profile: %v", err)
+            }
+            defer os.RemoveAll(".build")
+            out, code := runCovercheck(t)
+            if code != tc.wantExit {
+                t.Fatalf("exit %d, want %d; output: %s", code, tc.wantExit, out)
+            }
+            if !strings.Contains(out, tc.wantMsg) {
+                t.Fatalf("output %q does not contain %q", out, tc.wantMsg)
+            }
+        })
+    }
 }
-


### PR DESCRIPTION
## Summary
- add internal coverage checker ensuring test coverage >=95%
- simplify Makefile cover target to run Go checker

## Testing
- `gofmt -w internal/ci/covercheck/main.go internal/ci/covercheck/main_test.go` *(fails: No such file or directory)*
- `go test ./...` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d248642c83238a35a0ea5c90d1bf