### PR TITLE
Use go run for gofumpt in make fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ tidy: ## tidy modules
 	$(GO) mod tidy
 
 fmt: ## format code
-	gofumpt -l -w $(FMT_DIRS)
+	$(GO) run mvdan.cc/gofumpt@latest -l -w $(FMT_DIRS)
 	$(GOFMT) -s -w $(FMT_DIRS)
 	@if command -v terraform >/dev/null 2>&1; then \
 		terraform fmt -recursive tests/cases; \

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ cat variables.tf | hclalign --stdin --stdout
 | --- | --- |
 | `make init` | download and verify Go modules |
 | `make tidy` | tidy module dependencies |
-| `make fmt` | run gofumpt and gofmt on the codebase; `terraform fmt` then `hclalign` on test cases |
+| `make fmt` | run gofumpt (via `go run`) and gofmt on the codebase; `terraform fmt` then `hclalign` on test cases |
 | `make lint` | execute `golangci-lint` |
 | `make vet` | run `go vet` |
 | `make test` | run tests with coverage |
@@ -105,6 +105,8 @@ cat variables.tf | hclalign --stdin --stdout
 | `make clean` | remove build artifacts |
 
 Terraform CLI is optional. If installed, `make fmt` runs `terraform fmt` on `tests/cases` before invoking `hclalign`; otherwise `terraform fmt` is skipped with a warning.
+
+`make fmt` uses `go run mvdan.cc/gofumpt@latest` so contributors do not need to install `gofumpt` manually.
 
 ## Continuous Integration
 Use `hclalign . --check` in CI to fail builds when formatting is needed. The provided GitHub Actions workflow runs `make tidy`, `make fmt`, `make lint`, `make test-race`, and `make cover` on Linux and macOS with multiple Go versions.


### PR DESCRIPTION
## Summary
- run gofumpt via `go run` in `make fmt`
- note automatic gofumpt invocation in README

## Testing
- `make fmt` *(fails: parsing error in tests/cases/crlf_bom)*
- `make tidy`
- `make lint` *(fails: cyclomatic complexity 54 of func `reorderVariableBlock` is high (> 15))*
- `make test`
- `make cover` *(fails: Coverage 13.0% is below 95.0%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b32e31431c8323bf4c594d5ed10440