### PR TITLE
refactor: remove block order support

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -32,7 +32,7 @@ func newTestRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().Bool("stdout", false, "write result to STDOUT")
 	cmd.Flags().StringSlice("include", config.DefaultInclude, "glob patterns to include")
 	cmd.Flags().StringSlice("exclude", config.DefaultExclude, "glob patterns to exclude")
-	cmd.Flags().StringSlice("order", config.CanonicalOrder, "order of variable block fields and per-block ordering flags (e.g. locals=alphabetical)")
+	cmd.Flags().StringSlice("order", config.CanonicalOrder, "order of variable block fields")
 	cmd.Flags().String("providers-schema", "", "path to providers schema file")
 	cmd.Flags().Bool("use-terraform-schema", false, "use terraform schema for providers")
 	cmd.Flags().Int("concurrency", runtime.GOMAXPROCS(0), "maximum concurrency")
@@ -389,20 +389,4 @@ func TestRunEFollowSymlinks(t *testing.T) {
 			require.Equal(t, tt.want, string(data))
 		})
 	}
-}
-
-func TestRunELocalsAlphabetical(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "test.tf")
-	content := "locals {\n  b = 2\n  a = 1\n}\n"
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
-
-	cmd := newRootCmd(true)
-	cmd.SetArgs([]string{path, "--order", "locals=alphabetical", "--types", "locals"})
-	_, err := cmd.ExecuteC()
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(path)
-	require.NoError(t, err)
-	require.Equal(t, "locals {\n  a = 1\n  b = 2\n}\n", string(data))
 }

--- a/cli/parse.go
+++ b/cli/parse.go
@@ -36,7 +36,7 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 		return nil, err
 	}
 
-	attrOrder, blockOrder, err := config.ParseOrder(orderRaw)
+	attrOrder, err := config.ParseOrder(orderRaw)
 	if err != nil {
 		return nil, &ExitCodeError{Err: err, Code: 2}
 	}
@@ -78,7 +78,6 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 		Include:            include,
 		Exclude:            exclude,
 		Order:              attrOrder,
-		BlockOrder:         blockOrder,
 		ProvidersSchema:    providersSchema,
 		UseTerraformSchema: useTerraformSchema,
 		Concurrency:        concurrency,

--- a/cmd/hclalign/main.go
+++ b/cmd/hclalign/main.go
@@ -36,7 +36,7 @@ func run(args []string) int {
 	rootCmd.Flags().Bool("stdout", false, "write result to STDOUT")
 	rootCmd.Flags().StringSlice("include", config.DefaultInclude, "glob patterns to include")
 	rootCmd.Flags().StringSlice("exclude", config.DefaultExclude, "glob patterns to exclude")
-	rootCmd.Flags().StringSlice("order", config.CanonicalOrder, "order of variable block fields and per-block ordering flags (e.g. locals=alphabetical)")
+	rootCmd.Flags().StringSlice("order", config.CanonicalOrder, "order of variable block fields")
 	rootCmd.Flags().String("providers-schema", "", "path to providers schema file")
 	rootCmd.Flags().Bool("use-terraform-schema", false, "use terraform schema for providers")
 	rootCmd.Flags().Int("concurrency", runtime.GOMAXPROCS(0), "maximum concurrency")

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ package config
 import (
 	"fmt"
 	"runtime"
-	"strings"
 
 	"github.com/oferchen/hclalign/patternmatching"
 )
@@ -27,7 +26,6 @@ type Config struct {
 	Include            []string
 	Exclude            []string
 	Order              []string
-	BlockOrder         map[string]string
 	Concurrency        int
 	Verbose            bool
 	FollowSymlinks     bool
@@ -59,9 +57,6 @@ func (c *Config) Validate() error {
 	}
 	if err := patternmatching.ValidatePatterns(c.Exclude); err != nil {
 		return fmt.Errorf("invalid exclude: %w", err)
-	}
-	if err := ValidateBlockOrder(c.BlockOrder); err != nil {
-		return fmt.Errorf("invalid order: %w", err)
 	}
 	if err := ValidateOrder(c.Order); err != nil {
 		return fmt.Errorf("invalid order: %w", err)
@@ -98,39 +93,9 @@ func ValidateOrder(order []string) error {
 	return nil
 }
 
-func ValidateBlockOrder(order map[string]string) error {
-	for block, val := range order {
-		if block != "locals" || val != "alphabetical" {
-			return fmt.Errorf("unknown block ordering '%s=%s'", block, val)
-		}
+func ParseOrder(order []string) ([]string, error) {
+	if err := ValidateOrder(order); err != nil {
+		return nil, err
 	}
-	return nil
-}
-
-func ParseOrder(order []string) ([]string, map[string]string, error) {
-	attrs := make([]string, 0, len(order))
-	attrSet := make(map[string]struct{}, len(order))
-	blocks := make(map[string]string)
-	for _, item := range order {
-		if item == "" {
-			return nil, nil, fmt.Errorf("attribute name cannot be empty")
-		}
-		if strings.Contains(item, "=") {
-			block, val, ok := strings.Cut(item, "=")
-			if !ok || block == "" || val == "" {
-				return nil, nil, fmt.Errorf("invalid block ordering '%s'", item)
-			}
-			if _, exists := blocks[block]; exists {
-				return nil, nil, fmt.Errorf("duplicate attribute '%s' found in order", item)
-			}
-			blocks[block] = val
-			continue
-		}
-		if _, exists := attrSet[item]; exists {
-			return nil, nil, fmt.Errorf("duplicate attribute '%s' found in order", item)
-		}
-		attrSet[item] = struct{}{}
-		attrs = append(attrs, item)
-	}
-	return attrs, blocks, nil
+	return append([]string(nil), order...), nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,25 +37,6 @@ func TestValidateOrder_EmptyAttributeName(t *testing.T) {
 	}
 }
 
-func TestParseOrder_BlockOrderingFlag(t *testing.T) {
-	attrs, blocks, err := ParseOrder([]string{"locals=alphabetical"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(attrs) != 0 {
-		t.Fatalf("expected no attributes, got %v", attrs)
-	}
-	if blocks["locals"] != "alphabetical" {
-		t.Fatalf("expected locals=alphabetical, got %v", blocks)
-	}
-}
-
-func TestParseOrder_DuplicateBlockOrderingFlag(t *testing.T) {
-	if _, _, err := ParseOrder([]string{"locals=alphabetical", "locals=alphabetical"}); err == nil {
-		t.Fatalf("expected error for duplicate block ordering flag")
-	}
-}
-
 func TestDefaultExcludeMatchesExpected(t *testing.T) {
 	expected := []string{"**/.terraform/**", "**/vendor/**", "**/.git/**", "**/node_modules/**"}
 	if !reflect.DeepEqual(DefaultExclude, expected) {

--- a/internal/align/locals.go
+++ b/internal/align/locals.go
@@ -1,28 +1,12 @@
 // filename: internal/align/locals.go
 package align
 
-import (
-	"sort"
-
-	"github.com/hashicorp/hcl/v2/hclwrite"
-)
+import "github.com/hashicorp/hcl/v2/hclwrite"
 
 type localsStrategy struct{}
 
 func (localsStrategy) Name() string { return "locals" }
 
-func (localsStrategy) Align(block *hclwrite.Block, opts *Options) error {
-	if opts == nil || opts.BlockOrder == nil || opts.BlockOrder["locals"] != "alphabetical" {
-		return nil
-	}
-
-	attrs := block.Body().Attributes()
-	names := make([]string, 0, len(attrs))
-	for n := range attrs {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	return reorderBlock(block, names)
-}
+func (localsStrategy) Align(block *hclwrite.Block, opts *Options) error { return nil }
 
 func init() { Register(localsStrategy{}) }

--- a/internal/align/locals_test.go
+++ b/internal/align/locals_test.go
@@ -27,21 +27,3 @@ func TestLocalsPreservesAttributeOrder(t *testing.T) {
 }`
 	require.Equal(t, exp, got)
 }
-
-func TestLocalsAlphabeticalOrderFlag(t *testing.T) {
-	src := []byte(`locals {
-  z = 3
-  a = 1
-  m = 2
-}`)
-	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
-	require.False(t, diags.HasErrors())
-	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{BlockOrder: map[string]string{"locals": "alphabetical"}}))
-	got := string(file.Bytes())
-	exp := `locals {
-  a = 1
-  m = 2
-  z = 3
-}`
-	require.Equal(t, exp, got)
-}

--- a/internal/align/provider_test.go
+++ b/internal/align/provider_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProviderNestedBlockOrder(t *testing.T) {
+func TestProviderNestedBlocksPreserveOrder(t *testing.T) {
 	src := []byte(`provider "aws" {
   nested "b" {}
   assume_role {}

--- a/internal/align/strategy.go
+++ b/internal/align/strategy.go
@@ -4,8 +4,7 @@ package align
 import "github.com/hashicorp/hcl/v2/hclwrite"
 
 type Options struct {
-	Order      []string
-	BlockOrder map[string]string
+	Order []string
 
 	Schemas map[string]*Schema
 

--- a/internal/align/terraform_test.go
+++ b/internal/align/terraform_test.go
@@ -61,7 +61,7 @@ func TestTerraformRequiredProvidersSorting(t *testing.T) {
 	require.Equal(t, exp, string(file.Bytes()))
 }
 
-func TestTerraformBlockOrderWithoutExperiments(t *testing.T) {
+func TestTerraformBlocksOrderWithoutExperiments(t *testing.T) {
 	src := []byte(`terraform {
   backend "s3" {}
   required_providers {}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -101,7 +101,7 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 			typesMap[t] = struct{}{}
 		}
 	}
-	if err := align.Apply(file, &align.Options{Order: cfg.Order, BlockOrder: cfg.BlockOrder, Schemas: schemas, Types: typesMap, PrefixOrder: cfg.PrefixOrder}); err != nil {
+	if err := align.Apply(file, &align.Options{Order: cfg.Order, Schemas: schemas, Types: typesMap, PrefixOrder: cfg.PrefixOrder}); err != nil {
 		return false, err
 	}
 	formatted, err = terraformfmt.Format(file.Bytes(), "stdin", "")

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -149,7 +149,7 @@ func (p *Processor) processFile(ctx context.Context, filePath string) (bool, []b
 			typesMap[t] = struct{}{}
 		}
 	}
-	if err := align.Apply(file, &align.Options{Order: p.cfg.Order, BlockOrder: p.cfg.BlockOrder, Schemas: p.schemas, Types: typesMap, PrefixOrder: p.cfg.PrefixOrder}); err != nil {
+	if err := align.Apply(file, &align.Options{Order: p.cfg.Order, Schemas: p.schemas, Types: typesMap, PrefixOrder: p.cfg.PrefixOrder}); err != nil {
 		return false, nil, err
 	}
 	if testHookAfterReorder != nil {


### PR DESCRIPTION
## Summary
- remove BlockOrder option and validation
- simplify locals aligner to a no-op
- drop locals=alphabetical flag references

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b3518946b88323ba69ce8af5ecad56