### PR TITLE
Add provider schema fixtures and default exclude tests

### DIFF
--- a/internal/align/resource_test.go
+++ b/internal/align/resource_test.go
@@ -1,11 +1,14 @@
 // internal/align/resource_test.go
-package align
+package align_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	alignpkg "github.com/oferchen/hclalign/internal/align"
+	alignschema "github.com/oferchen/hclalign/internal/align/schema"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,15 +25,15 @@ func TestSchemaAwareOrder(t *testing.T) {
 	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
 	require.False(t, diags.HasErrors())
 
-	sch := &Schema{
+	sch := &alignpkg.Schema{
 		Required: map[string]struct{}{"foo": {}},
 		Optional: map[string]struct{}{"bar": {}},
 		Computed: map[string]struct{}{"baz": {}},
 		Meta:     map[string]struct{}{"provider": {}, "depends_on": {}, "count": {}, "for_each": {}},
 	}
-	schemas := map[string]*Schema{"test_thing": sch}
+	schemas := map[string]*alignpkg.Schema{"test_thing": sch}
 
-	require.NoError(t, Apply(file, &Options{Schemas: schemas}))
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{Schemas: schemas}))
 
 	got := string(file.Bytes())
 	exp := `resource "test_thing" "ex" {
@@ -40,6 +43,43 @@ func TestSchemaAwareOrder(t *testing.T) {
   depends_on = []
   provider   = "p"
   random     = 4
+}`
+	require.Equal(t, exp, got)
+}
+
+func TestProviderSchemaResourceOrdering(t *testing.T) {
+	path := filepath.Join("..", "..", "tests", "testdata", "providers-schema.json")
+	schemas, err := alignschema.LoadFile(path)
+	require.NoError(t, err)
+
+	src := []byte(`resource "aws_s3_bucket" "b" {
+  tags   = {}
+  id     = "id"
+  bucket = "b"
+  acl    = "private"
+}
+
+resource "null_resource" "n" {
+  id       = "nid"
+  triggers = {}
+}`)
+
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{Schemas: schemas}))
+
+	got := string(file.Bytes())
+	exp := `resource "aws_s3_bucket" "b" {
+  bucket = "b"
+  acl    = "private"
+  tags   = {}
+  id     = "id"
+}
+
+resource "null_resource" "n" {
+  triggers = {}
+  id       = "nid"
 }`
 	require.Equal(t, exp, got)
 }

--- a/internal/engine/process_reader_test.go
+++ b/internal/engine/process_reader_test.go
@@ -88,8 +88,6 @@ func TestProcessReaderModeCheckNoChange(t *testing.T) {
 }
 
 func TestProcessPrintsDelimiters(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	f1 := filepath.Join(dir, "a.tf")
 	f2 := filepath.Join(dir, "b.tf")

--- a/internal/engine/scan_test.go
+++ b/internal/engine/scan_test.go
@@ -13,17 +13,11 @@ import (
 func TestScanDefaultExcludeDirectories(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	// root tf file
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(""), 0o644))
+	dir := filepath.Join("..", "..", "tests", "cases", "default_excludes")
 
-	// create default excluded directories each with a tf file
-	excluded := []string{".terraform", "vendor", ".git", "node_modules"}
-	for _, d := range excluded {
-		sub := filepath.Join(dir, d)
-		require.NoError(t, os.MkdirAll(sub, 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(sub, "ignored.tf"), []byte(""), 0o644))
-	}
+	gitDir := filepath.Join(dir, ".git")
+	require.NoError(t, os.MkdirAll(gitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(gitDir, "ignored.tf"), []byte(""), 0o644))
 
 	cfg := &config.Config{
 		Target:  dir,

--- a/tests/cases/default_excludes/.terraform/ignored.tf
+++ b/tests/cases/default_excludes/.terraform/ignored.tf
@@ -1,0 +1,1 @@
+variable "ignored" {}

--- a/tests/cases/default_excludes/main.tf
+++ b/tests/cases/default_excludes/main.tf
@@ -1,0 +1,1 @@
+variable "example" {}

--- a/tests/cases/default_excludes/node_modules/ignored.tf
+++ b/tests/cases/default_excludes/node_modules/ignored.tf
@@ -1,0 +1,1 @@
+variable "ignored" {}

--- a/tests/cases/default_excludes/vendor/ignored.tf
+++ b/tests/cases/default_excludes/vendor/ignored.tf
@@ -1,0 +1,1 @@
+variable "ignored" {}

--- a/tests/cases/resource/aligned.tf
+++ b/tests/cases/resource/aligned.tf
@@ -2,4 +2,10 @@ resource "aws_s3_bucket" "b" {
   bucket = "b"
   acl    = "private"
   tags   = {}
+  id     = "id"
+}
+
+resource "null_resource" "n" {
+  triggers = {}
+  id       = "nid"
 }

--- a/tests/cases/resource/fmt.tf
+++ b/tests/cases/resource/fmt.tf
@@ -1,5 +1,11 @@
 resource "aws_s3_bucket" "b" {
   tags   = {}
+  id     = "id"
   bucket = "b"
   acl    = "private"
+}
+
+resource "null_resource" "n" {
+  id       = "nid"
+  triggers = {}
 }

--- a/tests/cases/resource/in.tf
+++ b/tests/cases/resource/in.tf
@@ -1,5 +1,11 @@
 resource "aws_s3_bucket" "b" {
   tags   = {}
+  id     = "id"
   bucket = "b"
   acl    = "private"
+}
+
+resource "null_resource" "n" {
+  id       = "nid"
+  triggers = {}
 }

--- a/tests/testdata/providers-schema.json
+++ b/tests/testdata/providers-schema.json
@@ -7,7 +7,8 @@
             "attributes": {
               "bucket": {"required": true},
               "acl": {"optional": true},
-              "tags": {"optional": true}
+              "tags": {"optional": true},
+              "id": {"computed": true}
             }
           }
         }
@@ -28,7 +29,8 @@
         "null_resource": {
           "block": {
             "attributes": {
-              "triggers": {"optional": true}
+              "triggers": {"optional": true},
+              "id": {"computed": true}
             }
           }
         }


### PR DESCRIPTION
## Summary
- add fixtures and test to ensure default excluded dirs like `.terraform` and `.git` are skipped
- provide provider schema JSON for `aws` and `null` and test ordering of required/optional/computed attributes
- stabilize delimiter tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1ef216ba08323a55d1186ab166e50