### PR TITLE
Add connection align strategy with strict validation

### DIFF
--- a/internal/align/connection.go
+++ b/internal/align/connection.go
@@ -1,0 +1,58 @@
+// internal/align/connection.go
+package align
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+type connectionStrategy struct{}
+
+func (connectionStrategy) Name() string { return "connection" }
+
+func (connectionStrategy) Align(block *hclwrite.Block, opts *Options) error {
+	attrs := block.Body().Attributes()
+	names := make([]string, 0, len(attrs))
+	allowed := map[string]struct{}{
+		"type":                 {},
+		"host":                 {},
+		"user":                 {},
+		"password":             {},
+		"private_key":          {},
+		"certificate":          {},
+		"timeout":              {},
+		"script_path":          {},
+		"port":                 {},
+		"proxy_command":        {},
+		"agent":                {},
+		"agent_socket":         {},
+		"bastion_host":         {},
+		"bastion_port":         {},
+		"bastion_user":         {},
+		"bastion_password":     {},
+		"bastion_private_key":  {},
+		"bastion_certificate":  {},
+		"bastion_agent":        {},
+		"bastion_agent_socket": {},
+		"host_key":             {},
+		"bastion_host_key":     {},
+	}
+	var unknown []string
+	for name := range attrs {
+		names = append(names, name)
+		if _, ok := allowed[name]; !ok {
+			unknown = append(unknown, name)
+		}
+	}
+	if opts != nil && opts.Strict && len(unknown) > 0 {
+		sort.Strings(unknown)
+		return fmt.Errorf("connection: unknown attributes: %s", strings.Join(unknown, ", "))
+	}
+	sort.Strings(names)
+	return reorderBlock(block, names)
+}
+
+func init() { Register(connectionStrategy{}) }

--- a/internal/align/strict_error_test.go
+++ b/internal/align/strict_error_test.go
@@ -76,6 +76,14 @@ func TestStrictOrderRejectsUnknownAttributes(t *testing.T) {
 			name: "provisioner",
 			src:  "provisioner \"local-exec\" {\n  when = \"create\"\n  foo  = 1\n}",
 		},
+		{
+			name: "connection",
+			src:  "connection {\n  host = \"h\"\n  foo  = 1\n}",
+		},
+		{
+			name: "connection_nested",
+			src:  "provisioner \"local-exec\" {\n  connection {\n    host = \"h\"\n    foo  = 1\n  }\n}",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tests/cases/connection/in.tf
+++ b/tests/cases/connection/in.tf
@@ -1,0 +1,15 @@
+resource "null_resource" "example" {
+  connection {
+    user    = "ubuntu"
+    host    = "example.com"
+    timeout = "1m"
+  }
+
+  provisioner "local-exec" {
+    connection {
+      timeout = "1m"
+      user    = "root"
+      host    = "127.0.0.1"
+    }
+  }
+}

--- a/tests/cases/connection/out.tf
+++ b/tests/cases/connection/out.tf
@@ -1,0 +1,17 @@
+resource "null_resource" "example" {
+
+  connection {
+    host    = "example.com"
+    timeout = "1m"
+    user    = "ubuntu"
+  }
+
+  provisioner "local-exec" {
+
+    connection {
+      host    = "127.0.0.1"
+      timeout = "1m"
+      user    = "root"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- align connection blocks by alphabetizing attributes
- validate connection attributes under `--strict-order`
- add golden fixture and strict tests including nested provisioner connections

## Testing
- `make tidy`
- `make lint`
- `make test`
- `make cover` *(fails: coverage 76.4% < 95%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b226386bd883239aee1e83a44ad171