### PR TITLE
docs: drop strict-order flag references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Changed project license to Apache-2.0.
-- Added variable-attribute reordering tool with support for include/exclude globs.
-- Removed `--strict-order` flag and strict mode.
+- Added variable-attribute reordering tool with support for include/exclude globs and the `--order` flag for custom schemas.
 - Introduced safety features such as check and diff modes, idempotent operation, and atomic file writes.
 - Improved testing with race detector and fuzz test execution.
 - Added optional symlink traversal via `--follow-symlinks` and clarified default include/exclude patterns.


### PR DESCRIPTION
## Summary
- remove lingering documentation of the removed `--strict-order` flag
- document `--order` flag for customizing attribute schemas

## Testing
- `make tidy`
- `make lint` *(fails: cyclomatic complexity > 15)*
- `make test`
- `make cover` *(fails: coverage 13.2% < 95% threshold)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b2f66c8910832386970759a8bb824c