### PR TITLE
Remove comments and enforce path headers

### DIFF
--- a/cmd/commentcheck/doc.go
+++ b/cmd/commentcheck/doc.go
@@ -1,3 +1,2 @@
 // cmd/commentcheck/doc.go
 package main
-

--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -81,80 +81,45 @@ func goFiles() ([]string, error) {
 func checkFile(path string) error {
 	rel := filepath.ToSlash(path)
 	expected := "// " + rel
-	fh, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer fh.Close()
-	reader := bufio.NewReader(fh)
-	first, err := reader.ReadString('\n')
-	if err != nil {
-		return fmt.Errorf("%s: unable to read first line", path)
-	}
-	first = strings.TrimRight(first, "\n")
-	if strings.HasPrefix(first, "//go:build") {
-		for {
-			next, err := reader.ReadString('\n')
-			if err != nil {
-				return fmt.Errorf("%s: unable to read after build tag", path)
-			}
-			line := strings.TrimRight(next, "\n")
-			if line == "" {
-				break
-			}
-			if !strings.HasPrefix(line, "//go:build") {
-				return fmt.Errorf("%s: invalid line %q in build tags", path, line)
-			}
-		}
-		pc, err := reader.ReadString('\n')
-		if err != nil {
-			return fmt.Errorf("%s: unable to read path comment", path)
-		}
-		pc = strings.TrimRight(pc, "\n")
-		if pc != expected {
-			return fmt.Errorf("%s: path comment must be %q", path, expected)
-		}
-	} else {
-		if first != expected {
-			return fmt.Errorf("%s: first line must be %q", path, expected)
-		}
-	}
+
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 	if err != nil {
 		return fmt.Errorf("%s: %v", path, err)
 	}
-	if len(file.Comments) == 0 {
+
+	groups := file.Comments
+	if len(groups) == 0 {
 		return fmt.Errorf("%s: missing file comment", path)
 	}
-	groups := file.Comments
-	if strings.HasPrefix(first, "//go:build") {
-		if len(groups) < 2 {
-			return fmt.Errorf("%s: missing file comment", path)
-		}
-		buildGroup := groups[0]
-		for _, c := range buildGroup.List {
+
+	idx := 0
+	if strings.HasPrefix(groups[0].List[0].Text, "//go:build") {
+		for _, c := range groups[0].List {
 			if !strings.HasPrefix(c.Text, "//go:build") {
-				return fmt.Errorf("%s: unexpected comment %q in build tags", path, c.Text)
+				return fmt.Errorf("%s: invalid line %q in build tags", path, c.Text)
 			}
 		}
-		pathGroup := groups[1]
-		pos := fset.Position(pathGroup.Pos())
-		if pathGroup.List[0].Text != expected || pos.Line < 2 {
-			return fmt.Errorf("%s: first non-build comment must be %q", path, expected)
-		}
-		if len(groups) > 2 || len(pathGroup.List) > 1 {
-			return fmt.Errorf("%s: found additional comments", path)
-		}
-	} else {
-		firstGroup := groups[0]
-		pos := fset.Position(firstGroup.Pos())
-		if pos.Line != 1 || firstGroup.List[0].Text != expected {
-			return fmt.Errorf("%s: first comment must be %q", path, expected)
-		}
-		if len(groups) > 1 || len(firstGroup.List) > 1 {
-			return fmt.Errorf("%s: found additional comments", path)
-		}
+		idx = 1
+	}
+
+	if idx >= len(groups) {
+		return fmt.Errorf("%s: missing file comment", path)
+	}
+
+	pathGroup := groups[idx]
+	pos := fset.Position(pathGroup.Pos())
+	if pathGroup.List[0].Text != expected {
+		return fmt.Errorf("%s: first comment must be %q", path, expected)
+	}
+	if idx == 0 && pos.Line != 1 {
+		return fmt.Errorf("%s: first comment must be %q", path, expected)
+	}
+	if idx > 0 && pos.Line < 2 {
+		return fmt.Errorf("%s: first non-build comment must be %q", path, expected)
+	}
+	if len(pathGroup.List) > 1 || len(groups) > idx+1 {
+		return fmt.Errorf("%s: found additional comments", path)
 	}
 	return nil
 }

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -42,7 +42,17 @@ func TestCheckFileMissingComment(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "foo.go")
 	write(t, path, "package main\n")
-	if err := checkFile(path); err == nil || !strings.Contains(err.Error(), "first line must be") {
+	if err := checkFile(path); err == nil || !strings.Contains(err.Error(), "missing file comment") {
+		t.Fatalf("expected error, got %v", err)
+	}
+}
+
+func TestCheckFileAdditionalComments(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foo.go")
+	comment := fmt.Sprintf("// %s\n", filepath.ToSlash(path))
+	write(t, path, comment+"package main\n// extra\n")
+	if err := checkFile(path); err == nil || !strings.Contains(err.Error(), "found additional comments") {
 		t.Fatalf("expected error, got %v", err)
 	}
 }

--- a/cmd/hclalign/main_test.go
+++ b/cmd/hclalign/main_test.go
@@ -1,3 +1,4 @@
+// cmd/hclalign/main_test.go
 package main
 
 import (
@@ -11,7 +12,6 @@ import (
 	"github.com/hashicorp/hclalign/cli"
 )
 
-// TestMainExitCode verifies that main uses osExit with the code returned by run.
 func TestMainExitCode(t *testing.T) {
 	oldOsExit := osExit
 	oldArgs := os.Args
@@ -37,7 +37,6 @@ func TestMainExitCode(t *testing.T) {
 	}
 }
 
-// TestRunCheckFlag ensures that flags parsed via rootCmd.SetArgs reach runE.
 func TestRunCheckFlag(t *testing.T) {
 	oldRunE := runE
 	t.Cleanup(func() { runE = oldRunE })
@@ -65,7 +64,6 @@ func TestRunCheckFlag(t *testing.T) {
 	}
 }
 
-// TestRunMutuallyExclusiveFlags validates that mutually exclusive flags cause an error.
 func TestRunMutuallyExclusiveFlags(t *testing.T) {
 	oldRunE := runE
 	t.Cleanup(func() { runE = oldRunE })
@@ -80,7 +78,6 @@ func TestRunMutuallyExclusiveFlags(t *testing.T) {
 	}
 }
 
-// TestRunWrappedExitCode confirms that wrapped ExitCodeError values are unwrapped.
 func TestRunWrappedExitCode(t *testing.T) {
 	oldRunE := runE
 	t.Cleanup(func() { runE = oldRunE })

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,3 +1,4 @@
+// formatter/formatter.go
 package formatter
 
 import (
@@ -11,9 +12,6 @@ import (
 	internalfs "github.com/hashicorp/hclalign/internal/fs"
 )
 
-// Format formats the given HCL source. It preserves a UTF-8 BOM and newline
-// style while ensuring non-empty files end with exactly one newline.
-// Non-UTF-8 input is rejected and parse errors are returned.
 func Format(src []byte, filename string) ([]byte, error) {
 	hints := internalfs.DetectHintsFromBytes(src)
 	if bom := hints.BOM(); len(bom) > 0 {

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,3 +1,4 @@
+// formatter/formatter_test.go
 package formatter
 
 import (
@@ -5,9 +6,6 @@ import (
 	"testing"
 )
 
-// TestFormatHints verifies that BOMs and newline styles are preserved after
-// formatting. It also checks that the formatted output matches the expected
-// canonical form.
 func TestFormatHints(t *testing.T) {
 	bom := []byte{0xEF, 0xBB, 0xBF}
 	tests := []struct {
@@ -41,8 +39,6 @@ func TestFormatHints(t *testing.T) {
 	}
 }
 
-// TestFormatTrailingNewline ensures that formatter enforces exactly one
-// trailing newline and applies newline hints when adding it.
 func TestFormatTrailingNewline(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -80,7 +76,6 @@ func TestFormatTrailingNewline(t *testing.T) {
 	}
 }
 
-// TestFormatRejectsInvalidUTF8 verifies that non-UTF-8 input is rejected.
 func TestFormatRejectsInvalidUTF8(t *testing.T) {
 	invalid := []byte{0xff, 0xfe, 0xfd}
 	if _, err := Format(invalid, "test.hcl"); err == nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 module github.com/hashicorp/hclalign
 
 go 1.23.0

--- a/internal/align/data.go
+++ b/internal/align/data.go
@@ -1,3 +1,4 @@
+// internal/align/data.go
 package align
 
 import "github.com/hashicorp/hcl/v2/hclwrite"

--- a/internal/align/dynamic.go
+++ b/internal/align/dynamic.go
@@ -1,3 +1,4 @@
+// internal/align/dynamic.go
 package align
 
 import (

--- a/internal/align/lifecycle.go
+++ b/internal/align/lifecycle.go
@@ -1,3 +1,4 @@
+// internal/align/lifecycle.go
 package align
 
 import (

--- a/internal/align/locals.go
+++ b/internal/align/locals.go
@@ -1,3 +1,4 @@
+// internal/align/locals.go
 package align
 
 import (

--- a/internal/align/module.go
+++ b/internal/align/module.go
@@ -1,3 +1,4 @@
+// internal/align/module.go
 package align
 
 import (

--- a/internal/align/output.go
+++ b/internal/align/output.go
@@ -1,3 +1,4 @@
+// internal/align/output.go
 package align
 
 import (

--- a/internal/align/phases_test.go
+++ b/internal/align/phases_test.go
@@ -1,3 +1,4 @@
+// internal/align/phases_test.go
 package align_test
 
 import (

--- a/internal/align/provider.go
+++ b/internal/align/provider.go
@@ -1,3 +1,4 @@
+// internal/align/provider.go
 package align
 
 import (

--- a/internal/align/provisioner.go
+++ b/internal/align/provisioner.go
@@ -1,3 +1,4 @@
+// internal/align/provisioner.go
 package align
 
 import (

--- a/internal/align/reorder.go
+++ b/internal/align/reorder.go
@@ -1,3 +1,4 @@
+// internal/align/reorder.go
 package align
 
 import (
@@ -6,10 +7,6 @@ import (
 	ihcl "github.com/hashicorp/hclalign/internal/hcl"
 )
 
-// reorderBlock reorders attributes in the given block according to order.
-// The order slice should contain all attribute names in their desired final
-// positions. Tokens and comments are preserved using BuildTokens and
-// SetAttributeRaw.
 func reorderBlock(block *hclwrite.Block, order []string) error {
 	body := block.Body()
 	attrs := body.Attributes()

--- a/internal/align/resource.go
+++ b/internal/align/resource.go
@@ -1,3 +1,4 @@
+// internal/align/resource.go
 package align
 
 import (
@@ -18,10 +19,6 @@ func (resourceStrategy) Align(block *hclwrite.Block, opts *Options) error {
 
 func init() { Register(resourceStrategy{}) }
 
-// schemaAwareOrder orders attributes using provider schema information when
-// available. Attributes are grouped as required, optional, computed, meta and
-// unknown. Unknown attributes sort alphabetically after known ones. When opts
-// is nil or opts.Schema is nil, attributes are sorted alphabetically.
 func schemaAwareOrder(block *hclwrite.Block, opts *Options) error {
 	attrs := block.Body().Attributes()
 	names := make([]string, 0, len(attrs))

--- a/internal/align/resource_test.go
+++ b/internal/align/resource_test.go
@@ -1,3 +1,4 @@
+// internal/align/resource_test.go
 package align
 
 import (

--- a/internal/align/schema/loader.go
+++ b/internal/align/schema/loader.go
@@ -1,3 +1,4 @@
+// internal/align/schema/loader.go
 package schema
 
 import (
@@ -13,8 +14,6 @@ import (
 	"github.com/hashicorp/hclalign/internal/align"
 )
 
-// Load reads provider schemas from the given reader and returns a map keyed by
-// resource or data source type.
 func Load(r io.Reader) (map[string]*align.Schema, error) {
 	var root tfSchema
 	dec := json.NewDecoder(r)
@@ -56,7 +55,6 @@ type attribute struct {
 	Computed bool `json:"computed"`
 }
 
-// buildSchema converts a set of attributes to an align.Schema.
 func buildSchema(attrs map[string]attribute) *align.Schema {
 	s := &align.Schema{
 		Required: map[string]struct{}{},
@@ -77,7 +75,6 @@ func buildSchema(attrs map[string]attribute) *align.Schema {
 	return s
 }
 
-// LoadFile loads provider schemas from a JSON file at path.
 func LoadFile(path string) (map[string]*align.Schema, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -87,8 +84,6 @@ func LoadFile(path string) (map[string]*align.Schema, error) {
 	return Load(f)
 }
 
-// FromTerraform invokes `terraform providers schema -json`, writes the output
-// to cachePath and returns the parsed schemas.
 func FromTerraform(ctx context.Context, cachePath string) (map[string]*align.Schema, error) {
 	cmd := exec.CommandContext(ctx, "terraform", "providers", "schema", "-json")
 	out, err := cmd.Output()

--- a/internal/align/schema/loader_test.go
+++ b/internal/align/schema/loader_test.go
@@ -1,3 +1,4 @@
+// internal/align/schema/loader_test.go
 package schema
 
 import (

--- a/internal/align/strategy.go
+++ b/internal/align/strategy.go
@@ -1,24 +1,18 @@
+// internal/align/strategy.go
 package align
 
 import "github.com/hashicorp/hcl/v2/hclwrite"
 
-// Options control how strategies behave.
 type Options struct {
-	// Order defines preferred attribute ordering for certain strategies.
 	Order []string
-	// Strict enforces strict ordering rules.
+
 	Strict bool
-	// Schemas maps resource and data types to provider schema
-	// information. When set, Apply will populate Schema for each
-	// block based on its type and first label.
+
 	Schemas map[string]*Schema
-	// Schema is the schema information for the current block being
-	// processed. It is populated automatically when Schemas is
-	// provided and should not be set directly by callers.
+
 	Schema *Schema
 }
 
-// Schema represents provider attribute schemas grouped by requirement.
 type Schema struct {
 	Required map[string]struct{}
 	Optional map[string]struct{}
@@ -26,22 +20,18 @@ type Schema struct {
 	Meta     map[string]struct{}
 }
 
-// Strategy defines alignment behaviour for a particular block type.
 type Strategy interface {
-	// Name returns block type handled by this strategy.
 	Name() string
-	// Align mutates the given block according to strategy rules.
+
 	Align(block *hclwrite.Block, opts *Options) error
 }
 
 var registry = map[string]Strategy{}
 
-// Register adds s to the registry keyed by its name.
 func Register(s Strategy) {
 	registry[s.Name()] = s
 }
 
-// Apply walks blocks in the given file and applies registered strategies.
 func Apply(file *hclwrite.File, opts *Options) error {
 	if opts == nil {
 		opts = &Options{}
@@ -70,8 +60,6 @@ func applyBody(body *hclwrite.Body, opts *Options) error {
 	return nil
 }
 
-// ReorderAttributes is a backwards compatible helper used by existing code.
-// It simply delegates to Apply with Options.
 func ReorderAttributes(file *hclwrite.File, order []string, strict bool) error {
 	return Apply(file, &Options{Order: order, Strict: strict})
 }

--- a/internal/align/strategy_fuzz_test.go
+++ b/internal/align/strategy_fuzz_test.go
@@ -1,3 +1,4 @@
+// internal/align/strategy_fuzz_test.go
 package align
 
 import (

--- a/internal/align/terraform.go
+++ b/internal/align/terraform.go
@@ -1,3 +1,4 @@
+// internal/align/terraform.go
 package align
 
 import (

--- a/internal/align/variable.go
+++ b/internal/align/variable.go
@@ -1,3 +1,4 @@
+// internal/align/variable.go
 package align
 
 import (
@@ -12,7 +13,6 @@ import (
 	ihcl "github.com/hashicorp/hclalign/internal/hcl"
 )
 
-// variableStrategy implements alignment for `variable` blocks.
 type variableStrategy struct{}
 
 func (variableStrategy) Name() string { return "variable" }
@@ -43,8 +43,6 @@ func (variableStrategy) Align(block *hclwrite.Block, opts *Options) error {
 func init() {
 	Register(variableStrategy{})
 }
-
-// -- original implementation below --
 
 func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet map[string]struct{}, strict bool) error {
 	body := block.Body()

--- a/internal/ci/covercheck/doc.go
+++ b/internal/ci/covercheck/doc.go
@@ -1,3 +1,2 @@
 // internal/ci/covercheck/doc.go
 package main
-

--- a/internal/ci/covercheck/main.go
+++ b/internal/ci/covercheck/main.go
@@ -78,4 +78,3 @@ func main() {
 		os.Exit(1)
 	}
 }
-

--- a/internal/ci/covercheck/main_test.go
+++ b/internal/ci/covercheck/main_test.go
@@ -2,70 +2,70 @@
 package main
 
 import (
-    "os"
-    "os/exec"
-    "path/filepath"
-    "strings"
-    "testing"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
 )
 
 func runCovercheck(t *testing.T) (string, int) {
-    t.Helper()
-    cmd := exec.Command("go", "run", ".")
-    out, err := cmd.CombinedOutput()
-    if err == nil {
-        return string(out), 0
-    }
-    if ee, ok := err.(*exec.ExitError); ok {
-        return string(out), ee.ExitCode()
-    }
-    t.Fatalf("unexpected error: %v", err)
-    return "", 0
+	t.Helper()
+	cmd := exec.Command("go", "run", ".")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return string(out), 0
+	}
+	if ee, ok := err.(*exec.ExitError); ok {
+		return string(out), ee.ExitCode()
+	}
+	t.Fatalf("unexpected error: %v", err)
+	return "", 0
 }
 
 func TestCovercheck(t *testing.T) {
-    tests := []struct {
-        name     string
-        profile  string
-        wantExit int
-        wantMsg  string
-    }{
-        {
-            name:    "above",
-            profile: "mode: set\nfile.go:1.1,1.2 1 1\n",
-            wantExit: 0,
-            wantMsg: "Total coverage: 100.0%",
-        },
-        {
-            name:    "below",
-            profile: "mode: set\nfile.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
-            wantExit: 1,
-            wantMsg: "Coverage 50.0% is below 95.0%",
-        },
-        {
-            name:    "ignored path",
-            profile: "mode: set\ncmd/commentcheck/file.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
-            wantExit: 0,
-            wantMsg: "Total coverage: 100.0%",
-        },
-    }
-    for _, tc := range tests {
-        t.Run(tc.name, func(t *testing.T) {
-            if err := os.MkdirAll(".build", 0755); err != nil {
-                t.Fatalf("mkdir .build: %v", err)
-            }
-            profile := filepath.Join(".build", "coverage.out")
-            if err := os.WriteFile(profile, []byte(tc.profile), 0644); err != nil {
-                t.Fatalf("write profile: %v", err)
-            }
-            defer os.RemoveAll(".build")
-            out, code := runCovercheck(t)
-            if code != tc.wantExit {
-                t.Fatalf("exit %d, want %d; output: %s", code, tc.wantExit, out)
-            }
-            if !strings.Contains(out, tc.wantMsg) {
-                t.Fatalf("output %q does not contain %q", out, tc.wantMsg)
-            }
-        })
-    }
+	tests := []struct {
+		name     string
+		profile  string
+		wantExit int
+		wantMsg  string
+	}{
+		{
+			name:     "above",
+			profile:  "mode: set\nfile.go:1.1,1.2 1 1\n",
+			wantExit: 0,
+			wantMsg:  "Total coverage: 100.0%",
+		},
+		{
+			name:     "below",
+			profile:  "mode: set\nfile.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
+			wantExit: 1,
+			wantMsg:  "Coverage 50.0% is below 95.0%",
+		},
+		{
+			name:     "ignored path",
+			profile:  "mode: set\ncmd/commentcheck/file.go:1.1,1.2 1 0\nfile.go:2.1,2.2 1 1\n",
+			wantExit: 0,
+			wantMsg:  "Total coverage: 100.0%",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.MkdirAll(".build", 0755); err != nil {
+				t.Fatalf("mkdir .build: %v", err)
+			}
+			profile := filepath.Join(".build", "coverage.out")
+			if err := os.WriteFile(profile, []byte(tc.profile), 0644); err != nil {
+				t.Fatalf("write profile: %v", err)
+			}
+			defer os.RemoveAll(".build")
+			out, code := runCovercheck(t)
+			if code != tc.wantExit {
+				t.Fatalf("exit %d, want %d; output: %s", code, tc.wantExit, out)
+			}
+			if !strings.Contains(out, tc.wantMsg) {
+				t.Fatalf("output %q does not contain %q", out, tc.wantMsg)
+			}
+		})
+	}
 }

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -7,13 +7,12 @@ const diffContext = 3
 
 func Unified(fromFile, toFile string, original, styled []byte, eol string) (string, error) {
 	ud := difflib.UnifiedDiff{
-		A:		difflib.SplitLines(string(original)),
-		B:		difflib.SplitLines(string(styled)),
-		FromFile:	fromFile,
-		ToFile:		toFile,
-		Context:	diffContext,
-		Eol:		eol,
+		A:        difflib.SplitLines(string(original)),
+		B:        difflib.SplitLines(string(styled)),
+		FromFile: fromFile,
+		ToFile:   toFile,
+		Context:  diffContext,
+		Eol:      eol,
 	}
 	return difflib.GetUnifiedDiffString(ud)
 }
-

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -38,4 +38,3 @@ func TestUnifiedDiffUsesEOL(t *testing.T) {
 		t.Fatalf("expected CRLF line endings in diff, got: %q", diffStr)
 	}
 }
-

--- a/internal/engine/phases_test.go
+++ b/internal/engine/phases_test.go
@@ -1,3 +1,4 @@
+// internal/engine/phases_test.go
 package engine
 
 import (

--- a/internal/engine/schema.go
+++ b/internal/engine/schema.go
@@ -1,3 +1,4 @@
+// internal/engine/schema.go
 package engine
 
 import (
@@ -9,8 +10,6 @@ import (
 	alignschema "github.com/hashicorp/hclalign/internal/align/schema"
 )
 
-// loadSchemas loads provider schemas based on configuration. It returns nil if
-// no schema options are provided.
 func loadSchemas(ctx context.Context, cfg *config.Config) (map[string]*align.Schema, error) {
 	if cfg.ProvidersSchema == "" && !cfg.UseTerraformSchema {
 		return nil, nil

--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -1,3 +1,4 @@
+// internal/fmt/terraformfmt.go
 package terraformfmt
 
 import (
@@ -19,8 +20,6 @@ const (
 	StrategyGo     Strategy = "go"
 )
 
-// Format formats HCL source using the specified strategy.
-// The filename parameter is used only for parse diagnostics.
 func Format(src []byte, filename, strategy string) ([]byte, error) {
 	switch Strategy(strategy) {
 	case StrategyGo:

--- a/internal/fmt/terraformfmt_test.go
+++ b/internal/fmt/terraformfmt_test.go
@@ -1,3 +1,4 @@
+// internal/fmt/terraformfmt_test.go
 package terraformfmt
 
 import (

--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -37,8 +37,6 @@ func DetectHintsFromBytes(b []byte) Hints {
 	return h
 }
 
-// ReadAllWithHints reads all data from r and detects newline and BOM hints.
-// Any BOM present in the input is stripped from the returned data.
 func ReadAllWithHints(r io.Reader) ([]byte, Hints, error) {
 	raw, err := io.ReadAll(r)
 	if err != nil {
@@ -51,8 +49,6 @@ func ReadAllWithHints(r io.Reader) ([]byte, Hints, error) {
 	return raw, h, nil
 }
 
-// PrepareForParse removes a leading BOM and normalizes CRLF line endings to LF
-// so the returned data is suitable for parsing.
 func PrepareForParse(data []byte, hints Hints) []byte {
 	if bom := hints.BOM(); len(bom) > 0 && bytes.HasPrefix(data, bom) {
 		data = data[len(bom):]
@@ -60,7 +56,6 @@ func PrepareForParse(data []byte, hints Hints) []byte {
 	return bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
 }
 
-// IsStdin reports whether r refers to the process standard input.
 func IsStdin(r io.Reader) bool {
 	if f, ok := r.(*os.File); ok {
 		return f.Fd() == os.Stdin.Fd()
@@ -68,7 +63,6 @@ func IsStdin(r io.Reader) bool {
 	return false
 }
 
-// IsStdout reports whether w refers to the process standard output.
 func IsStdout(w io.Writer) bool {
 	if f, ok := w.(*os.File); ok {
 		return f.Fd() == os.Stdout.Fd()

--- a/internal/fs/atomic_windows_test.go
+++ b/internal/fs/atomic_windows_test.go
@@ -30,4 +30,3 @@ func TestWriteFileAtomicChownIgnored(t *testing.T) {
 		t.Fatalf("WriteFileAtomic: %v", err)
 	}
 }
-

--- a/internal/fs/ewindows_other.go
+++ b/internal/fs/ewindows_other.go
@@ -6,4 +6,3 @@ package fs
 func isErrWindows(err error) bool {
 	return false
 }
-

--- a/internal/fs/ewindows_windows.go
+++ b/internal/fs/ewindows_windows.go
@@ -11,4 +11,3 @@ import (
 func isErrWindows(err error) bool {
 	return errors.Is(err, syscall.EWINDOWS)
 }
-

--- a/internal/fs/hints_test.go
+++ b/internal/fs/hints_test.go
@@ -13,29 +13,29 @@ import (
 func TestDetectHintsFromBytes(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name	string
-		input	[]byte
-		want	Hints
+		name  string
+		input []byte
+		want  Hints
 	}{
 		{
-			name:	"lf",
-			input:	[]byte("one\ntwo\n"),
-			want:	Hints{Newline: "\n"},
+			name:  "lf",
+			input: []byte("one\ntwo\n"),
+			want:  Hints{Newline: "\n"},
 		},
 		{
-			name:	"crlf",
-			input:	[]byte("one\r\ntwo\r\n"),
-			want:	Hints{Newline: "\r\n"},
+			name:  "crlf",
+			input: []byte("one\r\ntwo\r\n"),
+			want:  Hints{Newline: "\r\n"},
 		},
 		{
-			name:	"bom_lf",
-			input:	append(append([]byte{}, utf8BOM...), []byte("one\ntwo\n")...),
-			want:	Hints{HasBOM: true, Newline: "\n"},
+			name:  "bom_lf",
+			input: append(append([]byte{}, utf8BOM...), []byte("one\ntwo\n")...),
+			want:  Hints{HasBOM: true, Newline: "\n"},
 		},
 		{
-			name:	"bom_crlf",
-			input:	append(append([]byte{}, utf8BOM...), []byte("one\r\ntwo\r\n")...),
-			want:	Hints{HasBOM: true, Newline: "\r\n"},
+			name:  "bom_crlf",
+			input: append(append([]byte{}, utf8BOM...), []byte("one\r\ntwo\r\n")...),
+			want:  Hints{HasBOM: true, Newline: "\r\n"},
 		},
 	}
 	for _, tc := range tests {
@@ -52,25 +52,25 @@ func TestDetectHintsFromBytes(t *testing.T) {
 func TestReadFileWithHints(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name		string
-		content		[]byte
-		mode		os.FileMode
-		wantData	[]byte
-		wantHint	Hints
+		name     string
+		content  []byte
+		mode     os.FileMode
+		wantData []byte
+		wantHint Hints
 	}{
 		{
-			name:		"bom_crlf",
-			content:	append(append([]byte{}, utf8BOM...), []byte("one\r\ntwo\r\n")...),
-			mode:		0o600,
-			wantData:	[]byte("one\r\ntwo\r\n"),
-			wantHint:	Hints{HasBOM: true, Newline: "\r\n"},
+			name:     "bom_crlf",
+			content:  append(append([]byte{}, utf8BOM...), []byte("one\r\ntwo\r\n")...),
+			mode:     0o600,
+			wantData: []byte("one\r\ntwo\r\n"),
+			wantHint: Hints{HasBOM: true, Newline: "\r\n"},
 		},
 		{
-			name:		"plain",
-			content:	[]byte("one\ntwo\n"),
-			mode:		0o644,
-			wantData:	[]byte("one\ntwo\n"),
-			wantHint:	Hints{Newline: "\n"},
+			name:     "plain",
+			content:  []byte("one\ntwo\n"),
+			mode:     0o644,
+			wantData: []byte("one\ntwo\n"),
+			wantHint: Hints{Newline: "\n"},
 		},
 	}
 	for _, tc := range tests {
@@ -113,19 +113,19 @@ func TestReadFileWithHintsCanceledContext(t *testing.T) {
 func TestHintsBOM(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name	string
-		hints	Hints
-		want	[]byte
+		name  string
+		hints Hints
+		want  []byte
 	}{
 		{
-			name:	"with_bom",
-			hints:	Hints{HasBOM: true},
-			want:	utf8BOM,
+			name:  "with_bom",
+			hints: Hints{HasBOM: true},
+			want:  utf8BOM,
 		},
 		{
-			name:	"without_bom",
-			hints:	Hints{HasBOM: false},
-			want:	nil,
+			name:  "without_bom",
+			hints: Hints{HasBOM: false},
+			want:  nil,
 		},
 	}
 	for _, tc := range tests {
@@ -144,4 +144,3 @@ func TestHintsBOM(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/hcl/fuzz_tokens_test.go
+++ b/internal/hcl/fuzz_tokens_test.go
@@ -1,3 +1,4 @@
+// internal/hcl/fuzz_tokens_test.go
 package hcl
 
 import (

--- a/internal/hcl/tokens.go
+++ b/internal/hcl/tokens.go
@@ -1,3 +1,4 @@
+// internal/hcl/tokens.go
 package hcl
 
 import (
@@ -7,17 +8,11 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
-// AttrTokens splits an attribute's tokens into leading comment tokens and
-// expression tokens. The resulting slices omit trailing newlines or comments
-// that include a newline so they can be reinserted with SetAttributeRaw.
 type AttrTokens struct {
 	LeadTokens hclwrite.Tokens
 	ExprTokens hclwrite.Tokens
 }
 
-// ExtractAttrTokens returns the leading comment tokens and expression tokens
-// for the given attribute. The returned slices are suitable for reinsertion via
-// SetAttributeRaw.
 func ExtractAttrTokens(attr *hclwrite.Attribute) AttrTokens {
 	toks := attr.BuildTokens(nil)
 	i := 0
@@ -40,8 +35,6 @@ func ExtractAttrTokens(attr *hclwrite.Attribute) AttrTokens {
 	return AttrTokens{LeadTokens: lead, ExprTokens: expr}
 }
 
-// HasTrailingComma reports whether the body tokens contain a trailing comma
-// immediately before the closing brace.
 func HasTrailingComma(tokens hclwrite.Tokens) bool {
 	for i := len(tokens) - 1; i >= 0; i-- {
 		tok := tokens[i]
@@ -62,8 +55,6 @@ func HasTrailingComma(tokens hclwrite.Tokens) bool {
 	return false
 }
 
-// DetectLineEnding inspects tokens and returns the newline sequence used.
-// It defaults to LF if no newline token is found.
 func DetectLineEnding(tokens hclwrite.Tokens) []byte {
 	for _, t := range tokens {
 		if i := bytes.IndexByte(t.Bytes, '\n'); i >= 0 {
@@ -76,9 +67,6 @@ func DetectLineEnding(tokens hclwrite.Tokens) []byte {
 	return []byte{'\n'}
 }
 
-// NormalizeTokens converts CRLF line endings to LF in the provided tokens and
-// strips any UTF-8 BOM from the first token. The returned boolean indicates
-// whether a BOM was removed.
 func NormalizeTokens(tokens hclwrite.Tokens) bool {
 	bom := []byte{0xEF, 0xBB, 0xBF}
 	hasBOM := false
@@ -97,8 +85,6 @@ func NormalizeTokens(tokens hclwrite.Tokens) bool {
 	return hasBOM
 }
 
-// AttributeOrder returns the order of attributes as they originally appear in
-// the body. The attrs map should contain the attributes present in the body.
 func AttributeOrder(body *hclwrite.Body, attrs map[string]*hclwrite.Attribute) []string {
 	tokens := body.BuildTokens(nil)
 	order := make([]string, 0, len(attrs))

--- a/internal/hclalign/benchmark_test.go
+++ b/internal/hclalign/benchmark_test.go
@@ -26,4 +26,3 @@ func BenchmarkReorderAttributes(b *testing.B) {
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary
- drop license comment from go.mod
- strip all Go source comments except path header
- update commentcheck to error on any extra comments and test it

## Testing
- `go run ./cmd/commentcheck --mode=ci`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1dea86f008323ad5bc22295fda832