### PR TITLE
chore: streamline build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ cat variables.tf | hclalign --stdin --stdout
 | --- | --- |
 | `make init` | download and verify Go modules |
 | `make tidy` | tidy module dependencies |
-| `make fmt` | run gofumpt (via `go run`) and gofmt on the codebase; `terraform fmt` then `hclalign` on test cases |
+| `make fmt` | run `gofumpt` (v0.6.0) and `gofmt`; run `terraform fmt` on test cases if available |
+| `make strip` | remove comments and enforce the single-line comment policy |
 | `make lint` | execute `golangci-lint` |
 | `make vet` | run `go vet` |
 | `make test` | run tests with coverage |
@@ -157,9 +158,9 @@ cat variables.tf | hclalign --stdin --stdout
 | `make build` | build the `hclalign` binary into `.build/` |
 | `make clean` | remove build artifacts |
 
-Terraform CLI is optional. If installed, `make fmt` runs `terraform fmt` on `tests/cases` before invoking `hclalign`; otherwise `terraform fmt` is skipped with a warning.
+Terraform CLI is optional. If installed, `make fmt` runs `terraform fmt` on `tests/cases`.
 
-`make fmt` uses `go run mvdan.cc/gofumpt@latest` so contributors do not need to install `gofumpt` manually.
+`make fmt` uses `go run mvdan.cc/gofumpt@v0.6.0` so contributors do not need to install `gofumpt` manually.
 
 ## Continuous Integration
 Use `hclalign . --check` in CI to fail builds when formatting is needed. The provided GitHub Actions workflow runs `make tidy`, `make fmt`, `make lint`, `make test-race`, and `make cover` on Linux and macOS with multiple Go versions.


### PR DESCRIPTION
## Summary
- streamline Makefile with updated phony targets and pinned tool versions
- document new targets and fmt behavior in README

## Testing
- `make tidy`
- `make fmt`
- `make strip` *(fails: stat /workspace/hclalign/--: no such file or directory)*
- `make lint` *(fails: could not import unicode/utf8; unsupported version 2)*
- `make test`
- `make cover` *(fails: coverage 87.8% is below 95%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b3517ba0ac832396550841d0e2815f