### PR TITLE
Consolidate strip target and streamline fmt workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
       - run: make tidy
       - run: make fmt
       - run: go run ./cmd/hclalign --check tests/cases
-      - run: make strip
       - run: make lint
       - run: make vet
       - name: Fuzz tests

--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,18 @@ tidy: ## tidy modules
 fmt: ## format code
 	$(GO) run mvdan.cc/gofumpt@v0.6.0 -w .
 	gofmt -s -w .
+	$(MAKE) strip
 	@if command -v terraform >/dev/null 2>&1; then \
-	terraform fmt -list=false -diff=false -write=true tests/cases; \
+	terraform fmt -recursive tests/cases; \
 	fi
+	$(GO) run ./cmd/hclalign tests/cases
 
-strip: ## remove comments and enforce policy
-	$(GO) run ./tools/stripcomments -- --repo-root "$(PWD)"
+strip: ## normalize Go file comments and enforce policy
+	$(GO) run ./tools/stripcomments --repo-root "$(PWD)"
 	$(GO) run ./cmd/commentcheck
 
 lint: ## run linters
-	$(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1 run --timeout=5m
-
-strip: ## normalize Go file comments
-	$(GO) run ./tools/stripcomments --repo-root "$(PWD)"
+	       $(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1 run --timeout=5m
 
 vet: ## vet code
 	$(GO) vet $(PKG)


### PR DESCRIPTION
## Summary
- consolidate duplicate `strip` target to enforce comments via `tools/stripcomments` then `cmd/commentcheck`
- expand `fmt` target to format Go, strip comments, run `terraform fmt` and canonicalize fixtures with `hclalign`
- simplify CI to invoke only the updated `fmt` target

## Testing
- `make fmt` *(fails: tests/cases/crlf_bom/fmt.tf: parsing error)*
- `go test ./...` *(fails: golden test mismatch for crlf_bom)*

------
https://chatgpt.com/codex/tasks/task_e_68b35a0e73208323a337699d68d0b1f7