### PR TITLE
chore: enable gocyclo linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,9 +12,12 @@ linters:
     - misspell
     - gofumpt
     - depguard
+    - gocyclo
 linters-settings:
   gofumpt:
     extra-rules: true
+  gocyclo:
+    min-complexity: 15
   revive:
     rules:
       - name: indent-error-flow


### PR DESCRIPTION
## Summary
- enable gocyclo in golangci-lint config
- set minimum cyclomatic complexity threshold to 15

## Testing
- `go test -shuffle=on -cover ./...`
- `/tmp/golangci1/golangci-lint run --timeout=5m` *(fails: undefined: doublestar)*
- `go test -race -covermode=atomic -coverpkg=./... -coverprofile=.build/coverage.out ./...`
- `go run ./internal/ci/covercheck .build/coverage.out` *(fails: Coverage 11.5% is below 95.0%)*
- `go build -trimpath -ldflags="-s -w" -buildvcs=false -o .build/hclalign ./cmd/hclalign`


------
https://chatgpt.com/codex/tasks/task_e_68b2b7a19b7883238317bb1567d0dff7