### PR TITLE
chore: refine build tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for considering a contribution to `hclalign`!
 Run the comment stripping tool to ensure each Go file begins with a path comment:
 
 ```sh
-make strip-comments
+make sanitize
 ```
 
 Before submitting a pull request, ensure the continuous integration pipeline passes:

--- a/internal/ci/covercheck/main.go
+++ b/internal/ci/covercheck/main.go
@@ -17,7 +17,11 @@ var ignore = []string{
 }
 
 func main() {
-	const profile = ".build/coverage.out"
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: covercheck <profile>")
+		os.Exit(1)
+	}
+	profile := os.Args[1]
 
 	f, err := os.Open(profile)
 	if err != nil {

--- a/internal/ci/covercheck/main_test.go
+++ b/internal/ci/covercheck/main_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 )
 
-func runCovercheck(t *testing.T) (string, int) {
+func runCovercheck(t *testing.T, profile string) (string, int) {
 	t.Helper()
-	cmd := exec.Command("go", "run", ".")
+	cmd := exec.Command("go", "run", ".", profile)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		return string(out), 0
@@ -53,7 +53,7 @@ func TestCovercheck(t *testing.T) {
 				t.Fatalf("write profile: %v", err)
 			}
 			defer os.RemoveAll(".build")
-			out, code := runCovercheck(t)
+			out, code := runCovercheck(t, profile)
 			if code != tc.wantExit {
 				t.Fatalf("exit %d, want %d; output: %s", code, tc.wantExit, out)
 			}

--- a/tools/stripcomments/main.go
+++ b/tools/stripcomments/main.go
@@ -1,4 +1,4 @@
-// /tools/nocomments/main.go
+// /tools/stripcomments/main.go
 package main
 
 import (


### PR DESCRIPTION
## Summary
- rename `nocomments` target to `sanitize` using new `stripcomments` tool and `commentcheck`
- run tests with coverage and add `fuzz-short` and `help` targets
- switch coverage gate to `covercheck` utility and require profile argument

## Testing
- `go test ./... -shuffle=on -cover`
- `go run ./internal/ci/covercheck .build/coverage.out` *(fails: Coverage 11.5% is below 95.0%)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b11b04688323bfca74efb82c0d1f