### PR TITLE
Remove duplicate banner comment in strict_error_test.go

### DIFF
--- a/internal/align/strict_error_test.go
+++ b/internal/align/strict_error_test.go
@@ -1,5 +1,4 @@
 // /internal/align/strict_error_test.go
-// /internal/align/strict_error_test.go
 package align
 
 import (


### PR DESCRIPTION
## Summary
- remove duplicated banner comment from internal/align/strict_error_test.go

## Testing
- `go test ./internal/align/...` *(fails: TestGolden/complex, TestTerraformAttributeOrderAndBlocks, TestTerraformRequiredProvidersSorting)*

------
https://chatgpt.com/codex/tasks/task_e_68b23a92c4ec8323b3181977a86d5479