### PR TITLE
Order output attributes by canonical preference

### DIFF
--- a/tests/cases/non_variable/out.tf
+++ b/tests/cases/non_variable/out.tf
@@ -19,8 +19,8 @@ module "m" {
 }
 
 output "o" {
-  a = 2
   b = 1
+  a = 2
 }
 
 locals {

--- a/tests/cases/output/aligned.tf
+++ b/tests/cases/output/aligned.tf
@@ -1,5 +1,23 @@
 output "example" {
   description = "desc"
-  sensitive   = true
   value       = var.a
+  sensitive   = true
+}
+
+output "unknown" {
+  description = "other"
+  value       = var.b
+  foo         = "bar"
+  baz         = "qux"
+}
+
+output "depends" {
+  value      = var.c
+  depends_on = [var.x]
+}
+
+output "already" {
+  description = "foo"
+  value       = var.foo
+  sensitive   = false
 }

--- a/tests/cases/output/fmt.tf
+++ b/tests/cases/output/fmt.tf
@@ -3,3 +3,21 @@ output "example" {
   sensitive   = true
   description = "desc"
 }
+
+output "unknown" {
+  foo         = "bar"
+  description = "other"
+  value       = var.b
+  baz         = "qux"
+}
+
+output "depends" {
+  depends_on = [var.x]
+  value      = var.c
+}
+
+output "already" {
+  description = "foo"
+  value       = var.foo
+  sensitive   = false
+}

--- a/tests/cases/output/in.tf
+++ b/tests/cases/output/in.tf
@@ -3,3 +3,21 @@ output "example" {
   sensitive   = true
   description = "desc"
 }
+
+output "unknown" {
+  foo         = "bar"
+  description = "other"
+  value       = var.b
+  baz         = "qux"
+}
+
+output "depends" {
+  depends_on  = [var.x]
+  value       = var.c
+}
+
+output "already" {
+  description = "foo"
+  value       = var.foo
+  sensitive   = false
+}

--- a/tests/cases/output/out.tf
+++ b/tests/cases/output/out.tf
@@ -1,5 +1,23 @@
 output "example" {
   description = "desc"
-  sensitive   = true
   value       = var.a
+  sensitive   = true
+}
+
+output "unknown" {
+  description = "other"
+  value       = var.b
+  foo         = "bar"
+  baz         = "qux"
+}
+
+output "depends" {
+  value      = var.c
+  depends_on = [var.x]
+}
+
+output "already" {
+  description = "foo"
+  value       = var.foo
+  sensitive   = false
 }


### PR DESCRIPTION
## Summary
- order output attributes using canonical list and keep unknowns in original order
- expand output test cases to cover multiple attribute combos and idempotency
- adjust non-variable fixture for new output ordering

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1f4867a1483239b72bf4cfc1cf3c3