### PR TITLE
fs: move build tags before banner comments

### DIFF
--- a/internal/fs/ewindows_other.go
+++ b/internal/fs/ewindows_other.go
@@ -1,6 +1,6 @@
-// internal/fs/ewindows_other.go
 //go:build !windows
 
+// internal/fs/ewindows_other.go
 package fs
 
 func isErrWindows(err error) bool {

--- a/internal/fs/ewindows_windows.go
+++ b/internal/fs/ewindows_windows.go
@@ -1,6 +1,6 @@
-// internal/fs/ewindows_windows.go
 //go:build windows
 
+// internal/fs/ewindows_windows.go
 package fs
 
 import (


### PR DESCRIPTION
## Summary
- place Windows build tags before banner comments in platform-specific helpers
- verify `tools/nocomments` keeps build tags above banner comments

## Testing
- `go test ./...`
- `go run ./cmd/commentcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b22c5701d08323836b04e618263669