### PR TITLE
chore: update CI workflow with nocomments and coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,16 @@ jobs:
           cache: true
       - run: make tidy
       - run: make fmt
+      - run: make nocomments
       - run: make lint
-      - run: make commentcheck
+      - run: make vet
       - name: Vulnerability check
         run: make vuln
         continue-on-error: true
-      - run: make test
       - run: make test-race
       - run: make cover
+        env:
+          COVER_THRESH: 95
       - run: make build
 
   terraform-fmt:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GO ?= go
 FMT_PKGS := $(shell $(GO) list $(PKG))
 FMT_DIRS := $(shell $(GO) list -f '{{.Dir}}' $(PKG))
 
-.PHONY: all init tidy fmt lint vet vuln commentcheck test test-race cover cover-html build ci clean
+.PHONY: all init tidy fmt lint vet vuln nocomments test test-race cover cover-html build ci clean
 
 all: build
 
@@ -28,7 +28,7 @@ lint:
 	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	golangci-lint run --timeout=5m
 
-commentcheck:
+nocomments:
 	$(GO) run ./cmd/commentcheck
 
 vet:
@@ -55,7 +55,7 @@ build:
 vuln:
 	$(GO) run golang.org/x/vuln/cmd/govulncheck@latest $(PKG)
 
-ci: tidy fmt lint vuln commentcheck test cover build
+ci: tidy fmt nocomments lint vet vuln test-race cover build
 
 clean:
 	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
## Summary
- run `make nocomments` after formatting and add vet and race targets
- gate coverage with `COVER_THRESH` env var in CI
- provide `nocomments` target and update CI recipe in Makefile

## Testing
- `make nocomments`
- `make lint`
- `make vet`
- `make test-race`
- `COVER_THRESH=95 make cover` *(fails: Coverage 80.9% is below 95.0%)*

------
https://chatgpt.com/codex/tasks/task_e_68b215d4c7f88323b0dbc98445275fc7