### PR TITLE
ci: run race detector separately from default tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Vulnerability check
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
         continue-on-error: true
+      - run: make test
       - run: make test-race
       - run: make cover
         env:

--- a/Makefile
+++ b/Makefile
@@ -36,16 +36,15 @@ vet: ## vet code
 	$(GO) vet $(PKG)
 
 test: ## run tests
-	mkdir -p $(BUILD_DIR)
-	$(GO) test -race -shuffle=on -coverprofile=$(COVERPROFILE) $(PKG)
+	$(GO) test -shuffle=on -cover $(PKG)
 
 test-race: ## run tests with race detector
-	$(GO) test $(PKG) -race -shuffle=on
+	$(GO) test -race -shuffle=on $(PKG)
 
 cover: export COVER_THRESH ?= 95
 cover: ## run coverage check
 	mkdir -p $(BUILD_DIR)
-	$(GO) test -race -shuffle=on -covermode=atomic -coverpkg=./... -coverprofile=$(COVERPROFILE) ./...
+	$(GO) test -shuffle=on -covermode=atomic -coverpkg=./... -coverprofile=$(COVERPROFILE) ./...
 	$(GO) tool cover -func=$(COVERPROFILE) | awk -v thresh=$(COVER_THRESH) '/^total:/ { sub(/%/, "", $$3); if ($$3+0 < thresh) { printf "coverage %.1f%% is below %d%%\n", $$3, thresh; exit 1 } }'
 
 build: ## build binary


### PR DESCRIPTION
## Summary
- run `go test` without the race detector in the default `make test`
- keep race detector isolated to `make test-race`
- update CI workflow to run new test targets

## Testing
- `make test` *(fails: fmt mismatch for crlf_bom)*
- `make test-race` *(fails: fmt mismatch for crlf_bom)*
- `make cover` *(fails: fmt mismatch for crlf_bom)*

------
https://chatgpt.com/codex/tasks/task_e_68b35a331fec8323b9120c5e0df5ff0f