### PR TITLE
test: force Go formatter in phase tests

### DIFF
--- a/internal/align/phases_test.go
+++ b/internal/align/phases_test.go
@@ -34,7 +34,7 @@ func TestPhases(t *testing.T) {
 			wantAligned, err := os.ReadFile(alignedPath)
 			require.NoError(t, err)
 
-			gotFmt, err := terraformfmt.Format(inBytes, inPath, "")
+			gotFmt, err := terraformfmt.Format(inBytes, inPath, string(terraformfmt.StrategyGo))
 			require.NoError(t, err)
 			hadNewline := len(inBytes) > 0 && inBytes[len(inBytes)-1] == '\n'
 			if !hadNewline && len(gotFmt) > 0 && gotFmt[len(gotFmt)-1] == '\n' {
@@ -64,7 +64,7 @@ func TestPhases(t *testing.T) {
 	}
 
 	t.Run("error", func(t *testing.T) {
-		_, err := terraformfmt.Format([]byte("variable \"a\" {"), "bad.hcl", "")
+		_, err := terraformfmt.Format([]byte("variable \"a\" {"), "bad.hcl", string(terraformfmt.StrategyGo))
 		require.Error(t, err)
 	})
 }

--- a/internal/engine/phases_test.go
+++ b/internal/engine/phases_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hclalign/config"
+	terraformfmt "github.com/hashicorp/hclalign/internal/fmt"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,8 +26,8 @@ func TestPhases(t *testing.T) {
 			alignedExp, err := os.ReadFile(filepath.Join(base, name, "aligned.tf"))
 			require.NoError(t, err)
 
-			cfgFmt := &config.Config{Stdout: true, FmtOnly: true}
-			cfgFull := &config.Config{Stdout: true}
+			cfgFmt := &config.Config{Stdout: true, FmtOnly: true, FmtStrategy: string(terraformfmt.StrategyGo)}
+			cfgFull := &config.Config{Stdout: true, FmtStrategy: string(terraformfmt.StrategyGo)}
 			if name == "resource" || name == "data" {
 				cfgFmt.ProvidersSchema = schemaPath
 				cfgFull.ProvidersSchema = schemaPath
@@ -54,7 +55,7 @@ func TestPhases(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		var out bytes.Buffer
-		cfg := &config.Config{Stdout: true}
+		cfg := &config.Config{Stdout: true, FmtStrategy: string(terraformfmt.StrategyGo)}
 		_, err := ProcessReader(context.Background(), bytes.NewReader([]byte("variable \"a\" {")), &out, cfg)
 		require.Error(t, err)
 	})


### PR DESCRIPTION
## Summary
- ensure phase tests explicitly use Go formatter
- add FmtStrategy to engine phase tests

## Testing
- `go test ./internal/align ./internal/engine`


------
https://chatgpt.com/codex/tasks/task_e_68b1d4efa24c832394486dfa48e6b736