### PR TITLE
ci: allow optional vuln check failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  VULN_STRICT: 0
+
 jobs:
   ci:
     name: CI
@@ -27,7 +30,7 @@ jobs:
       - run: make vet
       - name: Vulnerability check
         run: make vuln
-        continue-on-error: true
+        continue-on-error: ${{ env.VULN_STRICT != '1' }}
       - run: make test-race
       - run: make cover
         env:


### PR DESCRIPTION
## Summary
- allow configuring vulnerability scan strictness via `VULN_STRICT`
- skip failing the workflow when `VULN_STRICT` is not set to `1`

## Testing
- `make tidy`
- `make lint`
- `make test` *(fails: github.com/oferchen/hclalign/internal/align)*
- `make cover` *(interrupted)*
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_68b23ad8305c83238c1d0c838659da09