### PR TITLE
refactor fmt runner to use stdin

### DIFF
--- a/internal/align/golden_test.go
+++ b/internal/align/golden_test.go
@@ -13,6 +13,7 @@ import (
 	alignpkg "github.com/oferchen/hclalign/internal/align"
 	alignschema "github.com/oferchen/hclalign/internal/align/schema"
 	terraformfmt "github.com/oferchen/hclalign/internal/fmt"
+	internalfs "github.com/oferchen/hclalign/internal/fs"
 )
 
 func TestGolden(t *testing.T) {
@@ -87,7 +88,9 @@ func TestGolden(t *testing.T) {
 				t.Fatalf("fmt not idempotent for %s", name)
 			}
 
-			file, diags := hclwrite.ParseConfig(fmtBytes, fmtPath, hcl.InitialPos)
+			hints := internalfs.DetectHintsFromBytes(fmtBytes)
+			parseBytes := internalfs.PrepareForParse(fmtBytes, hints)
+			file, diags := hclwrite.ParseConfig(parseBytes, fmtPath, hcl.InitialPos)
 			if diags.HasErrors() {
 				t.Fatalf("parse fmt: %v", diags)
 			}

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -128,7 +128,7 @@ func (p *Processor) processFile(ctx context.Context, filePath string) (bool, []b
 
 	original := data
 	hadNewline := len(data) > 0 && data[len(data)-1] == '\n'
-	formatted, err := terraformfmt.Run(ctx, filePath, data)
+	formatted, err := terraformfmt.Run(ctx, data)
 	if err != nil {
 		return false, nil, fmt.Errorf("parsing error in file %s: %w", filePath, err)
 	}
@@ -155,7 +155,7 @@ func (p *Processor) processFile(ctx context.Context, filePath string) (bool, []b
 	if testHookAfterReorder != nil {
 		testHookAfterReorder()
 	}
-	formatted, err = terraformfmt.Run(ctx, filePath, file.Bytes())
+	formatted, err = terraformfmt.Run(ctx, file.Bytes())
 	if err != nil {
 		return false, nil, err
 	}

--- a/internal/fmt/runner.go
+++ b/internal/fmt/runner.go
@@ -2,54 +2,15 @@
 package terraformfmt
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"unicode/utf8"
 
 	"github.com/oferchen/hclalign/formatter"
-	internalfs "github.com/oferchen/hclalign/internal/fs"
 )
 
-func Run(ctx context.Context, filename string, src []byte) ([]byte, error) {
+func Run(ctx context.Context, src []byte) ([]byte, error) {
 	if _, err := exec.LookPath("terraform"); err != nil {
-		return formatter.Format(src, filename)
+		return formatter.Format(src, "")
 	}
-	hints := internalfs.DetectHintsFromBytes(src)
-	src = internalfs.PrepareForParse(src, hints)
-	if len(src) > 0 && !utf8.Valid(src) {
-		return nil, fmt.Errorf("input is not valid UTF-8")
-	}
-	dir := filepath.Dir(filename)
-	tmp, err := os.CreateTemp(dir, "hclalign-*.tf")
-	if err != nil {
-		return nil, err
-	}
-	tmpName := tmp.Name()
-	if _, err := tmp.Write(src); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
-		return nil, err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
-		return nil, err
-	}
-	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "terraform", "fmt", "-no-color", "-list=false", "-write=true", "-diff=false", tmpName)
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		os.Remove(tmpName)
-		return nil, fmt.Errorf("terraform fmt failed: %v: %s", err, stderr.String())
-	}
-	formatted, err := os.ReadFile(tmpName)
-	os.Remove(tmpName)
-	if err != nil {
-		return nil, err
-	}
-	formatted = internalfs.ApplyHints(formatted, hints)
-	return formatted, nil
+	return formatBinary(ctx, src)
 }

--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -25,21 +25,20 @@ func Format(src []byte, filename, strategy string) ([]byte, error) {
 	case StrategyGo:
 		return formatter.Format(src, filename)
 	case StrategyBinary:
-		return formatBinary(src)
+		return formatBinary(context.Background(), src)
 	case StrategyAuto, "":
-		return Run(context.Background(), filename, src)
+		return Run(context.Background(), src)
 	default:
 		return nil, fmt.Errorf("unknown fmt strategy %q", strategy)
 	}
 }
 
-func formatBinary(src []byte) ([]byte, error) {
+func formatBinary(ctx context.Context, src []byte) ([]byte, error) {
 	hints := internalfs.DetectHintsFromBytes(src)
 	src = internalfs.PrepareForParse(src, hints)
 	if len(src) > 0 && !utf8.Valid(src) {
 		return nil, fmt.Errorf("input is not valid UTF-8")
 	}
-	ctx := context.Background()
 	cmd := exec.CommandContext(ctx, "terraform", "fmt", "-no-color", "-list=false", "-write=false", "-")
 	cmd.Stdin = bytes.NewReader(src)
 	var stdout bytes.Buffer

--- a/tests/cases/crlf_bom/aligned.tf
+++ b/tests/cases/crlf_bom/aligned.tf
@@ -2,4 +2,3 @@ variable "crlf" {
   type    = number
   default = 1
 }
-

--- a/tests/cases/crlf_bom/fmt.tf
+++ b/tests/cases/crlf_bom/fmt.tf
@@ -3,5 +3,4 @@
   default = 1
 }
 
-  type    = number
 }


### PR DESCRIPTION
## Summary
- refactor terraform fmt runner to use stdin/stdout and drop temp files
- adjust engine pipeline and tests for new runner
- ensure formatter preserves BOM/CRLF and falls back when terraform is missing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b35a2d20048323a94bb4763c2e1a41