### PR TITLE
Propagate fs newline hints to diff output

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,18 +1,34 @@
 // internal/diff/diff.go
 package diff
 
-import "github.com/pmezard/go-difflib/difflib"
+import (
+	"strings"
+
+	internalfs "github.com/oferchen/hclalign/internal/fs"
+	"github.com/pmezard/go-difflib/difflib"
+)
 
 const diffContext = 3
 
-func Unified(fromFile, toFile string, original, styled []byte, eol string) (string, error) {
+func Unified(fromFile, toFile string, original, styled []byte, hints internalfs.Hints) (string, error) {
+	if bom := hints.BOM(); len(bom) > 0 {
+		original = append(append([]byte{}, bom...), original...)
+		styled = append(append([]byte{}, bom...), styled...)
+	}
 	ud := difflib.UnifiedDiff{
 		A:        difflib.SplitLines(string(original)),
 		B:        difflib.SplitLines(string(styled)),
 		FromFile: fromFile,
 		ToFile:   toFile,
 		Context:  diffContext,
-		Eol:      eol,
+		Eol:      hints.Newline,
 	}
-	return difflib.GetUnifiedDiffString(ud)
+	out, err := difflib.GetUnifiedDiffString(ud)
+	if err != nil {
+		return "", err
+	}
+	if hints.Newline == "\r\n" && strings.HasSuffix(out, "\n") && !strings.HasSuffix(out, "\r\n") {
+		out = strings.TrimSuffix(out, "\n") + "\r\n"
+	}
+	return out, nil
 }

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -4,12 +4,14 @@ package diff
 import (
 	"strings"
 	"testing"
+
+	internalfs "github.com/oferchen/hclalign/internal/fs"
 )
 
 func TestUnifiedDiff(t *testing.T) {
 	a := []byte("line1\nline2\n")
 	b := []byte("line1\nline3\n")
-	diffStr, err := Unified("a", "a", a, b, "\n")
+	diffStr, err := Unified("a", "a", a, b, internalfs.Hints{Newline: "\n"})
 	if err != nil {
 		t.Fatalf("Unified returned error: %v", err)
 	}
@@ -30,11 +32,32 @@ func TestUnifiedDiff(t *testing.T) {
 func TestUnifiedDiffUsesEOL(t *testing.T) {
 	a := []byte("line1\r\nline2\r\n")
 	b := []byte("line1\r\nline3\r\n")
-	diffStr, err := Unified("a", "a", a, b, "\r\n")
+	diffStr, err := Unified("a", "a", a, b, internalfs.Hints{Newline: "\r\n"})
 	if err != nil {
 		t.Fatalf("Unified returned error: %v", err)
 	}
 	if !strings.Contains(diffStr, "-line2\r\n+line3\r\n") {
 		t.Fatalf("expected CRLF line endings in diff, got: %q", diffStr)
+	}
+}
+
+func TestUnifiedDiffCRLFExact(t *testing.T) {
+	a := []byte("line1\r\nline2\r\n")
+	b := []byte("line1\r\nline3\r\n")
+	diffStr, err := Unified("a", "a", a, b, internalfs.Hints{Newline: "\r\n"})
+	if err != nil {
+		t.Fatalf("Unified returned error: %v", err)
+	}
+	expected := strings.Join([]string{
+		"--- a",
+		"+++ a",
+		"@@ -1,3 +1,3 @@",
+		" line1",
+		"-line2",
+		"+line3",
+		" ",
+	}, "\r\n") + "\r\n"
+	if diffStr != expected {
+		t.Fatalf("unexpected diff:\n%q\nexpected:\n%q", diffStr, expected)
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -117,7 +117,7 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 	switch cfg.Mode {
 	case config.ModeDiff:
 		if changed {
-			text, err := diff.Unified("stdin", "stdin", original, styled, hints.Newline)
+			text, err := diff.Unified("stdin", "stdin", original, styled, hints)
 			if err != nil {
 				return false, err
 			}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -128,7 +128,7 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.WriteFile(f, inb, 0o644))
 
 				hints := internalfs.DetectHintsFromBytes(inb)
-				diffText, err := diff.Unified(f, f, inb, outb, hints.Newline)
+				diffText, err := diff.Unified(f, f, inb, outb, hints)
 				require.NoError(t, err)
 
 				cfg := &config.Config{

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -183,7 +183,7 @@ func processFile(ctx context.Context, filePath string, cfg *config.Config, schem
 		}
 	case config.ModeDiff:
 		if changed {
-			text, err := diff.Unified(filePath, filePath, original, styled, hints.Newline)
+			text, err := diff.Unified(filePath, filePath, original, styled, hints)
 			if err != nil {
 				return false, nil, err
 			}

--- a/internal/engine/process_reader_test.go
+++ b/internal/engine/process_reader_test.go
@@ -51,7 +51,7 @@ func TestProcessReaderModeDiff(t *testing.T) {
 	require.True(t, changed)
 
 	hints := internalfs.DetectHintsFromBytes([]byte(input))
-	diffText, err := diff.Unified("stdin", "stdin", []byte(input), []byte(styled), hints.Newline)
+	diffText, err := diff.Unified("stdin", "stdin", []byte(input), []byte(styled), hints)
 	require.NoError(t, err)
 	require.Equal(t, diffText, out.String())
 }
@@ -82,7 +82,7 @@ func TestProcessReaderModeCheckNoChange(t *testing.T) {
 	require.Equal(t, input, out.String())
 
 	hints := internalfs.DetectHintsFromBytes([]byte(input))
-	diffText, err := diff.Unified("stdin", "stdin", []byte(input), out.Bytes(), hints.Newline)
+	diffText, err := diff.Unified("stdin", "stdin", []byte(input), out.Bytes(), hints)
 	require.NoError(t, err)
 	require.Empty(t, diffText)
 }

--- a/internal/engine/scan_test.go
+++ b/internal/engine/scan_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/hashicorp/hclalign/config"
+	"github.com/oferchen/hclalign/config"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
## Summary
- ensure diff.Unified respects BOM and newline hints when constructing output
- forward fs hints to diff generation
- test CRLF diff output

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1eb9d0164832390d9cd70a2428bae