### PR TITLE
refactor: drop terraform experiments

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -67,7 +67,7 @@ Non-negotiables:
     * `locals`: **no reordering** (fmt only)
     * `module`: `source, version, providers, count, for_each, depends_on, <inputs alpha>, <other>`
     * `provider`: `alias, <config attrs alpha>, <blocks>`
-    * `terraform`: `required_version, required_providers(alpha), experiments, cloud, backend, <other>`
+    * `terraform`: `required_version, required_providers(alpha), backend, cloud, <other>`
     * `resource/data`: meta-args first `provider, count, for_each, depends_on, lifecycle, provisioner*`, then **schema-driven** tiers: required → optional → computed (each alpha). Fallback to alpha when schema unknown.
   * Move **attributes** only; keep nested blocks & their order unless explicitly defined.
   * Use `BuildTokens(nil)` + `SetAttributeRaw`; never rebuild expressions.

--- a/internal/align/strict_error_test.go
+++ b/internal/align/strict_error_test.go
@@ -62,7 +62,7 @@ func TestStrictOrderRejectsUnknownAttributes(t *testing.T) {
 		},
 		{
 			name: "terraform",
-			src:  "terraform {\n  required_version = \"1.0\"\n  required_providers {}\n  experiments       = []\n  cloud {}\n  backend \"local\" {}\n  foo = 1\n}",
+			src:  "terraform {\n  required_version = \"1.0\"\n  required_providers {}\n  backend \"local\" {}\n  cloud {}\n  foo = 1\n}",
 		},
 		{
 			name: "dynamic",

--- a/internal/align/terraform.go
+++ b/internal/align/terraform.go
@@ -39,7 +39,7 @@ func (terraformStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrs := body.Attributes()
 	blocks := body.Blocks()
 
-	canonical := []string{"required_version", "required_providers", "experiments", "cloud", "backend"}
+	canonical := []string{"required_version", "required_providers", "backend", "cloud"}
 	canonSet := make(map[string]struct{}, len(canonical))
 	for _, n := range canonical {
 		canonSet[n] = struct{}{}
@@ -119,7 +119,7 @@ func (terraformStrategy) Align(block *hclwrite.Block, opts *Options) error {
 
 	otherAttrNames := make([]string, 0, len(attrTokens))
 	for name := range attrTokens {
-		if name != "required_version" && name != "experiments" {
+		if name != "required_version" {
 			otherAttrNames = append(otherAttrNames, name)
 		}
 	}
@@ -138,14 +138,11 @@ func (terraformStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	if reqProviders != nil {
 		items = append(items, item{block: reqProviders})
 	}
-	if _, ok := attrTokens["experiments"]; ok {
-		items = append(items, item{name: "experiments", isAttr: true})
+	if backendBlock != nil {
+		items = append(items, item{block: backendBlock})
 	}
 	if cloudBlock != nil {
 		items = append(items, item{block: cloudBlock})
-	}
-	if backendBlock != nil {
-		items = append(items, item{block: backendBlock})
 	}
 	for _, name := range otherAttrNames {
 		items = append(items, item{name: name, isAttr: true})

--- a/tests/cases/terraform/aligned.tf
+++ b/tests/cases/terraform/aligned.tf
@@ -12,11 +12,11 @@ terraform {
     }
   }
 
-  cloud {
-    organization = "hashicorp"
-  }
-
   backend "s3" {
     region = "us-east-1"
+  }
+
+  cloud {
+    organization = "hashicorp"
   }
 }

--- a/tests/cases/terraform/out.tf
+++ b/tests/cases/terraform/out.tf
@@ -12,11 +12,11 @@ terraform {
     }
   }
 
-  cloud {
-    organization = "hashicorp"
-  }
-
   backend "s3" {
     region = "us-east-1"
+  }
+
+  cloud {
+    organization = "hashicorp"
   }
 }


### PR DESCRIPTION
## Summary
- update terraform canonical ordering to `required_version`, `required_providers`, `backend`, `cloud`
- remove handling/tests for `experiments`
- refresh terraform fixtures

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b21c6373788323a8577ec33200b715