### PR TITLE
chore: add additional make targets

### DIFF
--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -25,7 +25,10 @@ var (
 func main() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	mode := fs.String("mode", "ci", "ci or fix")
-	fs.Parse(os.Args[1:])
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		osExit(1)
+	}
 
 	files, err := goFiles()
 	if err != nil {

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -87,7 +87,7 @@ func TestMainModes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	defer os.Chdir(oldWD)
+	defer func() { _ = os.Chdir(oldWD) }()
 	if err := os.Chdir(dir); err != nil {
 		t.Fatalf("chdir: %v", err)
 	}
@@ -120,10 +120,10 @@ func TestMainModes(t *testing.T) {
 		t.Fatalf("fix via main failed: %q", data)
 	}
 
-       code = 0
-       os.Args = []string{"cmd", "--mode=ci"}
-       main()
-       if code != 0 {
+	code = 0
+	os.Args = []string{"cmd", "--mode=ci"}
+	main()
+	if code != 0 {
 		t.Fatalf("unexpected exit %d", code)
 	}
 }

--- a/internal/align/strategy.go
+++ b/internal/align/strategy.go
@@ -51,7 +51,7 @@ func Apply(file *hclwrite.File, opts *Options) error {
 
 func applyBody(body *hclwrite.Body, opts *Options) error {
 	for _, b := range body.Blocks() {
-		if strat, ok := registry[b.Type()]; ok {
+		if strategy, ok := registry[b.Type()]; ok {
 			sub := *opts
 			sub.Schema = nil
 			if len(b.Labels()) > 0 && opts.Schemas != nil {
@@ -59,7 +59,7 @@ func applyBody(body *hclwrite.Body, opts *Options) error {
 					sub.Schema = s
 				}
 			}
-			if err := strat.Align(b, &sub); err != nil {
+			if err := strategy.Align(b, &sub); err != nil {
 				return err
 			}
 		}

--- a/internal/align/variable.go
+++ b/internal/align/variable.go
@@ -86,7 +86,7 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 	allTokens := body.BuildTokens(nil)
 	newline := ihcl.DetectLineEnding(allTokens)
 	prefixTokens := hclwrite.Tokens{}
-	tailTokens := hclwrite.Tokens{}
+	var tailTokens hclwrite.Tokens
 	blockLeadTokens := make(map[*hclwrite.Block]hclwrite.Tokens)
 	attrLeadTrim := make(map[string]int)
 	attrExtraLead := make(map[string]hclwrite.Tokens)

--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -21,8 +21,8 @@ const (
 
 // Format formats HCL source using the specified strategy.
 // The filename parameter is used only for parse diagnostics.
-func Format(src []byte, filename, strat string) ([]byte, error) {
-	switch Strategy(strat) {
+func Format(src []byte, filename, strategy string) ([]byte, error) {
+	switch Strategy(strategy) {
 	case StrategyGo:
 		return formatter.Format(src, filename)
 	case StrategyBinary:
@@ -33,7 +33,7 @@ func Format(src []byte, filename, strat string) ([]byte, error) {
 		}
 		return formatter.Format(src, filename)
 	default:
-		return nil, fmt.Errorf("unknown fmt strategy %q", strat)
+		return nil, fmt.Errorf("unknown fmt strategy %q", strategy)
 	}
 }
 

--- a/internal/hclalign/hclalign.go
+++ b/internal/hclalign/hclalign.go
@@ -89,7 +89,7 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 	allTokens := body.BuildTokens(nil)
 	newline := ihcl.DetectLineEnding(allTokens)
 	prefixTokens := hclwrite.Tokens{}
-	tailTokens := hclwrite.Tokens{}
+	var tailTokens hclwrite.Tokens
 	blockLeadTokens := make(map[*hclwrite.Block]hclwrite.Tokens)
 	attrLeadTrim := make(map[string]int)
 	currentTokens := hclwrite.Tokens{}


### PR DESCRIPTION
## Summary
- add dedicated formatting packages and new CI targets including `vuln` and `cover-html`
- build CLI with reproducible flags and handle flag parsing errors in comment checker
- tidy up strategy code and parameter names to satisfy lint

## Testing
- `make init`
- `make tidy`
- `make fmt`
- `make build`
- `make lint`
- `make vuln` *(fails: fetching vulnerabilities forbidden)*
- `make test`
- `make cover` *(fails: Coverage 79.2% < 95%)*
- `make cover-html`
- `make commentcheck` *(fails: missing file comments)*
- `make ci` *(fails: fetching vulnerabilities forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1da174ca88323b89d44983a9739de