### PR TITLE
Add formatter tests and normalize newline handling

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -28,6 +28,7 @@ func Format(src []byte, filename string) ([]byte, error) {
 		return nil, diags
 	}
 	formatted := hclwrite.Format(f.Bytes())
+	formatted = bytes.ReplaceAll(formatted, []byte("\r\n"), []byte("\n"))
 
 	if len(formatted) > 0 {
 		formatted = bytes.TrimRight(formatted, "\n")

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,0 +1,89 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestFormatHints verifies that BOMs and newline styles are preserved after
+// formatting. It also checks that the formatted output matches the expected
+// canonical form.
+func TestFormatHints(t *testing.T) {
+	bom := []byte{0xEF, 0xBB, 0xBF}
+	tests := []struct {
+		name  string
+		input []byte
+		want  []byte
+	}{
+		{
+			name:  "lf",
+			input: []byte("a=1\nb=2\n"),
+			want:  []byte("a = 1\nb = 2\n"),
+		},
+		{
+			name:  "crlf_bom",
+			input: append(append([]byte{}, bom...), []byte("a=1\r\n")...),
+			want:  append(append([]byte{}, bom...), []byte("a = 1\r\n")...),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Format(tc.input, "test.hcl")
+			if err != nil {
+				t.Fatalf("Format returned error: %v", err)
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Fatalf("unexpected output\nwant: %q\n got: %q", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestFormatTrailingNewline ensures that formatter enforces exactly one
+// trailing newline and applies newline hints when adding it.
+func TestFormatTrailingNewline(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		want  []byte
+	}{
+		{
+			name:  "missing",
+			input: []byte("a=1"),
+			want:  []byte("a = 1\n"),
+		},
+		{
+			name:  "extra",
+			input: []byte("a=1\n\n"),
+			want:  []byte("a = 1\n"),
+		},
+		{
+			name:  "crlf_style",
+			input: []byte("a=1\r\nb=2"),
+			want:  []byte("a = 1\r\nb = 2\r\n"),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Format(tc.input, "test.hcl")
+			if err != nil {
+				t.Fatalf("Format returned error: %v", err)
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Fatalf("unexpected output\nwant: %q\n got: %q", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestFormatRejectsInvalidUTF8 verifies that non-UTF-8 input is rejected.
+func TestFormatRejectsInvalidUTF8(t *testing.T) {
+	invalid := []byte{0xff, 0xfe, 0xfd}
+	if _, err := Format(invalid, "test.hcl"); err == nil {
+		t.Fatalf("expected error for invalid UTF-8 input")
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for BOM preservation, newline normalization, trailing newline enforcement, and UTF-8 validation
- normalize CRLF newlines before hint reapplication in formatter

## Testing
- `go test ./formatter -cover`

------
https://chatgpt.com/codex/tasks/task_e_68b1d7f79ab08323a64a2a67a993a804