### PR TITLE
chore: simplify coverage check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ APP := hclalign
 PKG := ./...
 BUILD_DIR := ./.build
 COVERPROFILE := coverage.out
-COVER_THRESH ?= 95
 
 GO ?= go
 
@@ -47,7 +46,7 @@ test-race:
 
 cover:
 	$(GO) test -race -covermode=atomic -coverpkg=./... -coverprofile=$(COVERPROFILE) ./...
-	$(GO) tool cover -func=$(COVERPROFILE) | tee /dev/stderr | awk -v thr=$(COVER_THRESH) '/^total:/ {sub("%", "", $$3); if ($$3+0 < thr) {printf("coverage %s%% is below %s%%\n", $$3, thr); exit 1}}'
+	$(GO) tool cover -func=$(COVERPROFILE) | awk '/total:/ { if ($$3+0 < 95) { print "COVERAGE <95%"; exit 1 } }'
 
 cover-html: cover
 	$(GO) tool cover -html=$(COVERPROFILE) -o $(BUILD_DIR)/coverage.html


### PR DESCRIPTION
## Summary
- simplify coverage gate by removing COVER_THRESH variable and tee usage
- enforce fixed 95% coverage threshold via inline awk check

## Testing
- `make cover` *(fails: TestTerraformRequiredProvidersSorting/strict)*

------
https://chatgpt.com/codex/tasks/task_e_68b23aba777c8323a0c2950b9211bd01