### PR TITLE
align: sort provider nested blocks

### DIFF
--- a/tests/cases/provider/aligned.tf
+++ b/tests/cases/provider/aligned.tf
@@ -12,4 +12,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::123456789012:role/test"
   }
+
+  # nested a comment
+  nested "a" {
+    v = 1
+  }
+
+  # nested b comment
+  nested "b" {
+    v = 2
+  }
 }

--- a/tests/cases/provider/fmt.tf
+++ b/tests/cases/provider/fmt.tf
@@ -8,8 +8,18 @@ provider "aws" {
   # alias comment
   alias = "east"
 
+  # nested b comment
+  nested "b" {
+    v = 2
+  }
+
   # assume role block
   assume_role {
     role_arn = "arn:aws:iam::123456789012:role/test"
+  }
+
+  # nested a comment
+  nested "a" {
+    v = 1
   }
 }

--- a/tests/cases/provider/in.tf
+++ b/tests/cases/provider/in.tf
@@ -8,8 +8,18 @@ provider "aws" {
   # alias comment
   alias = "east"
 
+  # nested b comment
+  nested "b" {
+    v = 2
+  }
+
   # assume role block
   assume_role {
     role_arn = "arn:aws:iam::123456789012:role/test"
+  }
+
+  # nested a comment
+  nested "a" {
+    v = 1
   }
 }

--- a/tests/cases/provider/out.tf
+++ b/tests/cases/provider/out.tf
@@ -12,4 +12,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::123456789012:role/test"
   }
+
+  # nested a comment
+  nested "a" {
+    v = 1
+  }
+
+  # nested b comment
+  nested "b" {
+    v = 2
+  }
 }


### PR DESCRIPTION
## Summary
- sort provider nested blocks by type then labels
- add golden test for nested block ordering

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b21ab5d86483238808bb806a494677