### PR TITLE
Ensure internal fmt strategy ignores Terraform binary

### DIFF
--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -21,19 +21,16 @@ const (
 )
 
 func Format(src []byte, filename, strategy string) ([]byte, error) {
-	switch Strategy(strategy) {
-	case StrategyGo:
-		return formatter.Format(src, filename)
-	case StrategyBinary:
-		return formatBinary(src)
-	case StrategyAuto, "":
-		if _, err := exec.LookPath("terraform"); err == nil {
-			return formatBinary(src)
-		}
-		return formatter.Format(src, filename)
-	default:
-		return nil, fmt.Errorf("unknown fmt strategy %q", strategy)
-	}
+        switch Strategy(strategy) {
+        case StrategyGo:
+                return formatter.Format(src, filename)
+        case StrategyBinary:
+                return formatBinary(src)
+       case StrategyAuto, "":
+               return formatter.Format(src, filename)
+        default:
+                return nil, fmt.Errorf("unknown fmt strategy %q", strategy)
+        }
 }
 
 func formatBinary(src []byte) ([]byte, error) {

--- a/internal/fmt/terraformfmt_test.go
+++ b/internal/fmt/terraformfmt_test.go
@@ -22,16 +22,16 @@ func TestGoMatchesBinary(t *testing.T) {
 	require.Equal(t, string(binFmt), string(goFmt))
 }
 
-func TestAutoMatchesBinary(t *testing.T) {
-	if _, err := exec.LookPath("terraform"); err != nil {
-		t.Skip("terraform binary not found")
-	}
-	src := []byte("variable \"a\" {\n  type = string\n}\n")
-	autoFmt, err := Format(src, "test.tf", string(StrategyAuto))
-	require.NoError(t, err)
-	binFmt, err := Format(src, "test.tf", string(StrategyBinary))
-	require.NoError(t, err)
-	require.Equal(t, string(binFmt), string(autoFmt))
+func TestAutoUsesGoEvenIfTerraformPresent(t *testing.T) {
+       if _, err := exec.LookPath("terraform"); err != nil {
+               t.Skip("terraform binary not found")
+       }
+       src := []byte("variable \"a\" {\n  type = string\n}\n")
+       autoFmt, err := Format(src, "test.tf", string(StrategyAuto))
+       require.NoError(t, err)
+       goFmt, err := Format(src, "test.tf", string(StrategyGo))
+       require.NoError(t, err)
+       require.Equal(t, string(goFmt), string(autoFmt))
 }
 
 func TestIdempotent(t *testing.T) {


### PR DESCRIPTION
## Summary
- Always format using internal Go formatter when strategy is `auto`
- Add test to prove `auto` uses Go formatter even if `terraform` is on PATH

## Testing
- `PATH=/tmp:$PATH go test ./...`
- `PATH=/tmp:$PATH go test -coverprofile=coverage.out ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b338e4535083239e8c9b8a11c9d19d