### PR TITLE
align: alphabetize provider attributes

### DIFF
--- a/internal/align/provider.go
+++ b/internal/align/provider.go
@@ -2,8 +2,9 @@
 package align
 
 import (
+	"sort"
+
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	ihcl "github.com/oferchen/hclalign/internal/hcl"
 )
 
 type providerStrategy struct{}
@@ -20,15 +21,14 @@ func (providerStrategy) Align(block *hclwrite.Block, opts *Options) error {
 		names = append(names, "alias")
 	}
 
-	order := ihcl.AttributeOrder(body, attrs)
-	others := make([]string, 0, len(order))
-	for _, name := range order {
+	others := make([]string, 0, len(attrs))
+	for name := range attrs {
 		if name == "alias" {
 			continue
 		}
 		others = append(others, name)
 	}
-
+	sort.Strings(others)
 	names = append(names, others...)
 
 	return reorderBlock(block, names)

--- a/internal/align/provider_test.go
+++ b/internal/align/provider_test.go
@@ -43,8 +43,8 @@ func TestProviderAttributeOrder(t *testing.T) {
 	got := string(file.Bytes())
 	exp := `provider "aws" {
   alias   = "west"
-  region  = "us-east-1"
   profile = "default"
+  region  = "us-east-1"
 }`
 	require.Equal(t, exp, got)
 }

--- a/tests/cases/non_variable/out.tf
+++ b/tests/cases/non_variable/out.tf
@@ -9,8 +9,8 @@ data "d" "t" {
 }
 
 provider "p" {
-  b = 1
   a = 2
+  b = 1
 }
 
 module "m" {

--- a/tests/cases/provider/aligned.tf
+++ b/tests/cases/provider/aligned.tf
@@ -1,10 +1,10 @@
 provider "aws" {
   # alias comment
   alias = "east"
-  # region comment
-  region = "us-east-1"
   # access key comment
   access_key = "foo"
+  # region comment
+  region = "us-east-1"
   # secret key comment
   secret_key = "bar"
 

--- a/tests/cases/provider/out.tf
+++ b/tests/cases/provider/out.tf
@@ -1,10 +1,10 @@
 provider "aws" {
   # alias comment
   alias = "east"
-  # region comment
-  region = "us-east-1"
   # access key comment
   access_key = "foo"
+  # region comment
+  region = "us-east-1"
   # secret key comment
   secret_key = "bar"
 


### PR DESCRIPTION
## Summary
- sort provider block attributes (excluding alias) alphabetically
- update provider golden tests to assert deterministic order
- keep nested block order unchanged

## Testing
- `go test ./internal/align`
- `go test ./...`
- `make lint` *(fails: cyclomatic complexity > 15)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ef5d61d48323a47c288c9f0129bb