### PR TITLE
Use errors.As for CLI exit codes

### DIFF
--- a/cmd/hclalign/main.go
+++ b/cmd/hclalign/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"runtime"
 
@@ -11,7 +12,10 @@ import (
 	"github.com/hashicorp/hclalign/config"
 )
 
-var osExit = os.Exit
+var (
+	osExit = os.Exit
+	runE   = cli.RunE
+)
 
 func main() { osExit(run(os.Args[1:])) }
 
@@ -20,7 +24,7 @@ func run(args []string) int {
 		Use:          "hclalign [target file or directory]",
 		Short:        "Aligns HCL files based on given criteria",
 		Args:         cobra.MaximumNArgs(1),
-		RunE:         cli.RunE,
+		RunE:         runE,
 		SilenceUsage: true,
 	}
 
@@ -46,7 +50,8 @@ func run(args []string) int {
 
 	rootCmd.SetArgs(args)
 	if err := rootCmd.Execute(); err != nil {
-		if ec, ok := err.(*cli.ExitCodeError); ok {
+		var ec *cli.ExitCodeError
+		if errors.As(err, &ec) {
 			return ec.Code
 		}
 		return 1

--- a/cmd/hclalign/main_test.go
+++ b/cmd/hclalign/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hashicorp/hclalign/cli"
+)
+
+func TestRunWrappedExitCode(t *testing.T) {
+	oldRunE := runE
+	t.Cleanup(func() { runE = oldRunE })
+
+	runE = func(_ *cobra.Command, _ []string) error {
+		return fmt.Errorf("wrap: %w", &cli.ExitCodeError{Err: errors.New("boom"), Code: 7})
+	}
+
+	if code := run(nil); code != 7 {
+		t.Fatalf("expected exit code 7, got %d", code)
+	}
+}


### PR DESCRIPTION
## Summary
- handle wrapped `ExitCodeError` using `errors.As`
- add tests for wrapped `ExitCodeError` to ensure exit-code extraction

## Testing
- `go test ./cmd/hclalign`


------
https://chatgpt.com/codex/tasks/task_e_68b1d5e8ac80832386389f707c879298