### PR TITLE
Add validation to canonical order and add variable validation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This process is idempotent: running the tool multiple times yields the same resu
 
 ## Schema Options
 
-The default schema orders variable attributes as `description`, `type`, `default`, `sensitive`, `nullable`. Override it with `--order`.
+The default schema orders variable attributes as `description → type → default → sensitive → nullable → validation`. Override it with `--order`.
 
 ## Formatting Strategies
 

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ type Config struct {
 var (
 	DefaultInclude = []string{"**/*.tf"}
 	DefaultExclude = []string{"**/.terraform/**", "**/vendor/**", "**/.git/**", "**/node_modules/**"}
-	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
+	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable", "validation"}
 )
 
 const (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,7 @@ func TestValidateOrder_EmptyAttribute(t *testing.T) {
 }
 
 func TestCanonicalOrderMatchesBuiltInAttributes(t *testing.T) {
-	expected := []string{"description", "type", "default", "sensitive", "nullable"}
+	expected := []string{"description", "type", "default", "sensitive", "nullable", "validation"}
 	if !reflect.DeepEqual(CanonicalOrder, expected) {
 		t.Fatalf("expected CanonicalOrder to be %v, got %v", expected, CanonicalOrder)
 	}

--- a/tests/cases/variable_validation/in.tf
+++ b/tests/cases/variable_validation/in.tf
@@ -1,0 +1,15 @@
+variable "valid" {
+  validation {
+    condition     = true
+    error_message = "msg1"
+  }
+  nullable    = false
+  sensitive   = true
+  default     = "ok"
+  validation {
+    condition     = 2 > 1
+    error_message = "msg2"
+  }
+  description = "desc"
+  type        = string
+}

--- a/tests/cases/variable_validation/out.tf
+++ b/tests/cases/variable_validation/out.tf
@@ -1,0 +1,15 @@
+variable "valid" {
+  description = "desc"
+  type        = string
+  default     = "ok"
+  sensitive   = true
+  nullable    = false
+  validation {
+    condition     = true
+    error_message = "msg1"
+  }
+  validation {
+    condition     = 2 > 1
+    error_message = "msg2"
+  }
+}


### PR DESCRIPTION
## Summary
- include `validation` in canonical variable ordering and tests
- document schema order including validation
- add golden test for variable blocks with multiple validation blocks

## Testing
- `make tidy`
- `make lint` *(fails: cyclomatic complexity 56 of func `schemaAwareOrder` is high (> 15))*
- `make test`
- `make cover` *(fails: Coverage 11.8% is below 95.0%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b2eb2825608323b53b6ea85f3a3b78