### PR TITLE
chore: strip extraneous comments

### DIFF
--- a/internal/align/provider.go
+++ b/internal/align/provider.go
@@ -37,7 +37,6 @@ func (providerStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrs := body.Attributes()
 	names := make([]string, 0, len(attrs))
 
-	// Ensure alias is first if present
 	if _, ok := attrs["alias"]; ok {
 		names = append(names, "alias")
 	}

--- a/internal/align/terraform.go
+++ b/internal/align/terraform.go
@@ -15,10 +15,6 @@ type terraformStrategy struct{}
 
 func (terraformStrategy) Name() string { return "terraform" }
 
-// Align orders attributes and nested blocks within a terraform block. Attributes
-// are sorted alphabetically. Nested blocks are sorted by type and labels while
-// preserving the ordering of their contents. If a required_providers block is
-// present, the provider entries inside it are also sorted alphabetically.
 func (terraformStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	body := block.Body()
 

--- a/internal/fs/stdio.go
+++ b/internal/fs/stdio.go
@@ -3,8 +3,6 @@ package fs
 
 import "io"
 
-// WriteAllWithHints applies the provided hints to data and writes the result
-// to w.
 func WriteAllWithHints(w io.Writer, data []byte, hints Hints) error {
 	content := ApplyHints(data, hints)
 	_, err := w.Write(content)


### PR DESCRIPTION
## Summary
- prune non-banner comments from internal fs and align modules

## Testing
- `make tidy`
- `make lint`
- `make test`
- `make cover` *(fails: coverage 75.9% < 95%)*
- `make build`
- `go run ./cmd/commentcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b22508459c832388066e7943fb6da6