### PR TITLE
Sort terraform blocks and required provider entries

### DIFF
--- a/internal/align/terraform.go
+++ b/internal/align/terraform.go
@@ -3,6 +3,7 @@ package align
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
@@ -11,13 +12,52 @@ type terraformStrategy struct{}
 
 func (terraformStrategy) Name() string { return "terraform" }
 
+// Align orders attributes and nested blocks within a terraform block. Attributes
+// are sorted alphabetically. Nested blocks are sorted by type and labels while
+// preserving the ordering of their contents. If a required_providers block is
+// present, the provider entries inside it are also sorted alphabetically.
 func (terraformStrategy) Align(block *hclwrite.Block, _ *Options) error {
-	attrs := block.Body().Attributes()
+	body := block.Body()
+
+	// Sort provider entries within required_providers blocks
+	for _, nb := range body.Blocks() {
+		if nb.Type() == "required_providers" {
+			attrs := nb.Body().Attributes()
+			names := make([]string, 0, len(attrs))
+			for name := range attrs {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			if err := reorderBlock(nb, names); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Order top-level blocks by type then labels
+	blocks := body.Blocks()
+	sort.SliceStable(blocks, func(i, j int) bool {
+		bi, bj := blocks[i], blocks[j]
+		if bi.Type() != bj.Type() {
+			return bi.Type() < bj.Type()
+		}
+		return strings.Join(bi.Labels(), "\x00") < strings.Join(bj.Labels(), "\x00")
+	})
+	for _, b := range body.Blocks() {
+		body.RemoveBlock(b)
+	}
+	for _, b := range blocks {
+		body.AppendBlock(b)
+	}
+
+	// Gather and order attributes
+	attrs := body.Attributes()
 	names := make([]string, 0, len(attrs))
 	for name := range attrs {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+
 	return reorderBlock(block, names)
 }
 

--- a/tests/cases/terraform/aligned.tf
+++ b/tests/cases/terraform/aligned.tf
@@ -1,4 +1,22 @@
 terraform {
-  backend          = "local"
   required_version = ">= 1.0"
+
+  backend "s3" {
+    region = "us-east-1"
+  }
+
+  cloud {
+    organization = "hashicorp"
+  }
+
+  required_providers {
+    aws = {
+      version = "~> 4.0"
+      source  = "hashicorp/aws"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
 }

--- a/tests/cases/terraform/fmt.tf
+++ b/tests/cases/terraform/fmt.tf
@@ -1,4 +1,22 @@
 terraform {
+  cloud {
+    organization = "hashicorp"
+  }
+
   required_version = ">= 1.0"
-  backend          = "local"
+
+  backend "s3" {
+    region = "us-east-1"
+  }
+
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    aws = {
+      version = "~> 4.0"
+      source  = "hashicorp/aws"
+    }
+  }
 }

--- a/tests/cases/terraform/in.tf
+++ b/tests/cases/terraform/in.tf
@@ -1,4 +1,22 @@
 terraform {
+  cloud {
+    organization = "hashicorp"
+  }
+
   required_version = ">= 1.0"
-  backend = "local"
+
+  backend "s3" {
+    region = "us-east-1"
+  }
+
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    aws = {
+      version = "~> 4.0"
+      source  = "hashicorp/aws"
+    }
+  }
 }

--- a/tests/cases/terraform/out.tf
+++ b/tests/cases/terraform/out.tf
@@ -1,4 +1,22 @@
 terraform {
-  backend          = "local"
   required_version = ">= 1.0"
+
+  backend "s3" {
+    region = "us-east-1"
+  }
+
+  cloud {
+    organization = "hashicorp"
+  }
+
+  required_providers {
+    aws = {
+      version = "~> 4.0"
+      source  = "hashicorp/aws"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- order attributes, blocks, and required_providers entries in terraform blocks
- expand terraform test case to cover nested blocks and idempotency

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1f821d7648323a63950182cde0702