### PR TITLE
align: reorder module meta args

### DIFF
--- a/internal/align/module.go
+++ b/internal/align/module.go
@@ -23,7 +23,7 @@ func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 		order = append(order, "version")
 	}
 
-	metaArgs := []string{"count", "for_each", "providers", "depends_on"}
+	metaArgs := []string{"providers", "count", "for_each", "depends_on"}
 	for _, name := range metaArgs {
 		if _, ok := attrs[name]; ok {
 			order = append(order, name)
@@ -33,9 +33,9 @@ func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	reserved := map[string]struct{}{
 		"source":     {},
 		"version":    {},
+		"providers":  {},
 		"count":      {},
 		"for_each":   {},
-		"providers":  {},
 		"depends_on": {},
 	}
 

--- a/tests/cases/module/aligned.tf
+++ b/tests/cases/module/aligned.tf
@@ -6,9 +6,9 @@ module "m" {
 module "complex" {
   source     = "./complex"
   version    = "1.0"
+  providers  = {}
   count      = 1
   for_each   = {}
-  providers  = {}
   depends_on = []
   a          = 1
   b          = 2

--- a/tests/cases/module/out.tf
+++ b/tests/cases/module/out.tf
@@ -6,9 +6,9 @@ module "m" {
 module "complex" {
   source     = "./complex"
   version    = "1.0"
+  providers  = {}
   count      = 1
   for_each   = {}
-  providers  = {}
   depends_on = []
   a          = 1
   b          = 2


### PR DESCRIPTION
## Summary
- reorder module meta arguments to `providers`, `count`, `for_each`, `depends_on`
- refresh module test fixtures for new ordering

## Testing
- `make tidy` *(fails: missing separator; ran `go mod tidy` instead)*
- `golangci-lint run --timeout=5m` *(fails: cyclomatic complexity warnings)*
- `go test -race -shuffle=on -cover ./...`
- `go test -coverprofile=.build/coverage.out ./...`
- `go tool cover -func=.build/coverage.out`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2db6f79d4832392c4c13d84e347dd