### PR TITLE
test: order lifecycle and provisioners

### DIFF
--- a/internal/align/resource_test.go
+++ b/internal/align/resource_test.go
@@ -112,3 +112,58 @@ func TestMetaArgsOrder(t *testing.T) {
 }`
 	require.Equal(t, exp, got)
 }
+
+func TestLifecycleProvisionerOrder(t *testing.T) {
+	src := []byte(`resource "test_thing" "ex" {
+  baz        = 3
+  provisioner "local-exec" {}
+  for_each   = {}
+  foo        = 1
+  lifecycle {
+    prevent_destroy = true
+  }
+  bar        = 2
+  random     = 4
+  provider   = "p"
+  count      = 1
+  depends_on = []
+  provisioner "remote-exec" {}
+}`)
+
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	sch := &alignpkg.Schema{
+		Required: map[string]struct{}{"foo": {}},
+		Optional: map[string]struct{}{"bar": {}},
+		Computed: map[string]struct{}{"baz": {}},
+		Meta:     map[string]struct{}{"provider": {}, "depends_on": {}, "count": {}, "for_each": {}},
+	}
+	schemas := map[string]*alignpkg.Schema{"test_thing": sch}
+
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{Schemas: schemas}))
+
+	got := string(file.Bytes())
+	exp := `resource "test_thing" "ex" {
+  provider   = "p"
+  count      = 1
+  for_each   = {}
+  depends_on = []
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  provisioner "local-exec" {}
+
+  provisioner "remote-exec" {}
+  foo    = 1
+  bar    = 2
+  baz    = 3
+  random = 4
+}`
+	require.Equal(t, exp, got)
+
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{Schemas: schemas}))
+	require.Equal(t, exp, string(file.Bytes()))
+}


### PR DESCRIPTION
## Summary
- add resource alignment test covering lifecycle and provisioners
- verify ordering and idempotency

## Testing
- `go test ./internal/align -run TestLifecycleProvisionerOrder -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2eb3306d08323bfd812e85cb3fdc1