### PR TITLE
chore: fix windows fs banner path

### DIFF
--- a/internal/fs/ewindows_windows.go
+++ b/internal/fs/ewindows_windows.go
@@ -1,5 +1,6 @@
 //go:build windows
-// internal/fs/ewindows_windows.go
+
+// /internal/fs/ewindows_windows.go
 package fs
 
 import (


### PR DESCRIPTION
## Summary
- add leading slash in windows error helper banner
- tidy banner formatting

## Testing
- `go test ./internal/fs/...`
- `GOOS=windows go test -c ./internal/fs` *(fails: undefined syscall.Stat_t)*

------
https://chatgpt.com/codex/tasks/task_e_68b23aa6c2748323a5ac9496f7333813