### PR TITLE
docs: drop strict-order flag

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -26,7 +26,7 @@ Non-negotiables:
 
 * Language: Go ≥ 1.21
 * HCL engine: `hcl/v2/hclwrite` with **SetAttributeRaw** + **BuildTokens** only
-* CLI: `--fmt-only`, `--no-fmt`, `--fmt-strategy {auto,binary,go}`, `--providers-schema`, `--use-terraform-schema`, `--strict-order`, `--check`, `--diff`
+* CLI: `--fmt-only`, `--no-fmt`, `--fmt-strategy {auto,binary,go}`, `--providers-schema`, `--use-terraform-schema`, `--check`, `--diff`
 * Defaults: include `**/*.tf`; exclude `**/.terraform/**`, `**/vendor/**`, `**/.git/**`, `**/node_modules/**`
 * Structure (target):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Changed project license to Apache-2.0.
-- Added variable-attribute reordering tool with support for include/exclude globs and strict ordering.
+- Added variable-attribute reordering tool with support for include/exclude globs.
 - Introduced safety features such as check and diff modes, idempotent operation, and atomic file writes.
 - Improved testing with race detector and fuzz test execution.
 - Added optional symlink traversal via `--follow-symlinks` and clarified default include/exclude patterns.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This process is idempotent: running the tool multiple times yields the same resu
 
 ## Schema Options
 
-The default schema orders variable attributes as `description`, `type`, `default`, `sensitive`, `nullable`. Override it with `--order` and enforce that only those attributes appear by adding `--strict-order`.
+The default schema orders variable attributes as `description`, `type`, `default`, `sensitive`, `nullable`. Override it with `--order`.
 
 ## Formatting Strategies
 
@@ -41,7 +41,7 @@ fall back to alphabetical order.
 - `--stdin`, `--stdout`: read from stdin and/or write to stdout
 - `--include`, `--exclude`: glob patterns controlling which files are processed
 - `--follow-symlinks`: traverse symbolic links
-- `--order`, `--strict-order`: control schema ordering; `--strict-order` applies globally to all blocks
+- `--order`: control schema ordering
 - `--concurrency`: maximum parallel file processing
 - `-v, --verbose`: enable verbose logging
 - `--fmt-only`: run only the formatting phase


### PR DESCRIPTION
## Summary
- remove `--strict-order` flag from docs
- clean up flag lists and examples

## Testing
- `make tidy` *(fails: missing separator)*
- `go mod tidy`
- `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
- `golangci-lint run --timeout=5m` *(fails: unsupported version of the configuration)*
- `go test -shuffle=on -cover ./...`
- `go test -race -covermode=atomic -coverpkg=./... -coverprofile=.build/coverage.out ./...`
- `go run ./internal/ci/covercheck .build/coverage.out` *(fails: Coverage 11.5% is below 95.0%)*
- `go build -trimpath -ldflags="-s -w" -buildvcs=false -o .build/hclalign ./cmd/hclalign`


------
https://chatgpt.com/codex/tasks/task_e_68b2dfa017508323bbe6f71a388d4f99