### PR TITLE
feat: sort terraform unknown attrs

### DIFF
--- a/internal/align/terraform.go
+++ b/internal/align/terraform.go
@@ -74,6 +74,9 @@ func (terraformStrategy) Align(block *hclwrite.Block, opts *Options) error {
 		}
 		otherAttrs = append(otherAttrs, name)
 	}
+	if opts != nil && opts.PrefixOrder {
+		sort.Strings(otherAttrs)
+	}
 
 	var items []item
 	if _, ok := attrTokens["required_version"]; ok {

--- a/internal/align/terraform_test.go
+++ b/internal/align/terraform_test.go
@@ -81,3 +81,18 @@ func TestTerraformBlockOrderWithoutExperiments(t *testing.T) {
 }`
 	require.Equal(t, exp, string(file.Bytes()))
 }
+
+func TestTerraformUnknownAttrsPrefixOrder(t *testing.T) {
+	src := []byte(`terraform {
+  zzz = 1
+  aaa = 2
+}`)
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{PrefixOrder: true}))
+	exp := `terraform {
+  aaa = 2
+  zzz = 1
+}`
+	require.Equal(t, exp, string(file.Bytes()))
+}

--- a/internal/engine/write_error_test.go
+++ b/internal/engine/write_error_test.go
@@ -51,7 +51,7 @@ func newRootCmd(exclusive bool) *cobra.Command {
 func TestProcessWriteFileError(t *testing.T) {
 	dir := t.TempDir()
 	casesDir := filepath.Join("..", "..", "tests", "cases")
-	data, err := os.ReadFile(filepath.Join(casesDir, "simple", "in.tf"))
+	data, err := os.ReadFile(filepath.Join(casesDir, "variable", "in.tf"))
 	require.NoError(t, err)
 	filePath := filepath.Join(dir, "example.tf")
 	require.NoError(t, os.WriteFile(filePath, data, 0o644))
@@ -63,7 +63,7 @@ func TestProcessWriteFileError(t *testing.T) {
 	defer func() { enginepkg.WriteFileAtomic = original }()
 
 	cmd := newRootCmd(true)
-	cmd.SetArgs([]string{filePath, "--write"})
+	cmd.SetArgs([]string{filePath, "--write", "--prefix-order"})
 	_, err = cmd.ExecuteC()
 	require.Error(t, err)
 	var exitErr *cli.ExitCodeError


### PR DESCRIPTION
## Summary
- sort terraform block's unknown attributes when `--prefix-order` is enabled
- extend terraform alignment tests
- stabilize engine symlink/concurrency scenarios and cover write errors

## Testing
- `go test -race -shuffle=on -coverprofile=.build/coverage.out ./...`
- `go tool cover -func=.build/coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68b34b6a79048323b9c039a450113ac8