### PR TITLE
align: centralize canonical attribute order

### DIFF
--- a/internal/align/canonical.go
+++ b/internal/align/canonical.go
@@ -1,0 +1,14 @@
+// internal/align/canonical.go
+package align
+
+import "github.com/oferchen/hclalign/config"
+
+// CanonicalBlockAttrOrder maps block types to their default attribute ordering.
+var CanonicalBlockAttrOrder = map[string][]string{
+	"variable": config.CanonicalOrder,
+	"output":   {"description", "value", "sensitive", "depends_on"},
+	"module":   {"source", "version", "providers", "count", "for_each", "depends_on"},
+	"provider": {"alias"},
+	"resource": {"provider", "count", "for_each", "depends_on"},
+	"data":     {"provider", "count", "for_each", "depends_on"},
+}

--- a/internal/align/module.go
+++ b/internal/align/module.go
@@ -14,29 +14,14 @@ func (moduleStrategy) Name() string { return "module" }
 func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrs := block.Body().Attributes()
 
+	canonical := CanonicalBlockAttrOrder["module"]
 	order := make([]string, 0, len(attrs))
-
-	if _, ok := attrs["source"]; ok {
-		order = append(order, "source")
-	}
-	if _, ok := attrs["version"]; ok {
-		order = append(order, "version")
-	}
-
-	metaArgs := []string{"providers", "count", "for_each", "depends_on"}
-	for _, name := range metaArgs {
+	reserved := make(map[string]struct{}, len(canonical))
+	for _, name := range canonical {
 		if _, ok := attrs[name]; ok {
 			order = append(order, name)
 		}
-	}
-
-	reserved := map[string]struct{}{
-		"source":     {},
-		"version":    {},
-		"providers":  {},
-		"count":      {},
-		"for_each":   {},
-		"depends_on": {},
+		reserved[name] = struct{}{}
 	}
 
 	vars := make([]string, 0, len(attrs))

--- a/internal/align/output.go
+++ b/internal/align/output.go
@@ -10,14 +10,13 @@ type outputStrategy struct{}
 
 func (outputStrategy) Name() string { return "output" }
 
-var outputCanonicalOrder = []string{"description", "value", "sensitive", "depends_on"}
-
 func (outputStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrs := block.Body().Attributes()
 
+	canonical := CanonicalBlockAttrOrder["output"]
 	order := make([]string, 0, len(attrs))
-	reserved := make(map[string]struct{}, len(outputCanonicalOrder))
-	for _, name := range outputCanonicalOrder {
+	reserved := make(map[string]struct{}, len(canonical))
+	for _, name := range canonical {
 		if _, ok := attrs[name]; ok {
 			order = append(order, name)
 		}

--- a/internal/align/provider.go
+++ b/internal/align/provider.go
@@ -12,18 +12,21 @@ type providerStrategy struct{}
 func (providerStrategy) Name() string { return "provider" }
 
 func (providerStrategy) Align(block *hclwrite.Block, opts *Options) error {
-	body := block.Body()
+	attrs := block.Body().Attributes()
+	canonical := CanonicalBlockAttrOrder["provider"]
 
-	attrs := body.Attributes()
 	names := make([]string, 0, len(attrs))
-
-	if _, ok := attrs["alias"]; ok {
-		names = append(names, "alias")
+	reserved := make(map[string]struct{}, len(canonical))
+	for _, name := range canonical {
+		if _, ok := attrs[name]; ok {
+			names = append(names, name)
+		}
+		reserved[name] = struct{}{}
 	}
 
 	others := make([]string, 0, len(attrs))
 	for name := range attrs {
-		if name == "alias" {
+		if _, ok := reserved[name]; ok {
 			continue
 		}
 		others = append(others, name)

--- a/internal/align/resource.go
+++ b/internal/align/resource.go
@@ -29,8 +29,9 @@ func schemaAwareOrder(block *hclwrite.Block, opts *Options) error {
 		names = append(names, name)
 	}
 	if opts == nil || opts.Schema == nil {
+		canonical := CanonicalBlockAttrOrder[block.Type()]
 		metaAttrs := []string{}
-		for _, n := range []string{"provider", "count", "for_each", "depends_on"} {
+		for _, n := range canonical {
 			if _, ok := attrs[n]; ok {
 				metaAttrs = append(metaAttrs, n)
 			}
@@ -71,8 +72,9 @@ func schemaAwareOrder(block *hclwrite.Block, opts *Options) error {
 	sort.Strings(opt)
 	sort.Strings(comp)
 
+	canonical := CanonicalBlockAttrOrder[block.Type()]
 	metaAttrs := []string{}
-	for _, n := range []string{"provider", "count", "for_each", "depends_on"} {
+	for _, n := range canonical {
 		if _, ok := attrs[n]; ok {
 			metaAttrs = append(metaAttrs, n)
 		}


### PR DESCRIPTION
## Summary
- centralize default attribute sequences in a new canonical mapping
- update module, output, provider, and resource strategies to read from canonical orders

## Testing
- `make tidy`
- `make lint` *(fails: cyclomatic complexity high for existing functions)*
- `make test`
- `make build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b32e2b5b4c8323871c98ab1ca6f98a