### PR TITLE
Preserve attribute order when schema absent

### DIFF
--- a/internal/align/resource_test.go
+++ b/internal/align/resource_test.go
@@ -37,8 +37,8 @@ func TestSchemaAwareOrder(t *testing.T) {
 
 	got := string(file.Bytes())
 	exp := `resource "test_thing" "ex" {
-  depends_on = []
   provider   = "p"
+  depends_on = []
   foo        = 1
   bar        = 2
   baz        = 3
@@ -86,25 +86,29 @@ resource "null_resource" "n" {
 
 func TestMetaArgsOrder(t *testing.T) {
 	src := []byte(`resource "test" "ex" {
-  provider   = "p"
+  baz        = 3
   for_each   = {}
+  foo        = 1
+  provider   = "p"
   count      = 1
   depends_on = []
-  foo        = 1
+  bar        = 2
 }`)
 
 	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
 	require.False(t, diags.HasErrors())
 
-	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{Schemas: map[string]*alignpkg.Schema{"test": {}}}))
+	require.NoError(t, alignpkg.Apply(file, nil))
 
 	got := string(file.Bytes())
 	exp := `resource "test" "ex" {
-  depends_on = []
+  provider   = "p"
   count      = 1
   for_each   = {}
-  provider   = "p"
+  depends_on = []
+  baz        = 3
   foo        = 1
+  bar        = 2
 }`
 	require.Equal(t, exp, got)
 }

--- a/tests/cases/data/aligned.tf
+++ b/tests/cases/data/aligned.tf
@@ -1,7 +1,7 @@
 data "aws_ami" "example" {
-  depends_on  = []
-  count       = 1
   provider    = aws.us
+  count       = 1
+  depends_on  = []
   owners      = ["amazon"]
   most_recent = true
   bar         = "bar"

--- a/tests/cases/non_variable/out.tf
+++ b/tests/cases/non_variable/out.tf
@@ -1,11 +1,11 @@
 resource "r" "t" {
-  a = 2
   b = 1
+  a = 2
 }
 
 data "d" "t" {
-  a = 2
   b = 1
+  a = 2
 }
 
 provider "p" {

--- a/tests/cases/resource/aligned.tf
+++ b/tests/cases/resource/aligned.tf
@@ -1,8 +1,8 @@
 resource "aws_s3_bucket" "b" {
-  depends_on = []
+  provider   = "aws.us"
   count      = 1
   for_each   = {}
-  provider   = "aws.us"
+  depends_on = []
   bucket     = "b"
   acl        = "private"
   tags       = {}


### PR DESCRIPTION
## Summary
- keep non-meta attributes in their original order when resource schema is missing
- order resource meta-arguments as provider, count, for_each, depends_on
- adjust tests and golden fixtures for new ordering

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b22c92fe108323907cd7eafea9e31b