### PR TITLE
feat: add terraform runner

### DIFF
--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -128,7 +128,7 @@ func (p *Processor) processFile(ctx context.Context, filePath string) (bool, []b
 
 	original := data
 	hadNewline := len(data) > 0 && data[len(data)-1] == '\n'
-	formatted, err := terraformfmt.Format(data, filePath, "")
+	formatted, err := terraformfmt.Run(ctx, filePath, data)
 	if err != nil {
 		return false, nil, fmt.Errorf("parsing error in file %s: %w", filePath, err)
 	}
@@ -155,7 +155,7 @@ func (p *Processor) processFile(ctx context.Context, filePath string) (bool, []b
 	if testHookAfterReorder != nil {
 		testHookAfterReorder()
 	}
-	formatted, err = terraformfmt.Format(file.Bytes(), filePath, "")
+	formatted, err = terraformfmt.Run(ctx, filePath, file.Bytes())
 	if err != nil {
 		return false, nil, err
 	}

--- a/internal/fmt/runner.go
+++ b/internal/fmt/runner.go
@@ -1,0 +1,55 @@
+// filename: internal/fmt/runner.go
+package terraformfmt
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"unicode/utf8"
+
+	"github.com/oferchen/hclalign/formatter"
+	internalfs "github.com/oferchen/hclalign/internal/fs"
+)
+
+func Run(ctx context.Context, filename string, src []byte) ([]byte, error) {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		return formatter.Format(src, filename)
+	}
+	hints := internalfs.DetectHintsFromBytes(src)
+	src = internalfs.PrepareForParse(src, hints)
+	if len(src) > 0 && !utf8.Valid(src) {
+		return nil, fmt.Errorf("input is not valid UTF-8")
+	}
+	dir := filepath.Dir(filename)
+	tmp, err := os.CreateTemp(dir, "hclalign-*.tf")
+	if err != nil {
+		return nil, err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(src); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return nil, err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return nil, err
+	}
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "terraform", "fmt", "-no-color", "-list=false", "-write=true", "-diff=false", tmpName)
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		os.Remove(tmpName)
+		return nil, fmt.Errorf("terraform fmt failed: %v: %s", err, stderr.String())
+	}
+	formatted, err := os.ReadFile(tmpName)
+	os.Remove(tmpName)
+	if err != nil {
+		return nil, err
+	}
+	formatted = internalfs.ApplyHints(formatted, hints)
+	return formatted, nil
+}

--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -27,7 +27,7 @@ func Format(src []byte, filename, strategy string) ([]byte, error) {
 	case StrategyBinary:
 		return formatBinary(src)
 	case StrategyAuto, "":
-		return formatter.Format(src, filename)
+		return Run(context.Background(), filename, src)
 	default:
 		return nil, fmt.Errorf("unknown fmt strategy %q", strategy)
 	}

--- a/internal/fmt/terraformfmt_test.go
+++ b/internal/fmt/terraformfmt_test.go
@@ -4,6 +4,8 @@ package terraformfmt
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	internalfs "github.com/oferchen/hclalign/internal/fs"
@@ -22,16 +24,25 @@ func TestGoMatchesBinary(t *testing.T) {
 	require.Equal(t, string(binFmt), string(goFmt))
 }
 
-func TestAutoUsesGoEvenIfTerraformPresent(t *testing.T) {
-	if _, err := exec.LookPath("terraform"); err != nil {
-		t.Skip("terraform binary not found")
-	}
+func TestAutoPrefersTerraformBinary(t *testing.T) {
+	tmpDir := t.TempDir()
+	argsOut := filepath.Join(tmpDir, "args.txt")
+	script := filepath.Join(tmpDir, "terraform")
+	content := "#!/bin/sh\n" + "echo \"$@\" > \"$MOCK_TF_ARGS_OUT\"\n"
+	require.NoError(t, os.WriteFile(script, []byte(content), 0o755))
+	oldPath := os.Getenv("PATH")
+	require.NoError(t, os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath))
+	defer os.Setenv("PATH", oldPath)
+	require.NoError(t, os.Setenv("MOCK_TF_ARGS_OUT", argsOut))
 	src := []byte("variable \"a\" {\n  type = string\n}\n")
-	autoFmt, err := Format(src, "test.tf", string(StrategyAuto))
+	formatted, err := Format(src, "test.tf", string(StrategyAuto))
 	require.NoError(t, err)
-	goFmt, err := Format(src, "test.tf", string(StrategyGo))
+	require.Equal(t, string(src), string(formatted))
+	argsBytes, err := os.ReadFile(argsOut)
 	require.NoError(t, err)
-	require.Equal(t, string(goFmt), string(autoFmt))
+	fields := strings.Fields(string(argsBytes))
+	require.Greater(t, len(fields), 0)
+	require.NotEqual(t, "-", fields[len(fields)-1])
 }
 
 func TestIdempotent(t *testing.T) {


### PR DESCRIPTION
## Summary
- add terraform fmt runner that uses temp files and falls back to Go formatter
- call new runner in pipeline around alignment
- ensure auto strategy prefers terraform binary and falls back to Go when absent

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68b3517c1da08323893b8c7271e51d2f