### PR TITLE
Group module attributes by category

### DIFF
--- a/tests/cases/module/aligned.tf
+++ b/tests/cases/module/aligned.tf
@@ -2,3 +2,26 @@ module "m" {
   source  = "./m"
   version = "1.0"
 }
+
+module "complex" {
+  source     = "./complex"
+  version    = "1.0"
+  providers  = {}
+  count      = 1
+  for_each   = {}
+  depends_on = []
+  a          = 1
+  b          = 2
+  c          = 3
+  z          = 0
+
+  foo {
+    x = 1
+  }
+}
+
+module "vars_only" {
+  a = 1
+  b = 2
+  c = 3
+}

--- a/tests/cases/module/fmt.tf
+++ b/tests/cases/module/fmt.tf
@@ -2,3 +2,26 @@ module "m" {
   version = "1.0"
   source  = "./m"
 }
+
+module "complex" {
+  z          = 0
+  for_each   = {}
+  source     = "./complex"
+  providers  = {}
+  depends_on = []
+  version    = "1.0"
+  count      = 1
+  a          = 1
+  c          = 3
+  b          = 2
+
+  foo {
+    x = 1
+  }
+}
+
+module "vars_only" {
+  c = 3
+  b = 2
+  a = 1
+}

--- a/tests/cases/module/in.tf
+++ b/tests/cases/module/in.tf
@@ -2,3 +2,26 @@ module "m" {
   version = "1.0"
   source  = "./m"
 }
+
+module "complex" {
+  z          = 0
+  for_each   = {}
+  source     = "./complex"
+  providers  = {}
+  depends_on = []
+  version    = "1.0"
+  count      = 1
+  a          = 1
+  c          = 3
+  b          = 2
+
+  foo {
+    x = 1
+  }
+}
+
+module "vars_only" {
+  c = 3
+  b = 2
+  a = 1
+}

--- a/tests/cases/module/out.tf
+++ b/tests/cases/module/out.tf
@@ -2,3 +2,26 @@ module "m" {
   source  = "./m"
   version = "1.0"
 }
+
+module "complex" {
+  source     = "./complex"
+  version    = "1.0"
+  providers  = {}
+  count      = 1
+  for_each   = {}
+  depends_on = []
+  a          = 1
+  b          = 2
+  c          = 3
+  z          = 0
+
+  foo {
+    x = 1
+  }
+}
+
+module "vars_only" {
+  a = 1
+  b = 2
+  c = 3
+}


### PR DESCRIPTION
## Summary
- group module attributes into source, version, providers, meta-args, input variables, and remaining attributes/blocks
- expand module golden tests with meta-args and variable-only scenarios

## Testing
- `go test ./internal/align -run TestGolden -count=1`
- `go test ./internal/align -run TestPhases/module -count=1`
- `go test ./internal/engine -run TestPhases/module -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1f1ba25448323a8c62bbf13a55501