### PR TITLE
ci: make coverage threshold configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ test-race: ## run tests with race detector
 fuzz-short: ## short fuzzing run
 	$(GO) test $(PKG) -run=^$ -fuzz=Fuzz -fuzztime=5s
 
+cover: export COVER_THRESH ?= 95
 cover: ## run coverage check
 	mkdir -p $(BUILD_DIR)
 	$(GO) test -race -shuffle=on -covermode=atomic -coverpkg=./... -coverprofile=$(COVERPROFILE) ./...

--- a/internal/ci/covercheck/main.go
+++ b/internal/ci/covercheck/main.go
@@ -10,7 +10,19 @@ import (
 	"strings"
 )
 
-const threshold = 95.0
+const defaultThreshold = 95.0
+
+func threshold() float64 {
+	v := os.Getenv("COVER_THRESH")
+	if v == "" {
+		return defaultThreshold
+	}
+	t, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return defaultThreshold
+	}
+	return t
+}
 
 var ignore = []string{
 	"internal/ci/",
@@ -77,8 +89,9 @@ func run(args []string, out, errOut io.Writer) int {
 
 	pct := covered / total * 100
 	fmt.Fprintf(out, "Total coverage: %.1f%%\n", pct)
-	if pct < threshold {
-		fmt.Fprintf(errOut, "Coverage %.1f%% is below %.1f%%\n", pct, threshold)
+	th := threshold()
+	if pct < th {
+		fmt.Fprintf(errOut, "Coverage %.1f%% is below %.1f%%\n", pct, th)
 		return 1
 	}
 	return 0

--- a/internal/ci/covercheck/run_test.go
+++ b/internal/ci/covercheck/run_test.go
@@ -56,3 +56,15 @@ func TestRunErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestRunEnvThreshold(t *testing.T) {
+	dir := t.TempDir()
+	profile := filepath.Join(dir, "cov.out")
+	os.WriteFile(profile, []byte("mode: set\nfile.go:1.1,1.2 1 0\n"), 0o644)
+	t.Setenv("COVER_THRESH", "0")
+	var out, errBuf bytes.Buffer
+	code := run([]string{"covercheck", profile}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, errBuf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- allow overriding coverage threshold with COVER_THRESH env var
- export COVER_THRESH in Makefile cover target for shared config
- test env override behavior

## Testing
- `go test ./internal/ci/covercheck`
- `make cover` *(fails: Coverage 13.0% is below 95.0%)*

------
https://chatgpt.com/codex/tasks/task_e_68b32e2343248323b7454d8b4f109122