### PR TITLE
test: add dynamic and provisioner alignment tests

### DIFF
--- a/internal/align/dynamic_test.go
+++ b/internal/align/dynamic_test.go
@@ -1,0 +1,31 @@
+// internal/align/dynamic_test.go
+package align_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	alignpkg "github.com/oferchen/hclalign/internal/align"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamicAttributeOrderAndComments(t *testing.T) {
+	src := []byte(`dynamic "x" {
+  foo = 1 // foo inline
+  iterator = "it" // iterator inline
+  for_each = var.list // for_each inline
+}`)
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
+	got := string(file.Bytes())
+	exp := `dynamic "x" {
+  for_each = var.list // for_each inline
+  iterator = "it" // iterator inline
+  foo      = 1 // foo inline
+}`
+	require.Equal(t, exp, got)
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
+	require.Equal(t, exp, string(file.Bytes()))
+}

--- a/internal/align/provisioner_test.go
+++ b/internal/align/provisioner_test.go
@@ -1,0 +1,31 @@
+// internal/align/provisioner_test.go
+package align_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	alignpkg "github.com/oferchen/hclalign/internal/align"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvisionerAttributeOrderAndComments(t *testing.T) {
+	src := []byte(`provisioner "local-exec" {
+  when = "destroy" // when inline
+  foo = "bar" // foo inline
+  on_failure = "continue" // on_failure inline
+}`)
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
+	got := string(file.Bytes())
+	exp := `provisioner "local-exec" {
+  on_failure = "continue" // on_failure inline
+  when       = "destroy" // when inline
+  foo        = "bar" // foo inline
+}`
+	require.Equal(t, exp, got)
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
+	require.Equal(t, exp, string(file.Bytes()))
+}


### PR DESCRIPTION
## Summary
- add coverage for dynamic block attribute ordering and comment retention
- verify provisioner blocks maintain ordering and comments across runs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b30399137c832391847e1922b738fd