### PR TITLE
Preserve terraform block ordering

### DIFF
--- a/internal/align/terraform_test.go
+++ b/internal/align/terraform_test.go
@@ -1,0 +1,85 @@
+// /internal/align/terraform_test.go
+package align_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	alignpkg "github.com/oferchen/hclalign/internal/align"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerraformAttributeOrderAndBlocks(t *testing.T) {
+	src := []byte(`terraform {
+  backend "s3" {}
+  required_providers {}
+  experiments = ["test"]
+  required_version = ">= 1.2.0"
+  cloud {}
+}`)
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
+	got := string(file.Bytes())
+	exp := `terraform {
+  required_version = ">= 1.2.0"
+  experiments      = ["test"]
+
+  backend "s3" {}
+
+  required_providers {}
+
+  cloud {}
+}`
+	require.Equal(t, exp, got)
+}
+
+func TestTerraformRequiredProvidersSorting(t *testing.T) {
+	t.Run("strict", func(t *testing.T) {
+		src := []byte(`terraform {
+  required_version = ">= 1.0"
+  backend "s3" {}
+  cloud {}
+  required_providers {
+    b = {}
+    a = {}
+  }
+}`)
+		file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{Strict: true}))
+		exp := `terraform {
+  required_version = ">= 1.0"
+
+  backend "s3" {}
+
+  cloud {}
+
+  required_providers {
+    a = {}
+    b = {}
+  }
+}`
+		require.Equal(t, exp, string(file.Bytes()))
+	})
+	t.Run("lenient", func(t *testing.T) {
+		src := []byte(`terraform {
+  required_providers {
+    b = {}
+    a = {}
+  }
+}`)
+		file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
+		exp := `terraform {
+
+  required_providers {
+    b = {}
+    a = {}
+  }
+}`
+		require.Equal(t, exp, string(file.Bytes()))
+	})
+}

--- a/internal/fs/ewindows_other.go
+++ b/internal/fs/ewindows_other.go
@@ -1,5 +1,6 @@
 //go:build !windows
-// internal/fs/ewindows_other.go
+
+// /internal/fs/ewindows_other.go
 package fs
 
 func isErrWindows(err error) bool {

--- a/tests/cases/non_variable/out.tf
+++ b/tests/cases/non_variable/out.tf
@@ -29,8 +29,8 @@ locals {
 }
 
 terraform {
-  a = 2
   b = 1
+  a = 2
 }
 
 moved {

--- a/tests/cases/terraform/out.tf
+++ b/tests/cases/terraform/out.tf
@@ -1,22 +1,22 @@
 terraform {
   required_version = ">= 1.0"
 
-  required_providers {
-    aws = {
-      version = "~> 4.0"
-      source  = "hashicorp/aws"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.0"
-    }
+  cloud {
+    organization = "hashicorp"
   }
 
   backend "s3" {
     region = "us-east-1"
   }
 
-  cloud {
-    organization = "hashicorp"
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    aws = {
+      version = "~> 4.0"
+      source  = "hashicorp/aws"
+    }
   }
 }

--- a/tests/cases/terraform/out_strict.tf
+++ b/tests/cases/terraform/out_strict.tf
@@ -10,13 +10,13 @@ terraform {
   }
 
   required_providers {
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.0"
-    }
     aws = {
       version = "~> 4.0"
       source  = "hashicorp/aws"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- keep terraform block order while only reordering `required_version` and `experiments`
- sort `required_providers` map only when strict
- test terraform attribute and provider ordering

## Testing
- `make tidy`
- `make lint`
- `make test`
- `make cover` *(fails: coverage 80.5% < 95%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b22ff2c47083238de2405541741ef9