### PR TITLE
Add ephemeral output attribute alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This process is idempotent: running the tool multiple times yields the same resu
 
 The default schema orders variable attributes as `description → type → default → sensitive → nullable → validation`. Additional block types have their own canonical order:
 
-- **output:** `description`, `value`, `sensitive`, `depends_on`
+- **output:** `description`, `value`, `sensitive`, `ephemeral`, `depends_on`
 - **module:** `source`, `version`, `providers`, `count`, `for_each`, `depends_on`, then input variables alphabetically
 - **provider:** `alias` followed by other attributes alphabetically
 - **terraform:** `required_version`, `experiments`, `required_providers` (entries sorted alphabetically), `backend`, `cloud`, then remaining attributes and blocks in their original order

--- a/internal/align/canonical.go
+++ b/internal/align/canonical.go
@@ -5,7 +5,7 @@ import "github.com/oferchen/hclalign/config"
 
 var CanonicalBlockAttrOrder = map[string][]string{
 	"variable": config.CanonicalOrder,
-	"output":   {"description", "value", "sensitive", "depends_on"},
+	"output":   {"description", "value", "sensitive", "ephemeral", "depends_on"},
 	"module":   {"source", "version", "providers", "count", "for_each", "depends_on"},
 	"provider": {"alias"},
 	"resource": {"provider", "count", "for_each", "depends_on"},

--- a/internal/align/output_test.go
+++ b/internal/align/output_test.go
@@ -1,0 +1,31 @@
+// filename: internal/align/output_test.go
+package align_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	alignpkg "github.com/oferchen/hclalign/internal/align"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutputEphemeralAttributeOrder(t *testing.T) {
+	src := []byte(`output "ephemeral" {
+  value      = var.v
+  depends_on = [var.x]
+  ephemeral  = true
+  sensitive  = false
+}`)
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
+	got := string(file.Bytes())
+	exp := `output "ephemeral" {
+  value      = var.v
+  sensitive  = false
+  ephemeral  = true
+  depends_on = [var.x]
+}`
+	require.Equal(t, exp, got)
+}

--- a/tests/cases/output/aligned.tf
+++ b/tests/cases/output/aligned.tf
@@ -14,6 +14,7 @@ output "unknown" {
 output "depends" {
   value      = var.c
   sensitive  = false
+  ephemeral  = true
   depends_on = [var.x]
   foo        = "bar"
 }

--- a/tests/cases/output/fmt.tf
+++ b/tests/cases/output/fmt.tf
@@ -13,6 +13,7 @@ output "unknown" {
 
 output "depends" {
   foo        = "bar"
+  ephemeral  = true
   sensitive  = false
   depends_on = [var.x]
   value      = var.c

--- a/tests/cases/output/in.tf
+++ b/tests/cases/output/in.tf
@@ -13,6 +13,7 @@ output "unknown" {
 
 output "depends" {
   foo        = "bar"
+  ephemeral  = true
   sensitive  = false
   depends_on = [var.x]
   value      = var.c

--- a/tests/cases/output/out.tf
+++ b/tests/cases/output/out.tf
@@ -14,6 +14,7 @@ output "unknown" {
 output "depends" {
   value      = var.c
   sensitive  = false
+  ephemeral  = true
   depends_on = [var.x]
   foo        = "bar"
 }


### PR DESCRIPTION
## Summary
- include `ephemeral` in canonical output attribute order
- add alignment test for `ephemeral` and update output fixtures
- document `ephemeral` in README

## Testing
- `go test ./internal/align -run TestOutputEphemeralAttributeOrder -count=1`
- `go test ./...` *(fails: fmt mismatch for crlf_bom golden case)*

------
https://chatgpt.com/codex/tasks/task_e_68b35a2402808323a3f6d08822ecfe37