### PR TITLE
Add depends_on ordering for output blocks

### DIFF
--- a/internal/align/output.go
+++ b/internal/align/output.go
@@ -10,7 +10,7 @@ type outputStrategy struct{}
 
 func (outputStrategy) Name() string { return "output" }
 
-var outputCanonicalOrder = []string{"description", "value", "sensitive"}
+var outputCanonicalOrder = []string{"description", "value", "sensitive", "depends_on"}
 
 func (outputStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrs := block.Body().Attributes()

--- a/tests/cases/output/aligned.tf
+++ b/tests/cases/output/aligned.tf
@@ -13,12 +13,14 @@ output "unknown" {
 
 output "depends" {
   value      = var.c
-  foo        = "bar"
+  sensitive  = false
   depends_on = [var.x]
+  foo        = "bar"
 }
 
 output "already" {
   description = "foo"
   value       = var.foo
   sensitive   = false
+  depends_on  = [var.dep]
 }

--- a/tests/cases/output/fmt.tf
+++ b/tests/cases/output/fmt.tf
@@ -13,6 +13,7 @@ output "unknown" {
 
 output "depends" {
   foo        = "bar"
+  sensitive  = false
   depends_on = [var.x]
   value      = var.c
 }
@@ -21,4 +22,5 @@ output "already" {
   description = "foo"
   value       = var.foo
   sensitive   = false
+  depends_on  = [var.dep]
 }

--- a/tests/cases/output/in.tf
+++ b/tests/cases/output/in.tf
@@ -13,6 +13,7 @@ output "unknown" {
 
 output "depends" {
   foo        = "bar"
+  sensitive  = false
   depends_on = [var.x]
   value      = var.c
 }
@@ -21,4 +22,5 @@ output "already" {
   description = "foo"
   value       = var.foo
   sensitive   = false
+  depends_on  = [var.dep]
 }

--- a/tests/cases/output/out.tf
+++ b/tests/cases/output/out.tf
@@ -13,12 +13,14 @@ output "unknown" {
 
 output "depends" {
   value      = var.c
-  foo        = "bar"
+  sensitive  = false
   depends_on = [var.x]
+  foo        = "bar"
 }
 
 output "already" {
   description = "foo"
   value       = var.foo
   sensitive   = false
+  depends_on  = [var.dep]
 }


### PR DESCRIPTION
## Summary
- include `depends_on` in output canonical ordering
- extend output block golden tests for depends_on ordering

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2db3824ac8323b8a49941c7e51b76