### PR TITLE
cmd/commentcheck: enforce repo-relative path comment

### DIFF
--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -37,6 +37,7 @@ func check(root string) error {
 		}
 		buildLines := 0
 		var lines []int
+		var texts []string
 		for _, cg := range file.Comments {
 			for _, c := range cg.List {
 				line := fset.Position(c.Slash).Line
@@ -48,9 +49,15 @@ func check(root string) error {
 					}
 				}
 				lines = append(lines, line)
+				texts = append(texts, text)
 			}
 		}
-		if len(lines) != 1 || lines[0] != buildLines+1 {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		want := "// /" + filepath.ToSlash(rel)
+		if len(lines) != 1 || lines[0] != buildLines+1 || len(texts) != 1 || texts[0] != want {
 			bad = append(bad, path)
 		}
 		return nil
@@ -59,7 +66,7 @@ func check(root string) error {
 		return err
 	}
 	if len(bad) > 0 {
-		return fmt.Errorf("comments beyond first line: %s", strings.Join(bad, ", "))
+		return fmt.Errorf("comment policy violation: %s", strings.Join(bad, ", "))
 	}
 	return nil
 }

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -10,14 +10,14 @@ import (
 func TestCheck(t *testing.T) {
 	t.Run("compliant", func(t *testing.T) {
 		dir := t.TempDir()
-		write(t, dir, "ok.go", "//go:build test\n// ok.go\n\npackage main\n")
+		write(t, dir, "ok.go", "//go:build test\n// /ok.go\n\npackage main\n")
 		if err := check(dir); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 	t.Run("noncompliant extra comment", func(t *testing.T) {
 		dir := t.TempDir()
-		write(t, dir, "bad.go", "//go:build test\n// bad.go\n\npackage main\n// bad\n")
+		write(t, dir, "bad.go", "//go:build test\n// /bad.go\n\npackage main\n// bad\n")
 		if err := check(dir); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -25,6 +25,13 @@ func TestCheck(t *testing.T) {
 	t.Run("noncompliant missing comment", func(t *testing.T) {
 		dir := t.TempDir()
 		write(t, dir, "bad.go", "//go:build test\n\npackage main\n")
+		if err := check(dir); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+	t.Run("noncompliant wrong path", func(t *testing.T) {
+		dir := t.TempDir()
+		write(t, dir, "bad.go", "//go:build test\n// /other.go\n\npackage main\n")
 		if err := check(dir); err == nil {
 			t.Fatalf("expected error")
 		}


### PR DESCRIPTION
## Summary
- verify each Go file's lone comment matches its repo-relative path
- extend comment check tests for matching and mismatching paths

## Testing
- `go vet ./cmd/commentcheck`
- `go test ./cmd/commentcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b23017b10483238e0e96b5f73797da