### PR TITLE
Add flag and exit-code tests for hclalign main command

### DIFF
--- a/cmd/hclalign/main_test.go
+++ b/cmd/hclalign/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -10,6 +11,76 @@ import (
 	"github.com/hashicorp/hclalign/cli"
 )
 
+// TestMainExitCode verifies that main uses osExit with the code returned by run.
+func TestMainExitCode(t *testing.T) {
+	oldOsExit := osExit
+	oldArgs := os.Args
+	oldRunE := runE
+	t.Cleanup(func() {
+		osExit = oldOsExit
+		os.Args = oldArgs
+		runE = oldRunE
+	})
+
+	var gotCode int
+	osExit = func(code int) { gotCode = code }
+
+	runE = func(_ *cobra.Command, _ []string) error {
+		return &cli.ExitCodeError{Err: errors.New("boom"), Code: 42}
+	}
+
+	os.Args = []string{"hclalign"}
+	main()
+
+	if gotCode != 42 {
+		t.Fatalf("expected exit code 42, got %d", gotCode)
+	}
+}
+
+// TestRunCheckFlag ensures that flags parsed via rootCmd.SetArgs reach runE.
+func TestRunCheckFlag(t *testing.T) {
+	oldRunE := runE
+	t.Cleanup(func() { runE = oldRunE })
+
+	runE = func(cmd *cobra.Command, args []string) error {
+		check, err := cmd.Flags().GetBool("check")
+		if err != nil {
+			t.Fatalf("get flag: %v", err)
+		}
+		if !check {
+			t.Fatalf("expected check flag to be true")
+		}
+		diff, err := cmd.Flags().GetBool("diff")
+		if err != nil {
+			t.Fatalf("get flag: %v", err)
+		}
+		if diff {
+			t.Fatalf("expected diff flag to be false")
+		}
+		return nil
+	}
+
+	if code := run([]string{"--check"}); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+}
+
+// TestRunMutuallyExclusiveFlags validates that mutually exclusive flags cause an error.
+func TestRunMutuallyExclusiveFlags(t *testing.T) {
+	oldRunE := runE
+	t.Cleanup(func() { runE = oldRunE })
+
+	runE = func(_ *cobra.Command, _ []string) error {
+		t.Fatal("runE should not be called")
+		return nil
+	}
+
+	if code := run([]string{"--check", "--diff"}); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}
+
+// TestRunWrappedExitCode confirms that wrapped ExitCodeError values are unwrapped.
 func TestRunWrappedExitCode(t *testing.T) {
 	oldRunE := runE
 	t.Cleanup(func() { runE = oldRunE })


### PR DESCRIPTION
## Summary
- expand main command tests to capture exit codes and flag parsing
- verify mutually exclusive flags return non-zero exit code
- ensure main propagates exit codes via osExit

## Testing
- `go test ./cmd/hclalign -cover`


------
https://chatgpt.com/codex/tasks/task_e_68b1d700a1fc83239e6418450a096599