### PR TITLE
Refactor order parsing and relax strict ordering

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -51,7 +51,11 @@ func RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	order, err := cmd.Flags().GetStringSlice("order")
+	orderRaw, err := cmd.Flags().GetStringSlice("order")
+	if err != nil {
+		return err
+	}
+	attrOrder, blockOrder, err := config.ParseOrder(orderRaw)
 	if err != nil {
 		return err
 	}
@@ -138,7 +142,8 @@ func RunE(cmd *cobra.Command, args []string) error {
 		Stdout:             stdout,
 		Include:            include,
 		Exclude:            exclude,
-		Order:              order,
+		Order:              attrOrder,
+		BlockOrder:         blockOrder,
 		StrictOrder:        strictOrder,
 		FmtOnly:            fmtOnly,
 		NoFmt:              noFmt,

--- a/internal/align/connection.go
+++ b/internal/align/connection.go
@@ -2,9 +2,7 @@
 package align
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
@@ -15,7 +13,6 @@ func (connectionStrategy) Name() string { return "connection" }
 
 func (connectionStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrs := block.Body().Attributes()
-	names := make([]string, 0, len(attrs))
 	allowed := map[string]struct{}{
 		"type":                 {},
 		"host":                 {},
@@ -40,18 +37,17 @@ func (connectionStrategy) Align(block *hclwrite.Block, opts *Options) error {
 		"host_key":             {},
 		"bastion_host_key":     {},
 	}
-	var unknown []string
+	var known, unknown []string
 	for name := range attrs {
-		names = append(names, name)
-		if _, ok := allowed[name]; !ok {
+		if _, ok := allowed[name]; ok {
+			known = append(known, name)
+		} else {
 			unknown = append(unknown, name)
 		}
 	}
-	if opts != nil && opts.Strict && len(unknown) > 0 {
-		sort.Strings(unknown)
-		return fmt.Errorf("connection: unknown attributes: %s", strings.Join(unknown, ", "))
-	}
-	sort.Strings(names)
+	sort.Strings(known)
+	sort.Strings(unknown)
+	names := append(known, unknown...)
 	return reorderBlock(block, names)
 }
 

--- a/internal/align/dynamic.go
+++ b/internal/align/dynamic.go
@@ -2,9 +2,7 @@
 package align
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
@@ -15,20 +13,18 @@ func (dynamicStrategy) Name() string { return "dynamic" }
 
 func (dynamicStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrs := block.Body().Attributes()
-	names := make([]string, 0, len(attrs))
 	allowed := map[string]struct{}{"for_each": {}, "iterator": {}}
-	var unknown []string
+	var known, unknown []string
 	for name := range attrs {
-		names = append(names, name)
-		if _, ok := allowed[name]; !ok {
+		if _, ok := allowed[name]; ok {
+			known = append(known, name)
+		} else {
 			unknown = append(unknown, name)
 		}
 	}
-	if opts != nil && opts.Strict && len(unknown) > 0 {
-		sort.Strings(unknown)
-		return fmt.Errorf("dynamic: unknown attributes: %s", strings.Join(unknown, ", "))
-	}
-	sort.Strings(names)
+	sort.Strings(known)
+	sort.Strings(unknown)
+	names := append(known, unknown...)
 	return reorderBlock(block, names)
 }
 

--- a/internal/align/lifecycle.go
+++ b/internal/align/lifecycle.go
@@ -2,9 +2,7 @@
 package align
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
@@ -15,25 +13,23 @@ func (lifecycleStrategy) Name() string { return "lifecycle" }
 
 func (lifecycleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrs := block.Body().Attributes()
-	names := make([]string, 0, len(attrs))
 	allowed := map[string]struct{}{
 		"create_before_destroy": {},
 		"prevent_destroy":       {},
 		"ignore_changes":        {},
 		"replace_triggered_by":  {},
 	}
-	var unknown []string
+	var known, unknown []string
 	for name := range attrs {
-		names = append(names, name)
-		if _, ok := allowed[name]; !ok {
+		if _, ok := allowed[name]; ok {
+			known = append(known, name)
+		} else {
 			unknown = append(unknown, name)
 		}
 	}
-	if opts != nil && opts.Strict && len(unknown) > 0 {
-		sort.Strings(unknown)
-		return fmt.Errorf("lifecycle: unknown attributes: %s", strings.Join(unknown, ", "))
-	}
-	sort.Strings(names)
+	sort.Strings(known)
+	sort.Strings(unknown)
+	names := append(known, unknown...)
 	return reorderBlock(block, names)
 }
 

--- a/internal/align/locals.go
+++ b/internal/align/locals.go
@@ -12,16 +12,7 @@ type localsStrategy struct{}
 func (localsStrategy) Name() string { return "locals" }
 
 func (localsStrategy) Align(block *hclwrite.Block, opts *Options) error {
-	alphabetical := false
-	if opts != nil {
-		for _, o := range opts.Order {
-			if o == "locals=alphabetical" {
-				alphabetical = true
-				break
-			}
-		}
-	}
-	if !alphabetical {
+	if opts == nil || opts.BlockOrder == nil || opts.BlockOrder["locals"] != "alphabetical" {
 		return nil
 	}
 

--- a/internal/align/locals_test.go
+++ b/internal/align/locals_test.go
@@ -36,7 +36,7 @@ func TestLocalsAlphabeticalOrderFlag(t *testing.T) {
 }`)
 	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
 	require.False(t, diags.HasErrors())
-	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{Order: []string{"locals=alphabetical"}}))
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{BlockOrder: map[string]string{"locals": "alphabetical"}}))
 	got := string(file.Bytes())
 	exp := `locals {
   a = 1

--- a/internal/align/module.go
+++ b/internal/align/module.go
@@ -2,9 +2,7 @@
 package align
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
@@ -48,10 +46,6 @@ func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 		}
 	}
 	sort.Strings(vars)
-
-	if opts != nil && opts.Strict && len(vars) > 0 {
-		return fmt.Errorf("module: unknown attributes: %s", strings.Join(vars, ", "))
-	}
 
 	order = append(order, vars...)
 

--- a/internal/align/output.go
+++ b/internal/align/output.go
@@ -2,10 +2,6 @@
 package align
 
 import (
-	"fmt"
-	"sort"
-	"strings"
-
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	ihcl "github.com/oferchen/hclalign/internal/hcl"
 )
@@ -29,19 +25,6 @@ func (outputStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	}
 
 	original := ihcl.AttributeOrder(block.Body(), attrs)
-
-	if opts != nil && opts.Strict {
-		var unknown []string
-		for _, name := range original {
-			if _, ok := reserved[name]; !ok {
-				unknown = append(unknown, name)
-			}
-		}
-		if len(unknown) > 0 {
-			sort.Strings(unknown)
-			return fmt.Errorf("output: unknown attributes: %s", strings.Join(unknown, ", "))
-		}
-	}
 
 	for _, name := range original {
 		if _, ok := reserved[name]; !ok {

--- a/internal/align/provisioner.go
+++ b/internal/align/provisioner.go
@@ -2,9 +2,7 @@
 package align
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
@@ -15,20 +13,18 @@ func (provisionerStrategy) Name() string { return "provisioner" }
 
 func (provisionerStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrs := block.Body().Attributes()
-	names := make([]string, 0, len(attrs))
 	allowed := map[string]struct{}{"when": {}, "on_failure": {}}
-	var unknown []string
+	var known, unknown []string
 	for name := range attrs {
-		names = append(names, name)
-		if _, ok := allowed[name]; !ok {
+		if _, ok := allowed[name]; ok {
+			known = append(known, name)
+		} else {
 			unknown = append(unknown, name)
 		}
 	}
-	if opts != nil && opts.Strict && len(unknown) > 0 {
-		sort.Strings(unknown)
-		return fmt.Errorf("provisioner: unknown attributes: %s", strings.Join(unknown, ", "))
-	}
-	sort.Strings(names)
+	sort.Strings(known)
+	sort.Strings(unknown)
+	names := append(known, unknown...)
 	return reorderBlock(block, names)
 }
 

--- a/internal/align/resource.go
+++ b/internal/align/resource.go
@@ -4,7 +4,6 @@ package align
 import (
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -103,9 +102,6 @@ func schemaAwareOrder(block *hclwrite.Block, opts *Options) error {
 			if _, ok := attrs[r]; !ok {
 				return fmt.Errorf("missing required attribute %q", r)
 			}
-		}
-		if len(unk) > 0 {
-			return fmt.Errorf("unknown attributes: %v", strings.Join(unk, ", "))
 		}
 	}
 

--- a/internal/align/strategy.go
+++ b/internal/align/strategy.go
@@ -4,7 +4,8 @@ package align
 import "github.com/hashicorp/hcl/v2/hclwrite"
 
 type Options struct {
-	Order []string
+	Order      []string
+	BlockOrder map[string]string
 
 	Strict bool
 

--- a/internal/align/strict_error_test.go
+++ b/internal/align/strict_error_test.go
@@ -1,4 +1,5 @@
 // /internal/align/strict_error_test.go
+// /internal/align/strict_error_test.go
 package align
 
 import (
@@ -39,7 +40,7 @@ func TestStrictOrderErrors(t *testing.T) {
 	}
 }
 
-func TestStrictOrderRejectsUnknownAttributes(t *testing.T) {
+func TestStrictOrderAllowsUnknownAttributes(t *testing.T) {
 	cases := []struct {
 		name string
 		src  string
@@ -87,8 +88,8 @@ func TestStrictOrderRejectsUnknownAttributes(t *testing.T) {
 			if diags.HasErrors() {
 				t.Fatalf("parse: %v", diags)
 			}
-			if err := Apply(f, &Options{Strict: true}); err == nil {
-				t.Fatalf("expected error")
+			if err := Apply(f, &Options{Strict: true}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/internal/align/variable.go
+++ b/internal/align/variable.go
@@ -68,20 +68,6 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 			}
 			return fmt.Errorf("variable %q: missing attributes: %s", varName, strings.Join(missing, ", "))
 		}
-		var unknown []string
-		for name := range attrs {
-			if _, ok := canonicalSet[name]; !ok {
-				unknown = append(unknown, name)
-			}
-		}
-		if len(unknown) > 0 {
-			sort.Strings(unknown)
-			varName := ""
-			if labels := block.Labels(); len(labels) > 0 {
-				varName = labels[0]
-			}
-			return fmt.Errorf("variable %q: unknown attributes: %s", varName, strings.Join(unknown, ", "))
-		}
 	}
 
 	allTokens := body.BuildTokens(nil)
@@ -200,6 +186,9 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 	canonicalOrderSet := map[string]struct{}{}
 	orderedKnown := make([]string, 0, len(config.CanonicalOrder))
 	for _, name := range order {
+		if _, ok := canonicalSet[name]; !ok {
+			continue
+		}
 		canonicalOrderSet[name] = struct{}{}
 		if _, ok := attrTokensMap[name]; ok {
 			orderedKnown = append(orderedKnown, name)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -98,7 +98,7 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 		if err != nil {
 			return false, err
 		}
-		if err := align.Apply(file, &align.Options{Order: cfg.Order, Strict: cfg.StrictOrder, Schemas: schemas}); err != nil {
+		if err := align.Apply(file, &align.Options{Order: cfg.Order, BlockOrder: cfg.BlockOrder, Strict: cfg.StrictOrder, Schemas: schemas}); err != nil {
 			return false, err
 		}
 		formatted = hclwrite.Format(file.Bytes())

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -143,7 +143,7 @@ func processFile(ctx context.Context, filePath string, cfg *config.Config, schem
 		if testHookAfterParse != nil {
 			testHookAfterParse()
 		}
-		if err := align.Apply(file, &align.Options{Order: cfg.Order, Strict: cfg.StrictOrder, Schemas: schemas}); err != nil {
+		if err := align.Apply(file, &align.Options{Order: cfg.Order, BlockOrder: cfg.BlockOrder, Strict: cfg.StrictOrder, Schemas: schemas}); err != nil {
 			return false, nil, err
 		}
 		if testHookAfterReorder != nil {

--- a/internal/hclalign/hclalign.go
+++ b/internal/hclalign/hclalign.go
@@ -70,20 +70,6 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 			}
 			return fmt.Errorf("variable %q: missing attributes: %s", varName, strings.Join(missing, ", "))
 		}
-		var unknown []string
-		for name := range attrs {
-			if _, ok := canonicalSet[name]; !ok {
-				unknown = append(unknown, name)
-			}
-		}
-		if len(unknown) > 0 {
-			sort.Strings(unknown)
-			varName := ""
-			if labels := block.Labels(); len(labels) > 0 {
-				varName = labels[0]
-			}
-			return fmt.Errorf("variable %q: unknown attributes: %s", varName, strings.Join(unknown, ", "))
-		}
 	}
 
 	allTokens := body.BuildTokens(nil)

--- a/internal/hclalign/hclalign_test.go
+++ b/internal/hclalign/hclalign_test.go
@@ -84,19 +84,6 @@ func TestReorderAttributes_IgnoresNonVariable(t *testing.T) {
 	require.Equal(t, src, string(f.Bytes()))
 }
 
-func TestReorderAttributes_StrictUnknownAttrError(t *testing.T) {
-	src := `variable "example" {
-  custom      = true
-  description = "d"
-  type        = string
-}`
-	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
-	require.False(t, diags.HasErrors())
-
-	err := hclalign.ReorderAttributes(f, []string{"custom", "description", "type"}, true)
-	require.Error(t, err)
-}
-
 func TestReorderAttributes_StrictUnknownAttrWithCanonical(t *testing.T) {
 	src := `variable "example" {
   description = "d"
@@ -109,8 +96,17 @@ func TestReorderAttributes_StrictUnknownAttrWithCanonical(t *testing.T) {
 	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
 	require.False(t, diags.HasErrors())
 
-	err := hclalign.ReorderAttributes(f, nil, true)
-	require.Error(t, err)
+	require.NoError(t, hclalign.ReorderAttributes(f, nil, true))
+
+	expected := `variable "example" {
+  description = "d"
+  type        = string
+  default     = "v"
+  sensitive   = true
+  nullable    = false
+  custom      = true
+}`
+	require.Equal(t, expected, string(f.Bytes()))
 }
 
 func TestReorderAttributes_LoosePlacesUnknownAfterCanonical(t *testing.T) {


### PR DESCRIPTION
## Summary
- Parse `--order` into attribute and per-block directives
- Allow unknown attributes in strict mode and append them after known ones across strategies
- Support block-level alphabetical locals ordering via dedicated map

## Testing
- `make tidy`
- `make lint` *(fails: make: *** [Makefile:28: lint] Interrupt)*
- `make test` *(fails: output mismatch in golden tests)*
- `make build` *(fails: make: *** [Makefile:57: build] Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b235cbc08c832381ed12e58d53ee25