### PR TITLE
Handle validation blocks before unknown attributes

### DIFF
--- a/tests/cases/complex/out.tf
+++ b/tests/cases/complex/out.tf
@@ -4,9 +4,9 @@ variable "complex" {
   default     = ["a", "b"]
   sensitive   = true
   nullable    = false
-  custom      = true
   validation {
     condition     = true
     error_message = "msg"
   }
+  custom = true
 }

--- a/tests/cases/variable/out.tf
+++ b/tests/cases/variable/out.tf
@@ -7,8 +7,6 @@ variable "example" {
   ]
   sensitive = true
   nullable  = true
-  bar       = "bar"
-  foo       = "foo"
   validation {
     condition     = var.example != ""
     error_message = "first"
@@ -17,4 +15,6 @@ variable "example" {
     condition     = length(var.example) > 1
     error_message = "second"
   }
+  bar = "bar"
+  foo = "foo"
 }

--- a/tests/cases/variable_validation/unknown_attrs/in.tf
+++ b/tests/cases/variable_validation/unknown_attrs/in.tf
@@ -1,0 +1,16 @@
+variable "multi" {
+  bar         = 2
+  validation {
+    condition     = true
+    error_message = "msg1"
+  }
+  default     = "ok"
+  foo         = 1
+  validation {
+    condition     = 2 > 1
+    error_message = "msg2"
+  }
+  description = "desc"
+  baz         = 3
+  type        = string
+}

--- a/tests/cases/variable_validation/unknown_attrs/out.tf
+++ b/tests/cases/variable_validation/unknown_attrs/out.tf
@@ -1,0 +1,16 @@
+variable "multi" {
+  description = "desc"
+  type        = string
+  default     = "ok"
+  validation {
+    condition     = true
+    error_message = "msg1"
+  }
+  validation {
+    condition     = 2 > 1
+    error_message = "msg2"
+  }
+  bar = 2
+  baz = 3
+  foo = 1
+}


### PR DESCRIPTION
## Summary
- emit `validation` blocks immediately after known attributes in variables
- preserve `validation` block order and place unknown attributes after them
- add golden test for variables with multiple validation blocks and unknown attributes

## Testing
- `make lint` *(fails: cyclomatic complexity high)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fda3d4088323892dad84a75b4c4e