### PR TITLE
refactor: use option structs for diff and fs writes

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -10,7 +10,18 @@ import (
 
 const diffContext = 3
 
-func Unified(fromFile, toFile string, original, styled []byte, hints internalfs.Hints) (string, error) {
+type UnifiedOpts struct {
+	FromFile string
+	ToFile   string
+	Original []byte
+	Styled   []byte
+	Hints    internalfs.Hints
+}
+
+func Unified(opts UnifiedOpts) (string, error) {
+	original := opts.Original
+	styled := opts.Styled
+	hints := opts.Hints
 	if bom := hints.BOM(); len(bom) > 0 {
 		original = append(append([]byte{}, bom...), original...)
 		styled = append(append([]byte{}, bom...), styled...)
@@ -18,8 +29,8 @@ func Unified(fromFile, toFile string, original, styled []byte, hints internalfs.
 	ud := difflib.UnifiedDiff{
 		A:        difflib.SplitLines(string(original)),
 		B:        difflib.SplitLines(string(styled)),
-		FromFile: fromFile,
-		ToFile:   toFile,
+		FromFile: opts.FromFile,
+		ToFile:   opts.ToFile,
 		Context:  diffContext,
 		Eol:      hints.Newline,
 	}

--- a/internal/diff/diff_bom_test.go
+++ b/internal/diff/diff_bom_test.go
@@ -11,7 +11,7 @@ import (
 func TestUnifiedDiffWithBOM(t *testing.T) {
 	a := []byte("line1\n")
 	b := []byte("line2\n")
-	diffStr, err := Unified("a", "a", a, b, internalfs.Hints{HasBOM: true, Newline: "\n"})
+	diffStr, err := Unified(UnifiedOpts{FromFile: "a", ToFile: "a", Original: a, Styled: b, Hints: internalfs.Hints{HasBOM: true, Newline: "\n"}})
 	if err != nil {
 		t.Fatalf("Unified returned error: %v", err)
 	}
@@ -23,7 +23,7 @@ func TestUnifiedDiffWithBOM(t *testing.T) {
 func TestUnifiedDiffWithBOMCRLF(t *testing.T) {
 	a := []byte("line1\r\n")
 	b := []byte("line2\r\n")
-	diffStr, err := Unified("a", "a", a, b, internalfs.Hints{HasBOM: true, Newline: "\r\n"})
+	diffStr, err := Unified(UnifiedOpts{FromFile: "a", ToFile: "a", Original: a, Styled: b, Hints: internalfs.Hints{HasBOM: true, Newline: "\r\n"}})
 	if err != nil {
 		t.Fatalf("Unified returned error: %v", err)
 	}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -11,7 +11,7 @@ import (
 func TestUnifiedDiff(t *testing.T) {
 	a := []byte("line1\nline2\n")
 	b := []byte("line1\nline3\n")
-	diffStr, err := Unified("a", "a", a, b, internalfs.Hints{Newline: "\n"})
+	diffStr, err := Unified(UnifiedOpts{FromFile: "a", ToFile: "a", Original: a, Styled: b, Hints: internalfs.Hints{Newline: "\n"}})
 	if err != nil {
 		t.Fatalf("Unified returned error: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestUnifiedDiff(t *testing.T) {
 func TestUnifiedDiffUsesEOL(t *testing.T) {
 	a := []byte("line1\r\nline2\r\n")
 	b := []byte("line1\r\nline3\r\n")
-	diffStr, err := Unified("a", "a", a, b, internalfs.Hints{Newline: "\r\n"})
+	diffStr, err := Unified(UnifiedOpts{FromFile: "a", ToFile: "a", Original: a, Styled: b, Hints: internalfs.Hints{Newline: "\r\n"}})
 	if err != nil {
 		t.Fatalf("Unified returned error: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestUnifiedDiffUsesEOL(t *testing.T) {
 func TestUnifiedDiffCRLFExact(t *testing.T) {
 	a := []byte("line1\r\nline2\r\n")
 	b := []byte("line1\r\nline3\r\n")
-	diffStr, err := Unified("a", "a", a, b, internalfs.Hints{Newline: "\r\n"})
+	diffStr, err := Unified(UnifiedOpts{FromFile: "a", ToFile: "a", Original: a, Styled: b, Hints: internalfs.Hints{Newline: "\r\n"}})
 	if err != nil {
 		t.Fatalf("Unified returned error: %v", err)
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -122,7 +122,7 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 	switch cfg.Mode {
 	case config.ModeDiff:
 		if changed {
-			text, err := diff.Unified("stdin", "stdin", original, styled, hints)
+			text, err := diff.Unified(diff.UnifiedOpts{FromFile: "stdin", ToFile: "stdin", Original: original, Styled: styled, Hints: hints})
 			if err != nil {
 				return false, err
 			}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -128,7 +128,7 @@ func TestProcessScenarios(t *testing.T) {
 				require.NoError(t, os.WriteFile(f, inb, 0o644))
 
 				hints := internalfs.DetectHintsFromBytes(inb)
-				diffText, err := diff.Unified(f, f, inb, outb, hints)
+				diffText, err := diff.Unified(diff.UnifiedOpts{FromFile: f, ToFile: f, Original: inb, Styled: outb, Hints: hints})
 				require.NoError(t, err)
 
 				cfg := &config.Config{

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -179,7 +179,7 @@ func (p *Processor) processFile(ctx context.Context, filePath string) (bool, []b
 			}
 			return false, out, nil
 		}
-		if err := WriteFileAtomic(ctx, filePath, formatted, perm, hints); err != nil {
+		if err := WriteFileAtomic(ctx, internalfs.WriteOpts{Path: filePath, Data: formatted, Perm: perm, Hints: hints}); err != nil {
 			return false, nil, fmt.Errorf("error writing file %s with original permissions: %w", filePath, err)
 		}
 		if p.cfg.Stdout {
@@ -191,7 +191,7 @@ func (p *Processor) processFile(ctx context.Context, filePath string) (bool, []b
 		}
 	case config.ModeDiff:
 		if changed {
-			text, err := diff.Unified(filePath, filePath, original, styled, hints)
+			text, err := diff.Unified(diff.UnifiedOpts{FromFile: filePath, ToFile: filePath, Original: original, Styled: styled, Hints: hints})
 			if err != nil {
 				return false, nil, err
 			}

--- a/internal/engine/process_reader_test.go
+++ b/internal/engine/process_reader_test.go
@@ -51,7 +51,7 @@ func TestProcessReaderModeDiff(t *testing.T) {
 	require.True(t, changed)
 
 	hints := internalfs.DetectHintsFromBytes([]byte(input))
-	diffText, err := diff.Unified("stdin", "stdin", []byte(input), []byte(styled), hints)
+	diffText, err := diff.Unified(diff.UnifiedOpts{FromFile: "stdin", ToFile: "stdin", Original: []byte(input), Styled: []byte(styled), Hints: hints})
 	require.NoError(t, err)
 	require.Equal(t, diffText, out.String())
 }
@@ -82,7 +82,7 @@ func TestProcessReaderModeCheckNoChange(t *testing.T) {
 	require.Equal(t, input, out.String())
 
 	hints := internalfs.DetectHintsFromBytes([]byte(input))
-	diffText, err := diff.Unified("stdin", "stdin", []byte(input), out.Bytes(), hints)
+	diffText, err := diff.Unified(diff.UnifiedOpts{FromFile: "stdin", ToFile: "stdin", Original: []byte(input), Styled: out.Bytes(), Hints: hints})
 	require.NoError(t, err)
 	require.Empty(t, diffText)
 }

--- a/internal/engine/write_error_test.go
+++ b/internal/engine/write_error_test.go
@@ -4,7 +4,6 @@ package engine_test
 import (
 	"context"
 	"errors"
-	iofs "io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -58,7 +57,7 @@ func TestProcessWriteFileError(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, data, 0o644))
 
 	original := enginepkg.WriteFileAtomic
-	enginepkg.WriteFileAtomic = func(ctx context.Context, path string, b []byte, perm iofs.FileMode, hints internalfs.Hints) error {
+	enginepkg.WriteFileAtomic = func(ctx context.Context, _ internalfs.WriteOpts) error {
 		return errors.New("write error")
 	}
 	defer func() { enginepkg.WriteFileAtomic = original }()

--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -104,10 +104,21 @@ func ApplyHints(data []byte, hints Hints) []byte {
 	return out
 }
 
-func WriteFileAtomic(ctx context.Context, path string, data []byte, perm iofs.FileMode, hints Hints) error {
+type WriteOpts struct {
+	Path  string
+	Data  []byte
+	Perm  iofs.FileMode
+	Hints Hints
+}
+
+func WriteFileAtomic(ctx context.Context, opts WriteOpts) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	path := opts.Path
+	data := opts.Data
+	perm := opts.Perm
+	hints := opts.Hints
 	dir := filepath.Dir(path)
 	uid, gid := -1, -1
 	if info, err := os.Stat(path); err == nil {

--- a/internal/fs/atomic_test.go
+++ b/internal/fs/atomic_test.go
@@ -183,7 +183,7 @@ func TestWriteFileAtomic(t *testing.T) {
 			if tc.setup != nil {
 				ctx = tc.setup(t, dir, path)
 			}
-			if err := WriteFileAtomic(context.Background(), path, tc.data, tc.perm, tc.hints); err != nil {
+			if err := WriteFileAtomic(context.Background(), WriteOpts{Path: path, Data: tc.data, Perm: tc.perm, Hints: tc.hints}); err != nil {
 				t.Fatalf("WriteFileAtomic: %v", err)
 			}
 			if tc.validate != nil {
@@ -206,7 +206,7 @@ func TestWriteFileAtomicContextCanceledBeforeRename(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- WriteFileAtomic(ctx, path, data, 0o644, Hints{})
+		errCh <- WriteFileAtomic(ctx, WriteOpts{Path: path, Data: data, Perm: 0o644, Hints: Hints{}})
 	}()
 
 	time.Sleep(10 * time.Millisecond)

--- a/internal/fs/atomic_windows_test.go
+++ b/internal/fs/atomic_windows_test.go
@@ -26,7 +26,7 @@ func TestWriteFileAtomicChownIgnored(t *testing.T) {
 		t.Fatalf("unexpected chown error: %v", err)
 	}
 
-	if err := WriteFileAtomic(context.Background(), path, []byte("new"), 0o644, Hints{}); err != nil {
+	if err := WriteFileAtomic(context.Background(), WriteOpts{Path: path, Data: []byte("new"), Perm: 0o644, Hints: Hints{}}); err != nil {
 		t.Fatalf("WriteFileAtomic: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- refactor diff.Unified to accept UnifiedOpts struct
- refactor WriteFileAtomic to accept WriteOpts struct
- update engine and tests for new APIs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b312b1cd288323a62a7a763f54023e