### PR TITLE
Check terraform availability in fmt target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,11 @@ tidy: ## tidy modules
 fmt: ## format code
 	gofumpt -l -w $(FMT_DIRS)
 	$(GOFMT) -s -w $(FMT_DIRS)
-	-terraform fmt -recursive tests/cases
+	@if command -v terraform >/dev/null 2>&1; then \
+		terraform fmt -recursive tests/cases; \
+	else \
+		echo "terraform not found; skipping terraform fmt"; \
+	fi
 
 lint: ## run linters
 	$(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run --timeout=5m

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cat variables.tf | hclalign --stdin --stdout
 | --- | --- |
 | `make init` | download and verify Go modules |
 | `make tidy` | tidy module dependencies |
-| `make fmt` | run gofumpt and gofmt on the codebase |
+| `make fmt` | run gofumpt and gofmt on the codebase; optionally `terraform fmt` on test cases |
 | `make lint` | execute `golangci-lint` |
 | `make vet` | run `go vet` |
 | `make test` | run tests with coverage |
@@ -110,6 +110,8 @@ cat variables.tf | hclalign --stdin --stdout
 | `make cover` | verify coverage ≥95% |
 | `make build` | build the `hclalign` binary into `.build/` |
 | `make clean` | remove build artifacts |
+
+Terraform CLI is optional. If installed, `make fmt` also runs `terraform fmt` on `tests/cases`; otherwise this step is skipped with a warning.
 
 ## Continuous Integration
 Use `hclalign . --check` in CI to fail builds when formatting is needed. The provided GitHub Actions workflow runs `make tidy`, `make fmt`, `make lint`, `make test-race`, and `make cover` on Linux and macOS with multiple Go versions.


### PR DESCRIPTION
## Summary
- Warn and skip Terraform formatting when the `terraform` binary is missing
- Document Terraform as an optional dependency for formatting

## Testing
- `make tidy`
- `make fmt` (warning: terraform not found; skipping)
- `make lint` *(fails: cyclomatic complexity > 15)*
- `make test`
- `make cover` *(fails: coverage 11.9% < 95%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b2ef6705cc832385fd98b6ac4d4ab7