### PR TITLE
align: reorder module attributes

### DIFF
--- a/internal/align/module.go
+++ b/internal/align/module.go
@@ -24,11 +24,8 @@ func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	if _, ok := attrs["version"]; ok {
 		order = append(order, "version")
 	}
-	if _, ok := attrs["providers"]; ok {
-		order = append(order, "providers")
-	}
 
-	metaArgs := []string{"count", "for_each", "depends_on"}
+	metaArgs := []string{"count", "for_each", "providers", "depends_on"}
 	for _, name := range metaArgs {
 		if _, ok := attrs[name]; ok {
 			order = append(order, name)
@@ -38,9 +35,9 @@ func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	reserved := map[string]struct{}{
 		"source":     {},
 		"version":    {},
-		"providers":  {},
 		"count":      {},
 		"for_each":   {},
+		"providers":  {},
 		"depends_on": {},
 	}
 

--- a/tests/cases/module/aligned.tf
+++ b/tests/cases/module/aligned.tf
@@ -6,9 +6,9 @@ module "m" {
 module "complex" {
   source     = "./complex"
   version    = "1.0"
-  providers  = {}
   count      = 1
   for_each   = {}
+  providers  = {}
   depends_on = []
   a          = 1
   b          = 2

--- a/tests/cases/module/out.tf
+++ b/tests/cases/module/out.tf
@@ -6,9 +6,9 @@ module "m" {
 module "complex" {
   source     = "./complex"
   version    = "1.0"
-  providers  = {}
   count      = 1
   for_each   = {}
+  providers  = {}
   depends_on = []
   a          = 1
   b          = 2


### PR DESCRIPTION
## Summary
- order module attributes as `source`, `version`, `count`, `for_each`, `providers`, `depends_on`
- update module test fixtures to match new ordering

## Testing
- `make tidy`
- `make lint`
- `make test`
- `make cover` *(fails: make: *** [Makefile:50: cover] Error 1)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b22c7beda08323840804eedbbeb06c