### PR TITLE
Use sanitize comment stripper in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           cache: true
       - run: make tidy
       - run: make fmt
-      - run: make nocomments
+      - run: make sanitize
       - run: make lint
       - run: make vet
       - name: Vulnerability check

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -36,6 +36,13 @@ func TestCheck(t *testing.T) {
 			t.Fatalf("expected error")
 		}
 	})
+	t.Run("noncompliant block comment", func(t *testing.T) {
+		dir := t.TempDir()
+		write(t, dir, "bad.go", "/* /bad.go */\npackage main\n")
+		if err := check(dir); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
 }
 
 func write(t *testing.T, dir, name, content string) {


### PR DESCRIPTION
## Summary
- run `make sanitize` in CI instead of obsolete `make nocomments`
- ensure comment check fails on block comments

## Testing
- `go test ./cmd/commentcheck`
- `go build -o .build/stripcomments ./tools/stripcomments`
- `./.build/stripcomments $(git ls-files '*.go')`
- `go run ./cmd/commentcheck`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2bb16cb44832384d98ca1cc790a99