### PR TITLE
chore: set go directive to 1.24.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oferchen/hclalign
 
-go 1.23.0
+go 1.24.5
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1


### PR DESCRIPTION
## Summary
- use `go 1.24.5` directive in go.mod

## Testing
- `go mod tidy`
- `make tidy`
- `make lint`
- `make test` *(fails: output mismatch for golden tests and terraform sorting)*
- `make cover` *(fails: coverage tests fail with same mismatches)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b23af7b5a08323bfca580393ba03ca