### PR TITLE
stripcomments: add repo-root flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,12 @@ align: fmt ## align tests
 lint: ## run linters
 	$(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run --timeout=5m
 
-sanitize: ## enforce comment policy
-	mkdir -p $(BUILD_DIR)
-	$(GO) build -o $(BUILD_DIR)/stripcomments ./tools/stripcomments
-	$(BUILD_DIR)/stripcomments $(shell git ls-files '*.go')
+sanitize: strip ## enforce comment policy
 	$(GO) run ./cmd/commentcheck
 	$(GO) build $(PKG)
+
+strip: ## normalize Go file comments
+	$(GO) run ./tools/stripcomments --repo-root "$(PWD)"
 
 vet: ## vet code
 	$(GO) vet $(PKG)

--- a/tools/stripcomments/main_test.go
+++ b/tools/stripcomments/main_test.go
@@ -48,9 +48,59 @@ func TestProcess(t *testing.T) {
 	}
 }
 
-func TestMainNoArgs(t *testing.T) {
+func TestMainRepoRoot(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "x.go")
+	src := strings.Join([]string{
+		"//go:build tag",
+		"",
+		"package main",
+		"",
+		"// pkg comment",
+		"import \"fmt\"",
+		"",
+		"// main comment",
+		"func main() { fmt.Println(\"hi\") } // inline",
+	}, "\n") + "\n"
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	toolDir := filepath.Join(dir, "tools", "stripcomments")
+	if err := os.MkdirAll(toolDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ignoreFile := filepath.Join(toolDir, "ignore.go")
+	ignoreSrc := "package ignore\n// keep\n"
+	if err := os.WriteFile(ignoreFile, []byte(ignoreSrc), 0o644); err != nil {
+		t.Fatalf("write ignore: %v", err)
+	}
 	old := os.Args
 	defer func() { os.Args = old }()
-	os.Args = []string{"stripcomments"}
+	os.Args = []string{"stripcomments", "--repo-root", dir}
 	main()
+	out, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	expected := strings.Join([]string{
+		"//go:build tag",
+		"",
+		"// filename: x.go",
+		"package main",
+		"",
+		"import \"fmt\"",
+		"",
+		"func main() { fmt.Println(\"hi\") }",
+		"",
+	}, "\n")
+	if string(out) != expected {
+		t.Fatalf("got %q want %q", out, expected)
+	}
+	ignored, err := os.ReadFile(ignoreFile)
+	if err != nil {
+		t.Fatalf("read ignore: %v", err)
+	}
+	if string(ignored) != ignoreSrc {
+		t.Fatalf("ignored file changed: got %q want %q", ignored, ignoreSrc)
+	}
 }


### PR DESCRIPTION
## Summary
- add mandatory `--repo-root` flag to `tools/stripcomments` to walk Go files while skipping the tool directory
- auto-discover files from repository root and update tests
- add `strip` Makefile target invoking `go run ./tools/stripcomments --repo-root "$(PWD)"`

## Testing
- `go test -v ./tools/stripcomments`
- `make strip`


------
https://chatgpt.com/codex/tasks/task_e_68b351975630832393eef652db35c09d