### PR TITLE
Prioritize alias in provider blocks

### DIFF
--- a/internal/align/provider.go
+++ b/internal/align/provider.go
@@ -14,10 +14,22 @@ func (providerStrategy) Name() string { return "provider" }
 func (providerStrategy) Align(block *hclwrite.Block, _ *Options) error {
 	attrs := block.Body().Attributes()
 	names := make([]string, 0, len(attrs))
-	for name := range attrs {
-		names = append(names, name)
+
+	// Ensure alias is first if present
+	if _, ok := attrs["alias"]; ok {
+		names = append(names, "alias")
 	}
-	sort.Strings(names)
+
+	others := make([]string, 0, len(attrs))
+	for name := range attrs {
+		if name == "alias" {
+			continue
+		}
+		others = append(others, name)
+	}
+	sort.Strings(others)
+	names = append(names, others...)
+
 	return reorderBlock(block, names)
 }
 

--- a/tests/cases/provider/aligned.tf
+++ b/tests/cases/provider/aligned.tf
@@ -1,4 +1,15 @@
 provider "aws" {
-  alias  = "east"
+  # alias comment
+  alias = "east"
+  # access key comment
+  access_key = "foo"
+  # region comment
   region = "us-east-1"
+  # secret key comment
+  secret_key = "bar"
+
+  # assume role block
+  assume_role {
+    role_arn = "arn:aws:iam::123456789012:role/test"
+  }
 }

--- a/tests/cases/provider/fmt.tf
+++ b/tests/cases/provider/fmt.tf
@@ -1,4 +1,15 @@
 provider "aws" {
+  # region comment
   region = "us-east-1"
-  alias  = "east"
+  # access key comment
+  access_key = "foo"
+  # secret key comment
+  secret_key = "bar"
+  # alias comment
+  alias = "east"
+
+  # assume role block
+  assume_role {
+    role_arn = "arn:aws:iam::123456789012:role/test"
+  }
 }

--- a/tests/cases/provider/in.tf
+++ b/tests/cases/provider/in.tf
@@ -1,4 +1,15 @@
 provider "aws" {
+  # region comment
   region = "us-east-1"
-  alias  = "east"
+  # access key comment
+  access_key = "foo"
+  # secret key comment
+  secret_key = "bar"
+  # alias comment
+  alias = "east"
+
+  # assume role block
+  assume_role {
+    role_arn = "arn:aws:iam::123456789012:role/test"
+  }
 }

--- a/tests/cases/provider/out.tf
+++ b/tests/cases/provider/out.tf
@@ -1,4 +1,15 @@
 provider "aws" {
-  alias  = "east"
+  # alias comment
+  alias = "east"
+  # access key comment
+  access_key = "foo"
+  # region comment
   region = "us-east-1"
+  # secret key comment
+  secret_key = "bar"
+
+  # assume role block
+  assume_role {
+    role_arn = "arn:aws:iam::123456789012:role/test"
+  }
 }


### PR DESCRIPTION
## Summary
- ensure provider strategy places `alias` first and sorts remaining attributes
- add provider golden tests covering alias ordering and comment preservation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1f669748c8323b815374861a451ea