### PR TITLE
engine: preserve template strings in fmt

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -104,7 +104,10 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 	if err := align.Apply(file, &align.Options{Order: cfg.Order, BlockOrder: cfg.BlockOrder, Schemas: schemas, Types: typesMap, SortUnknown: cfg.SortUnknown}); err != nil {
 		return false, err
 	}
-	formatted = hclwrite.Format(file.Bytes())
+	formatted, err = terraformfmt.Format(file.Bytes(), "stdin", "")
+	if err != nil {
+		return false, err
+	}
 
 	if !hadNewline && len(formatted) > 0 && formatted[len(formatted)-1] == '\n' {
 		formatted = formatted[:len(formatted)-1]

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -149,7 +149,10 @@ func processFile(ctx context.Context, filePath string, cfg *config.Config, schem
 	if testHookAfterReorder != nil {
 		testHookAfterReorder()
 	}
-	formatted = hclwrite.Format(file.Bytes())
+	formatted, err = terraformfmt.Format(file.Bytes(), filePath, "")
+	if err != nil {
+		return false, nil, err
+	}
 
 	if !hadNewline && len(formatted) > 0 && formatted[len(formatted)-1] == '\n' {
 		formatted = formatted[:len(formatted)-1]


### PR DESCRIPTION
## Summary
- ensure formatting after alignment uses terraform's formatter
- avoid stripping quotes from interpolation-only strings

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b30b9255788323aecdef40027c70f1