### PR TITLE
allow ordering validation blocks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -40,7 +40,7 @@ type Config struct {
 var (
 	DefaultInclude = []string{"**/*.tf"}
 	DefaultExclude = []string{"**/.terraform/**", "**/vendor/**", "**/.git/**", "**/node_modules/**"}
-	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable", "validation"}
+	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
 )
 
 const (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,7 @@ func TestValidateOrder_EmptyAttribute(t *testing.T) {
 }
 
 func TestCanonicalOrderMatchesBuiltInAttributes(t *testing.T) {
-	expected := []string{"description", "type", "default", "sensitive", "nullable", "validation"}
+	expected := []string{"description", "type", "default", "sensitive", "nullable"}
 	if !reflect.DeepEqual(CanonicalOrder, expected) {
 		t.Fatalf("expected CanonicalOrder to be %v, got %v", expected, CanonicalOrder)
 	}

--- a/internal/align/reorder_attributes_test.go
+++ b/internal/align/reorder_attributes_test.go
@@ -159,3 +159,53 @@ func TestReorderAttributes_InlineCommentAfterBrace(t *testing.T) {
 
 	require.Equal(t, src, string(f.Bytes()))
 }
+
+func TestReorderAttributes_CustomOrderValidationFirst(t *testing.T) {
+	src := `variable "example" {
+  description = "d"
+  validation {
+    condition     = true
+    error_message = "msg"
+  }
+  type = string
+}`
+	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	require.NoError(t, alignpkg.ReorderAttributes(f, []string{"validation", "description", "type"}))
+
+	expected := `variable "example" {
+  validation {
+    condition     = true
+    error_message = "msg"
+  }
+  description = "d"
+  type        = string
+}`
+	require.Equal(t, expected, string(f.Bytes()))
+}
+
+func TestReorderAttributes_CustomOrderValidationMiddle(t *testing.T) {
+	src := `variable "example" {
+  description = "d"
+  validation {
+    condition     = true
+    error_message = "msg"
+  }
+  type = string
+}`
+	f, diags := hclwrite.ParseConfig([]byte(src), "test.hcl", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	require.NoError(t, alignpkg.ReorderAttributes(f, []string{"description", "validation", "type"}))
+
+	expected := `variable "example" {
+  description = "d"
+  validation {
+    condition     = true
+    error_message = "msg"
+  }
+  type = string
+}`
+	require.Equal(t, expected, string(f.Bytes()))
+}


### PR DESCRIPTION
## Summary
- remove `validation` from CanonicalOrder
- honor `validation` in `--order` to position validation blocks
- test variable ordering with validation blocks

## Testing
- `make tidy`
- `make lint` *(fails: cyclomatic complexity > 15)*
- `make test`
- `make cover` *(fails: Coverage 12.9% is below 95.0%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b331edc03c8323adb76c6671cb3990