### PR TITLE
Allow //go:build lines in comment check

### DIFF
--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -35,13 +35,17 @@ func check(root string) error {
 		if err != nil {
 			return err
 		}
+		var nonBuild []token.Position
 		for _, cg := range file.Comments {
 			for _, c := range cg.List {
-				if fset.Position(c.Slash).Line > 1 {
-					bad = append(bad, path)
-					return nil
+				if strings.HasPrefix(c.Text, "//go:build") {
+					continue
 				}
+				nonBuild = append(nonBuild, fset.Position(c.Slash))
 			}
+		}
+		if len(nonBuild) != 1 || nonBuild[0].Line != 1 {
+			bad = append(bad, path)
 		}
 		return nil
 	}

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -10,14 +10,21 @@ import (
 func TestCheck(t *testing.T) {
 	t.Run("compliant", func(t *testing.T) {
 		dir := t.TempDir()
-		write(t, dir, "ok.go", "// ok.go\npackage main\n")
+		write(t, dir, "ok.go", "// ok.go\n//go:build test\n\npackage main\n")
 		if err := check(dir); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
-	t.Run("noncompliant", func(t *testing.T) {
+	t.Run("noncompliant extra comment", func(t *testing.T) {
 		dir := t.TempDir()
-		write(t, dir, "bad.go", "// bad.go\npackage main\n// bad\n")
+		write(t, dir, "bad.go", "// bad.go\n//go:build test\n\npackage main\n// bad\n")
+		if err := check(dir); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+	t.Run("noncompliant missing comment", func(t *testing.T) {
+		dir := t.TempDir()
+		write(t, dir, "bad.go", "//go:build test\n\npackage main\n")
 		if err := check(dir); err == nil {
 			t.Fatalf("expected error")
 		}

--- a/internal/fs/ewindows_other.go
+++ b/internal/fs/ewindows_other.go
@@ -1,6 +1,6 @@
+// internal/fs/ewindows_other.go
 //go:build !windows
 
-// internal/fs/ewindows_other.go
 package fs
 
 func isErrWindows(err error) bool {

--- a/internal/fs/ewindows_windows.go
+++ b/internal/fs/ewindows_windows.go
@@ -1,6 +1,6 @@
+// internal/fs/ewindows_windows.go
 //go:build windows
 
-// internal/fs/ewindows_windows.go
 package fs
 
 import (

--- a/internal/fs/stdio.go
+++ b/internal/fs/stdio.go
@@ -1,3 +1,4 @@
+// internal/fs/stdio.go
 package fs
 
 import "io"


### PR DESCRIPTION
## Summary
- document path for internal/fs/stdio.go
- keep filename comments before build tags in Windows helpers
- ignore //go:build directives when enforcing single banner comment
- cover build-tag scenarios in commentcheck tests

## Testing
- `go mod tidy`
- `golangci-lint run --timeout=5m`
- `go test ./... -shuffle=on -cover -covermode=atomic -coverprofile=./.build/coverage.out`
- `go run ./internal/ci/covercheck` *(fails: coverage 79.5% is below 95%)*
- `go build -trimpath -buildvcs=false -ldflags="-s -w" -o ./.build/hclalign ./cmd/hclalign`
- `go run ./cmd/commentcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b20b66c17c83238e6d3d659280594c