### PR TITLE
chore: remove redundant comment in parse test

### DIFF
--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -59,7 +59,6 @@ func TestParseConfigNoTarget(t *testing.T) {
 	require.Equal(t, 2, exitErr.Code)
 }
 
-// Ensure helper continues to accept concurrency constraints from config.Validate
 func TestParseConfigConcurrencyValidation(t *testing.T) {
 	cmd := newRootCmd(true)
 	bad := runtime.GOMAXPROCS(0) + 1


### PR DESCRIPTION
## Summary
- remove explanatory comment from parse test to adhere to single-comment policy

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2f637bcf48323a01291afd84f3183