### PR TITLE
ci: run sanitize and align in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           cache: true
       - run: make tidy
       - run: make fmt
+      - run: make sanitize
+      - run: make align
       - run: make lint
       - name: Fuzz tests
         run: go test ./... -run=^$ -fuzz=Fuzz -fuzztime=5s


### PR DESCRIPTION
## Summary
- run `make sanitize` and `make align` in CI workflow

## Testing
- `make tidy`
- `make lint` *(fails: Error return value of `os.WriteFile` is not checked, cyclomatic complexity high)*
- `make test` *(fails: parsing error in tests/cases/crlf_bom)*
- `make cover` *(fails: parsing error in tests/cases/crlf_bom)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b347b0b8e4832387e8769db1826cb0