### PR TITLE
Run hclalign after terraform fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ fmt: ## format code
 	else \
 		echo "terraform not found; skipping terraform fmt"; \
 	fi
+	$(GO) run ./cmd/hclalign --write tests/cases
 
 lint: ## run linters
 	$(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run --timeout=5m

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cat variables.tf | hclalign --stdin --stdout
 | --- | --- |
 | `make init` | download and verify Go modules |
 | `make tidy` | tidy module dependencies |
-| `make fmt` | run gofumpt and gofmt on the codebase; optionally `terraform fmt` on test cases |
+| `make fmt` | run gofumpt and gofmt on the codebase; `terraform fmt` then `hclalign` on test cases |
 | `make lint` | execute `golangci-lint` |
 | `make vet` | run `go vet` |
 | `make test` | run tests with coverage |
@@ -111,7 +111,7 @@ cat variables.tf | hclalign --stdin --stdout
 | `make build` | build the `hclalign` binary into `.build/` |
 | `make clean` | remove build artifacts |
 
-Terraform CLI is optional. If installed, `make fmt` also runs `terraform fmt` on `tests/cases`; otherwise this step is skipped with a warning.
+Terraform CLI is optional. If installed, `make fmt` runs `terraform fmt` on `tests/cases` before invoking `hclalign`; otherwise `terraform fmt` is skipped with a warning.
 
 ## Continuous Integration
 Use `hclalign . --check` in CI to fail builds when formatting is needed. The provided GitHub Actions workflow runs `make tidy`, `make fmt`, `make lint`, `make test-race`, and `make cover` on Linux and macOS with multiple Go versions.


### PR DESCRIPTION
## Summary
- run `hclalign` on test cases after `terraform fmt`
- note in docs that `terraform fmt` runs before `hclalign`

## Testing
- `make fmt` *(fails: tests/cases/crlf_bom/aligned.tf: parsing error in file tests/cases/crlf_bom/aligned.tf: tests/cases/crlf_bom/aligned.tf:4,2-3: Invalid character)*
- `make tidy`
- `make lint` *(fails: internal/engine/pipeline.go:111:1: cyclomatic complexity 28 of func `processFile` is high (> 15) (gocyclo))*
- `make test` *(fails: TestProcessScenarios/concurrency)*
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_68b2f64d16f88323bdc9b2e83bed6434