### PR TITLE
Include variable block in golden tests

### DIFF
--- a/internal/align/golden_test.go
+++ b/internal/align/golden_test.go
@@ -23,6 +23,7 @@ func TestGolden(t *testing.T) {
 		"terraform": {},
 		"resource":  {},
 		"data":      {},
+		"variable":  {},
 	}
 	schemaPath := filepath.Join("..", "..", "tests", "testdata", "providers-schema.json")
 	schemas, err := alignschema.LoadFile(schemaPath)

--- a/internal/align/variable.go
+++ b/internal/align/variable.go
@@ -233,15 +233,6 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 		insertedValidation = true
 	}
 
-	if !insertedValidation {
-		for _, nb := range validationBlocks {
-			if lead, ok := blockLeadTokens[nb]; ok {
-				body.AppendUnstructuredTokens(lead)
-			}
-			body.AppendBlock(nb)
-		}
-	}
-
 	hasLeadingNewline := false
 	for _, t := range prefixTokens {
 		if t.Type == hclsyntax.TokenNewline {
@@ -261,6 +252,15 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalSet ma
 		if tok, ok := attrTokensMap[name]; ok {
 			body.AppendUnstructuredTokens(tok.LeadTokens)
 			body.SetAttributeRaw(name, tok.ExprTokens)
+		}
+	}
+
+	if !insertedValidation {
+		for _, nb := range validationBlocks {
+			if lead, ok := blockLeadTokens[nb]; ok {
+				body.AppendUnstructuredTokens(lead)
+			}
+			body.AppendBlock(nb)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- include variable cases in golden test suite
- ensure variable attributes reorder with validations after unknown fields

## Testing
- `go test -v ./internal/align -run TestGolden -count=1`
- `make cover` *(fails: Coverage 12.9% is below 95.0%)*

------
https://chatgpt.com/codex/tasks/task_e_68b336e11f248323bf8af6521be94d96