### PR TITLE
Enable shuffled test order for coverage runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ fuzz-short: ## short fuzzing run
 
 cover: ## run coverage check
 	mkdir -p $(BUILD_DIR)
-	$(GO) test -race -covermode=atomic -coverpkg=./... -coverprofile=$(COVERPROFILE) ./...
+	$(GO) test -race -shuffle=on -covermode=atomic -coverpkg=./... -coverprofile=$(COVERPROFILE) ./...
 	$(GO) run ./internal/ci/covercheck $(COVERPROFILE)
 
 cover-html: cover ## generate HTML coverage report


### PR DESCRIPTION
## Summary
- run coverage target with `-shuffle=on` to randomize test order
- CI workflow already invokes `make cover`, so coverage runs now shuffle tests automatically

## Testing
- `make tidy`
- `make lint` *(timeout: interrupted)*
- `make test` *(timeout: interrupted)*
- `make cover` *(fails: Coverage 11.9% is below 95%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b2ef6cd5488323a592c9d8f686903d