### PR TITLE
refactor: move CLI flag parsing into helper

### DIFF
--- a/cli/parse.go
+++ b/cli/parse.go
@@ -1,0 +1,171 @@
+// /cli/parse.go
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oferchen/hclalign/config"
+)
+
+func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
+	var target string
+	if len(args) == 1 {
+		target = args[0]
+	}
+
+	writeMode, err := cmd.Flags().GetBool("write")
+	if err != nil {
+		return nil, err
+	}
+	checkMode, err := cmd.Flags().GetBool("check")
+	if err != nil {
+		return nil, err
+	}
+	diffMode, err := cmd.Flags().GetBool("diff")
+	if err != nil {
+		return nil, err
+	}
+	stdin, err := cmd.Flags().GetBool("stdin")
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.Flags().GetBool("stdout")
+	if err != nil {
+		return nil, err
+	}
+	include, err := cmd.Flags().GetStringSlice("include")
+	if err != nil {
+		return nil, err
+	}
+	exclude, err := cmd.Flags().GetStringSlice("exclude")
+	if err != nil {
+		return nil, err
+	}
+	orderRaw, err := cmd.Flags().GetStringSlice("order")
+	if err != nil {
+		return nil, err
+	}
+	attrOrder, blockOrder, err := config.ParseOrder(orderRaw)
+	if err != nil {
+		return nil, &ExitCodeError{Err: err, Code: 2}
+	}
+	fmtOnly, err := cmd.Flags().GetBool("fmt-only")
+	if err != nil {
+		return nil, err
+	}
+	noFmt, err := cmd.Flags().GetBool("no-fmt")
+	if err != nil {
+		return nil, err
+	}
+	fmtStrategy, err := cmd.Flags().GetString("fmt-strategy")
+	if err != nil {
+		return nil, err
+	}
+	providersSchema, err := cmd.Flags().GetString("providers-schema")
+	if err != nil {
+		return nil, err
+	}
+	useTerraformSchema, err := cmd.Flags().GetBool("use-terraform-schema")
+	if err != nil {
+		return nil, err
+	}
+	concurrency, err := cmd.Flags().GetInt("concurrency")
+	if err != nil {
+		return nil, err
+	}
+	verbose, err := cmd.Flags().GetBool("verbose")
+	if err != nil {
+		return nil, err
+	}
+	followSymlinks, err := cmd.Flags().GetBool("follow-symlinks")
+	if err != nil {
+		return nil, err
+	}
+	types, err := cmd.Flags().GetStringSlice("types")
+	if err != nil {
+		return nil, err
+	}
+	all, err := cmd.Flags().GetBool("all")
+	if err != nil {
+		return nil, err
+	}
+	sortUnknown, err := cmd.Flags().GetBool("sort-unknown")
+	if err != nil {
+		return nil, err
+	}
+
+	modeCount := 0
+	if writeMode {
+		modeCount++
+	}
+	if checkMode {
+		modeCount++
+	}
+	if diffMode {
+		modeCount++
+	}
+	if modeCount > 1 {
+		return nil, &ExitCodeError{Err: fmt.Errorf("cannot specify more than one of --write, --check, or --diff"), Code: 2}
+	}
+	if fmtOnly && noFmt {
+		return nil, &ExitCodeError{Err: fmt.Errorf("cannot specify both --fmt-only and --no-fmt"), Code: 2}
+	}
+
+	if !stdin && target == "" {
+		return nil, &ExitCodeError{Err: fmt.Errorf(config.ErrMissingTarget), Code: 2}
+	}
+	if stdin && target != "" {
+		return nil, &ExitCodeError{Err: fmt.Errorf("cannot specify target when --stdin is used"), Code: 2}
+	}
+	if stdin && !stdout {
+		return nil, &ExitCodeError{Err: fmt.Errorf("--stdout is required when --stdin is used"), Code: 2}
+	}
+
+	var mode config.Mode
+	switch {
+	case writeMode:
+		mode = config.ModeWrite
+	case checkMode:
+		mode = config.ModeCheck
+	case diffMode:
+		mode = config.ModeDiff
+	default:
+		mode = config.ModeWrite
+	}
+
+	var cfgTypes []string
+	if all {
+		cfgTypes = nil
+	} else {
+		cfgTypes = types
+	}
+
+	cfg := &config.Config{
+		Target:             target,
+		Mode:               mode,
+		Stdin:              stdin,
+		Stdout:             stdout,
+		Include:            include,
+		Exclude:            exclude,
+		Order:              attrOrder,
+		BlockOrder:         blockOrder,
+		FmtOnly:            fmtOnly,
+		NoFmt:              noFmt,
+		FmtStrategy:        fmtStrategy,
+		ProvidersSchema:    providersSchema,
+		UseTerraformSchema: useTerraformSchema,
+		Concurrency:        concurrency,
+		Verbose:            verbose,
+		FollowSymlinks:     followSymlinks,
+		Types:              cfgTypes,
+		SortUnknown:        sortUnknown,
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, &ExitCodeError{Err: err, Code: 2}
+	}
+
+	return cfg, nil
+}

--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -1,0 +1,72 @@
+// /cli/parse_test.go
+package cli
+
+import (
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/oferchen/hclalign/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfigValid(t *testing.T) {
+	cmd := newRootCmd(true)
+	require.NoError(t, cmd.ParseFlags([]string{"--check"}))
+	cfg, err := parseConfig(cmd, []string{"target"})
+	require.NoError(t, err)
+	require.Equal(t, "target", cfg.Target)
+	require.Equal(t, config.ModeCheck, cfg.Mode)
+}
+
+func TestParseConfigTargetWithStdin(t *testing.T) {
+	cmd := newRootCmd(true)
+	require.NoError(t, cmd.ParseFlags([]string{"--stdin", "--stdout"}))
+	_, err := parseConfig(cmd, []string{"file"})
+	require.Error(t, err)
+	var exitErr *ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 2, exitErr.Code)
+}
+
+func TestParseConfigStdinRequiresStdout(t *testing.T) {
+	cmd := newRootCmd(true)
+	require.NoError(t, cmd.ParseFlags([]string{"--stdin"}))
+	_, err := parseConfig(cmd, nil)
+	require.Error(t, err)
+	var exitErr *ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 2, exitErr.Code)
+}
+
+func TestParseConfigMultipleModeFlags(t *testing.T) {
+	cmd := newRootCmd(false)
+	require.NoError(t, cmd.ParseFlags([]string{"--check", "--diff"}))
+	_, err := parseConfig(cmd, []string{"target"})
+	require.Error(t, err)
+	var exitErr *ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 2, exitErr.Code)
+}
+
+func TestParseConfigNoTarget(t *testing.T) {
+	cmd := newRootCmd(true)
+	require.NoError(t, cmd.ParseFlags([]string{}))
+	_, err := parseConfig(cmd, nil)
+	require.Error(t, err)
+	var exitErr *ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 2, exitErr.Code)
+}
+
+// Ensure helper continues to accept concurrency constraints from config.Validate
+func TestParseConfigConcurrencyValidation(t *testing.T) {
+	cmd := newRootCmd(true)
+	bad := runtime.GOMAXPROCS(0) + 1
+	require.NoError(t, cmd.ParseFlags([]string{"--concurrency", strconv.Itoa(bad)}))
+	_, err := parseConfig(cmd, []string{"target"})
+	require.Error(t, err)
+	var exitErr *ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 2, exitErr.Code)
+}


### PR DESCRIPTION
## Summary
- extract config parsing from `RunE` into new `parseConfig`
- simplify `RunE` to orchestrate execution
- add unit tests for `parseConfig` scenarios

## Testing
- `make lint` *(fails: interrupt)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ef7422b08323a4aad47a2bc81e85