### PR TITLE
Remove depends_on from output canonical order

### DIFF
--- a/internal/align/output.go
+++ b/internal/align/output.go
@@ -14,7 +14,7 @@ type outputStrategy struct{}
 
 func (outputStrategy) Name() string { return "output" }
 
-var outputCanonicalOrder = []string{"description", "value", "sensitive", "depends_on"}
+var outputCanonicalOrder = []string{"description", "value", "sensitive"}
 
 func (outputStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrs := block.Body().Attributes()

--- a/tests/cases/output/aligned.tf
+++ b/tests/cases/output/aligned.tf
@@ -13,6 +13,7 @@ output "unknown" {
 
 output "depends" {
   value      = var.c
+  foo        = "bar"
   depends_on = [var.x]
 }
 

--- a/tests/cases/output/fmt.tf
+++ b/tests/cases/output/fmt.tf
@@ -12,6 +12,7 @@ output "unknown" {
 }
 
 output "depends" {
+  foo        = "bar"
   depends_on = [var.x]
   value      = var.c
 }

--- a/tests/cases/output/in.tf
+++ b/tests/cases/output/in.tf
@@ -12,8 +12,9 @@ output "unknown" {
 }
 
 output "depends" {
-  depends_on  = [var.x]
-  value       = var.c
+  foo        = "bar"
+  depends_on = [var.x]
+  value      = var.c
 }
 
 output "already" {

--- a/tests/cases/output/out.tf
+++ b/tests/cases/output/out.tf
@@ -13,6 +13,7 @@ output "unknown" {
 
 output "depends" {
   value      = var.c
+  foo        = "bar"
   depends_on = [var.x]
 }
 


### PR DESCRIPTION
## Summary
- drop `depends_on` from output canonical attribute list
- extend output fixture to verify depends_on behaves like any other attribute

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b22ff83e08832389d9fc00f7a2078f