### PR TITLE
refactor: streamline formatting options

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -26,7 +26,7 @@ Non-negotiables:
 
 * Language: Go ≥ 1.21
 * HCL engine: `hcl/v2/hclwrite` with **SetAttributeRaw** + **BuildTokens** only
-* CLI: `--fmt-only`, `--no-fmt`, `--fmt-strategy {auto,binary,go}`, `--providers-schema`, `--use-terraform-schema`, `--check`, `--diff`
+* CLI: `--providers-schema`, `--use-terraform-schema`, `--check`, `--diff`
 * Defaults: include `**/*.tf`; exclude `**/.terraform/**`, `**/vendor/**`, `**/.git/**`, `**/node_modules/**`
 * Structure (target):
 
@@ -222,8 +222,8 @@ make build
 
 **Parity mismatch (FMT):**
 
-1. Confirm binary present; switch `--fmt-strategy=binary`.
-2. If still mismatched, update Go strategy and add failing fixture to `tests/cases/`.
+1. Confirm Terraform binary is present.
+2. If mismatched, update formatter and add failing fixture to `tests/cases/`.
 
 **Unexpected reordering:**
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,6 @@ This process is idempotent: running the tool multiple times yields the same resu
 
 The default schema orders variable attributes as `description → type → default → sensitive → nullable → validation`. Override it with `--order`.
 
-## Formatting Strategies
-
-The fmt phase supports multiple strategies controlled by `--fmt-strategy`:
-`auto` chooses the Terraform binary if available, `binary` always shells out to
-`terraform fmt`, and `go` uses the built-in formatter. Use `--fmt-only` to stop
-after formatting or `--no-fmt` to skip this phase.
-
 ## Provider Schema Integration
 
 Resource and data blocks can be ordered according to provider schemas. Supply a
@@ -44,9 +37,6 @@ fall back to alphabetical order.
 - `--order`: control schema ordering
 - `--concurrency`: maximum parallel file processing
 - `-v, --verbose`: enable verbose logging
-- `--fmt-only`: run only the formatting phase
-- `--no-fmt`: skip the formatting phase
-- `--fmt-strategy {auto,binary,go}`: choose formatting backend
 - `--providers-schema`: path to a provider schema JSON file
 - `--use-terraform-schema`: derive schema via `terraform providers schema -json`
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -33,9 +33,6 @@ func newTestRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().StringSlice("include", config.DefaultInclude, "glob patterns to include")
 	cmd.Flags().StringSlice("exclude", config.DefaultExclude, "glob patterns to exclude")
 	cmd.Flags().StringSlice("order", config.CanonicalOrder, "order of variable block fields and per-block ordering flags (e.g. locals=alphabetical)")
-	cmd.Flags().Bool("fmt-only", false, "only format files, skip alignment")
-	cmd.Flags().Bool("no-fmt", false, "skip initial formatting")
-	cmd.Flags().String("fmt-strategy", "auto", "formatting strategy to use")
 	cmd.Flags().String("providers-schema", "", "path to providers schema file")
 	cmd.Flags().Bool("use-terraform-schema", false, "use terraform schema for providers")
 	cmd.Flags().Int("concurrency", runtime.GOMAXPROCS(0), "maximum concurrency")
@@ -44,7 +41,6 @@ func newTestRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().StringSlice("types", []string{"variable"}, "comma-separated list of block types to align")
 	cmd.Flags().Bool("all", false, "align all block types")
 	cmd.Flags().Bool("sort-unknown", false, "lexicographically sort unknown attributes")
-	cmd.MarkFlagsMutuallyExclusive("fmt-only", "no-fmt")
 	cmd.MarkFlagsMutuallyExclusive("types", "all")
 	if exclusive {
 		cmd.MarkFlagsMutuallyExclusive("write", "check", "diff")

--- a/cli/parse.go
+++ b/cli/parse.go
@@ -51,18 +51,6 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 	if err != nil {
 		return nil, &ExitCodeError{Err: err, Code: 2}
 	}
-	fmtOnly, err := cmd.Flags().GetBool("fmt-only")
-	if err != nil {
-		return nil, err
-	}
-	noFmt, err := cmd.Flags().GetBool("no-fmt")
-	if err != nil {
-		return nil, err
-	}
-	fmtStrategy, err := cmd.Flags().GetString("fmt-strategy")
-	if err != nil {
-		return nil, err
-	}
 	providersSchema, err := cmd.Flags().GetString("providers-schema")
 	if err != nil {
 		return nil, err
@@ -109,9 +97,6 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 	if modeCount > 1 {
 		return nil, &ExitCodeError{Err: fmt.Errorf("cannot specify more than one of --write, --check, or --diff"), Code: 2}
 	}
-	if fmtOnly && noFmt {
-		return nil, &ExitCodeError{Err: fmt.Errorf("cannot specify both --fmt-only and --no-fmt"), Code: 2}
-	}
 
 	if !stdin && target == "" {
 		return nil, &ExitCodeError{Err: fmt.Errorf(config.ErrMissingTarget), Code: 2}
@@ -151,9 +136,6 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 		Exclude:            exclude,
 		Order:              attrOrder,
 		BlockOrder:         blockOrder,
-		FmtOnly:            fmtOnly,
-		NoFmt:              noFmt,
-		FmtStrategy:        fmtStrategy,
 		ProvidersSchema:    providersSchema,
 		UseTerraformSchema: useTerraformSchema,
 		Concurrency:        concurrency,

--- a/cmd/hclalign/main.go
+++ b/cmd/hclalign/main.go
@@ -37,9 +37,6 @@ func run(args []string) int {
 	rootCmd.Flags().StringSlice("include", config.DefaultInclude, "glob patterns to include")
 	rootCmd.Flags().StringSlice("exclude", config.DefaultExclude, "glob patterns to exclude")
 	rootCmd.Flags().StringSlice("order", config.CanonicalOrder, "order of variable block fields and per-block ordering flags (e.g. locals=alphabetical)")
-	rootCmd.Flags().Bool("fmt-only", false, "only format files, skip alignment")
-	rootCmd.Flags().Bool("no-fmt", false, "skip initial formatting")
-	rootCmd.Flags().String("fmt-strategy", "auto", "formatting strategy to use")
 	rootCmd.Flags().String("providers-schema", "", "path to providers schema file")
 	rootCmd.Flags().Bool("use-terraform-schema", false, "use terraform schema for providers")
 	rootCmd.Flags().Int("concurrency", runtime.GOMAXPROCS(0), "maximum concurrency")
@@ -48,7 +45,6 @@ func run(args []string) int {
 	rootCmd.Flags().StringSlice("types", []string{"variable"}, "comma-separated list of block types to align")
 	rootCmd.Flags().Bool("all", false, "align all block types")
 	rootCmd.Flags().Bool("sort-unknown", false, "lexicographically sort unknown attributes")
-	rootCmd.MarkFlagsMutuallyExclusive("fmt-only", "no-fmt")
 	rootCmd.MarkFlagsMutuallyExclusive("types", "all")
 
 	rootCmd.SetArgs(args)

--- a/config/config.go
+++ b/config/config.go
@@ -31,9 +31,6 @@ type Config struct {
 	Concurrency        int
 	Verbose            bool
 	FollowSymlinks     bool
-	FmtOnly            bool
-	NoFmt              bool
-	FmtStrategy        string
 	ProvidersSchema    string
 	UseTerraformSchema bool
 	Types              []string
@@ -56,9 +53,6 @@ func (c *Config) Validate() error {
 	}
 	if c.Concurrency > runtime.GOMAXPROCS(0) {
 		return fmt.Errorf("concurrency cannot exceed GOMAXPROCS (%d)", runtime.GOMAXPROCS(0))
-	}
-	if c.FmtOnly && c.NoFmt {
-		return fmt.Errorf("fmt-only and no-fmt cannot be used together")
 	}
 	if err := patternmatching.ValidatePatterns(c.Include); err != nil {
 		return fmt.Errorf("invalid include: %w", err)

--- a/internal/engine/phases_test.go
+++ b/internal/engine/phases_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/oferchen/hclalign/config"
-	terraformfmt "github.com/oferchen/hclalign/internal/fmt"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,32 +21,22 @@ func TestPhases(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			inBytes, err := os.ReadFile(filepath.Join(base, name, "in.tf"))
 			require.NoError(t, err)
-			fmtExp, err := os.ReadFile(filepath.Join(base, name, "fmt.tf"))
-			require.NoError(t, err)
 			alignedExp, err := os.ReadFile(filepath.Join(base, name, "aligned.tf"))
 			require.NoError(t, err)
 
-			cfgFmt := &config.Config{Stdout: true, FmtOnly: true, FmtStrategy: string(terraformfmt.StrategyGo)}
-			cfgFull := &config.Config{Stdout: true, FmtStrategy: string(terraformfmt.StrategyGo)}
+			cfg := &config.Config{Stdout: true}
 			if name == "resource" || name == "data" {
-				cfgFmt.ProvidersSchema = schemaPath
-				cfgFull.ProvidersSchema = schemaPath
+				cfg.ProvidersSchema = schemaPath
 			}
 
 			var out bytes.Buffer
-			changed, err := ProcessReader(context.Background(), bytes.NewReader(inBytes), &out, cfgFmt)
-			require.NoError(t, err)
-			require.Equal(t, !bytes.Equal(inBytes, fmtExp), changed)
-			require.Equal(t, string(fmtExp), out.String())
-
-			out.Reset()
-			changed, err = ProcessReader(context.Background(), bytes.NewReader(inBytes), &out, cfgFull)
+			changed, err := ProcessReader(context.Background(), bytes.NewReader(inBytes), &out, cfg)
 			require.NoError(t, err)
 			require.Equal(t, !bytes.Equal(inBytes, alignedExp), changed)
 			require.Equal(t, string(alignedExp), out.String())
 
 			out.Reset()
-			changed, err = ProcessReader(context.Background(), bytes.NewReader(alignedExp), &out, cfgFull)
+			changed, err = ProcessReader(context.Background(), bytes.NewReader(alignedExp), &out, cfg)
 			require.NoError(t, err)
 			require.False(t, changed)
 			require.Equal(t, string(alignedExp), out.String())
@@ -56,7 +45,7 @@ func TestPhases(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		var out bytes.Buffer
-		cfg := &config.Config{Stdout: true, FmtStrategy: string(terraformfmt.StrategyGo)}
+		cfg := &config.Config{Stdout: true}
 		_, err := ProcessReader(context.Background(), bytes.NewReader([]byte("variable \"a\" {")), &out, cfg)
 		require.Error(t, err)
 	})

--- a/internal/engine/write_error_test.go
+++ b/internal/engine/write_error_test.go
@@ -34,9 +34,6 @@ func newRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().StringSlice("include", config.DefaultInclude, "glob patterns to include")
 	cmd.Flags().StringSlice("exclude", config.DefaultExclude, "glob patterns to exclude")
 	cmd.Flags().StringSlice("order", config.CanonicalOrder, "order of variable block fields")
-	cmd.Flags().Bool("fmt-only", false, "only format files, skip alignment")
-	cmd.Flags().Bool("no-fmt", false, "skip initial formatting")
-	cmd.Flags().String("fmt-strategy", "auto", "formatting strategy to use")
 	cmd.Flags().String("providers-schema", "", "path to providers schema file")
 	cmd.Flags().Bool("use-terraform-schema", false, "use terraform schema for providers")
 	cmd.Flags().Int("concurrency", runtime.GOMAXPROCS(0), "maximum concurrency")
@@ -45,7 +42,6 @@ func newRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().StringSlice("types", []string{"variable"}, "comma-separated list of block types to align")
 	cmd.Flags().Bool("all", false, "align all block types")
 	cmd.Flags().Bool("sort-unknown", false, "lexicographically sort unknown attributes")
-	cmd.MarkFlagsMutuallyExclusive("fmt-only", "no-fmt")
 	cmd.MarkFlagsMutuallyExclusive("types", "all")
 	if exclusive {
 		cmd.MarkFlagsMutuallyExclusive("write", "check", "diff")


### PR DESCRIPTION
## Summary
- drop fmt-only, no-fmt and fmt-strategy flags and associated config
- always run formatting before alignment
- update tests and docs for simplified CLI

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2fdc5092c8323a12d6afb3b75a94f