### PR TITLE
chore: simplify file header comment

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -14,7 +14,7 @@ Coordinate autonomous agents (and humans) to deliver a **production-grade, two-p
 Non-negotiables:
 
 * **Apache-2.0** license for the repo.
-* **Comment policy:** every `.go` file contains exactly **one** comment on line 1: `// filename: <repo-relative-path>`.
+* **Comment policy:** every `.go` file contains exactly **one** comment on line 1: `// <repo-relative-path>`.
 * **Atomic writes:** same-dir temp → fsync → rename; preserve mode; preserve BOM/CRLF.
 * **Idempotency:** running twice yields identical bytes.
 * **Coverage:** ≥ **95%** functional coverage (enforced in CI).

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,4 +1,4 @@
-// filename: cli/cli.go
+// cli/cli.go
 package cli
 
 import (

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,4 +1,4 @@
-// filename: cli/cli_test.go
+// cli/cli_test.go
 package cli
 
 import (

--- a/cli/parse.go
+++ b/cli/parse.go
@@ -1,4 +1,4 @@
-// filename: cli/parse.go
+// cli/parse.go
 package cli
 
 import (

--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -1,4 +1,4 @@
-// filename: cli/parse_test.go
+// cli/parse_test.go
 package cli
 
 import (

--- a/cmd/commentcheck/main.go
+++ b/cmd/commentcheck/main.go
@@ -1,4 +1,4 @@
-// filename: cmd/commentcheck/main.go
+// cmd/commentcheck/main.go
 package main
 
 import (
@@ -56,7 +56,7 @@ func check(root string) error {
 		if err != nil {
 			return err
 		}
-		want := "// filename: " + filepath.ToSlash(rel)
+		want := "// " + filepath.ToSlash(rel)
 		if len(lines) != 1 || lines[0] != buildLines+1 || len(texts) != 1 || texts[0] != want {
 			bad = append(bad, path)
 		}

--- a/cmd/commentcheck/main_test.go
+++ b/cmd/commentcheck/main_test.go
@@ -1,4 +1,4 @@
-// filename: cmd/commentcheck/main_test.go
+// cmd/commentcheck/main_test.go
 package main
 
 import (
@@ -10,14 +10,14 @@ import (
 func TestCheck(t *testing.T) {
 	t.Run("compliant", func(t *testing.T) {
 		dir := t.TempDir()
-		write(t, dir, "ok.go", "//go:build test\n// filename: ok.go\n\npackage main\n")
+		write(t, dir, "ok.go", "//go:build test\n// ok.go\n\npackage main\n")
 		if err := check(dir); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 	t.Run("noncompliant extra comment", func(t *testing.T) {
 		dir := t.TempDir()
-		write(t, dir, "bad.go", "//go:build test\n// filename: bad.go\n\npackage main\n// bad\n")
+		write(t, dir, "bad.go", "//go:build test\n// bad.go\n\npackage main\n// bad\n")
 		if err := check(dir); err == nil {
 			t.Fatalf("expected error")
 		}
@@ -31,14 +31,14 @@ func TestCheck(t *testing.T) {
 	})
 	t.Run("noncompliant wrong path", func(t *testing.T) {
 		dir := t.TempDir()
-		write(t, dir, "bad.go", "//go:build test\n// filename: other.go\n\npackage main\n")
+		write(t, dir, "bad.go", "//go:build test\n// other.go\n\npackage main\n")
 		if err := check(dir); err == nil {
 			t.Fatalf("expected error")
 		}
 	})
 	t.Run("noncompliant block comment", func(t *testing.T) {
 		dir := t.TempDir()
-		write(t, dir, "bad.go", "/* filename: bad.go */\npackage main\n")
+		write(t, dir, "bad.go", "/* bad.go */\npackage main\n")
 		if err := check(dir); err == nil {
 			t.Fatalf("expected error")
 		}

--- a/cmd/hclalign/main.go
+++ b/cmd/hclalign/main.go
@@ -1,4 +1,4 @@
-// filename: cmd/hclalign/main.go
+// cmd/hclalign/main.go
 package main
 
 import (

--- a/cmd/hclalign/main_test.go
+++ b/cmd/hclalign/main_test.go
@@ -1,4 +1,4 @@
-// filename: cmd/hclalign/main_test.go
+// cmd/hclalign/main_test.go
 package main
 
 import (

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// filename: config/config.go
+// config/config.go
 package config
 
 import (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,4 +1,4 @@
-// filename: config/config_test.go
+// config/config_test.go
 package config
 
 import (

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,4 +1,4 @@
-// filename: formatter/formatter.go
+// formatter/formatter.go
 package formatter
 
 import (

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,4 +1,4 @@
-// filename: formatter/formatter_test.go
+// formatter/formatter_test.go
 package formatter
 
 import (

--- a/internal/align/benchmark_test.go
+++ b/internal/align/benchmark_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/benchmark_test.go
+// internal/align/benchmark_test.go
 package align
 
 import (

--- a/internal/align/canonical.go
+++ b/internal/align/canonical.go
@@ -1,4 +1,4 @@
-// filename: internal/align/canonical.go
+// internal/align/canonical.go
 package align
 
 import "github.com/oferchen/hclalign/config"

--- a/internal/align/connection.go
+++ b/internal/align/connection.go
@@ -1,4 +1,4 @@
-// filename: internal/align/connection.go
+// internal/align/connection.go
 package align
 
 import (

--- a/internal/align/connection_test.go
+++ b/internal/align/connection_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/connection_test.go
+// internal/align/connection_test.go
 package align_test
 
 import (

--- a/internal/align/data.go
+++ b/internal/align/data.go
@@ -1,4 +1,4 @@
-// filename: internal/align/data.go
+// internal/align/data.go
 package align
 
 import "github.com/hashicorp/hcl/v2/hclwrite"

--- a/internal/align/dynamic.go
+++ b/internal/align/dynamic.go
@@ -1,4 +1,4 @@
-// filename: internal/align/dynamic.go
+// internal/align/dynamic.go
 package align
 
 import (

--- a/internal/align/dynamic_test.go
+++ b/internal/align/dynamic_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/dynamic_test.go
+// internal/align/dynamic_test.go
 package align_test
 
 import (

--- a/internal/align/fuzz_test.go
+++ b/internal/align/fuzz_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/fuzz_test.go
+// internal/align/fuzz_test.go
 package align
 
 import (

--- a/internal/align/golden_test.go
+++ b/internal/align/golden_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/golden_test.go
+// internal/align/golden_test.go
 package align_test
 
 import (

--- a/internal/align/lifecycle.go
+++ b/internal/align/lifecycle.go
@@ -1,4 +1,4 @@
-// filename: internal/align/lifecycle.go
+// internal/align/lifecycle.go
 package align
 
 import (

--- a/internal/align/locals.go
+++ b/internal/align/locals.go
@@ -1,4 +1,4 @@
-// filename: internal/align/locals.go
+// internal/align/locals.go
 package align
 
 import "github.com/hashicorp/hcl/v2/hclwrite"

--- a/internal/align/locals_test.go
+++ b/internal/align/locals_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/locals_test.go
+// internal/align/locals_test.go
 package align_test
 
 import (

--- a/internal/align/module.go
+++ b/internal/align/module.go
@@ -1,4 +1,4 @@
-// filename: internal/align/module.go
+// internal/align/module.go
 package align
 
 import (

--- a/internal/align/output.go
+++ b/internal/align/output.go
@@ -1,4 +1,4 @@
-// filename: internal/align/output.go
+// internal/align/output.go
 package align
 
 import (

--- a/internal/align/output_test.go
+++ b/internal/align/output_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/output_test.go
+// internal/align/output_test.go
 package align_test
 
 import (

--- a/internal/align/phases_test.go
+++ b/internal/align/phases_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/phases_test.go
+// internal/align/phases_test.go
 package align_test
 
 import (

--- a/internal/align/prefix_order_test.go
+++ b/internal/align/prefix_order_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/prefix_order_test.go
+// internal/align/prefix_order_test.go
 package align_test
 
 import (

--- a/internal/align/provider.go
+++ b/internal/align/provider.go
@@ -1,4 +1,4 @@
-// filename: internal/align/provider.go
+// internal/align/provider.go
 package align
 
 import (

--- a/internal/align/provider_test.go
+++ b/internal/align/provider_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/provider_test.go
+// internal/align/provider_test.go
 package align_test
 
 import (

--- a/internal/align/provisioner.go
+++ b/internal/align/provisioner.go
@@ -1,4 +1,4 @@
-// filename: internal/align/provisioner.go
+// internal/align/provisioner.go
 package align
 
 import (

--- a/internal/align/provisioner_test.go
+++ b/internal/align/provisioner_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/provisioner_test.go
+// internal/align/provisioner_test.go
 package align_test
 
 import (

--- a/internal/align/reorder.go
+++ b/internal/align/reorder.go
@@ -1,4 +1,4 @@
-// filename: internal/align/reorder.go
+// internal/align/reorder.go
 package align
 
 import (

--- a/internal/align/reorder_attributes_test.go
+++ b/internal/align/reorder_attributes_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/reorder_attributes_test.go
+// internal/align/reorder_attributes_test.go
 package align_test
 
 import (

--- a/internal/align/resource.go
+++ b/internal/align/resource.go
@@ -1,4 +1,4 @@
-// filename: internal/align/resource.go
+// internal/align/resource.go
 package align
 
 import (

--- a/internal/align/resource_test.go
+++ b/internal/align/resource_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/resource_test.go
+// internal/align/resource_test.go
 package align_test
 
 import (

--- a/internal/align/schema/loader.go
+++ b/internal/align/schema/loader.go
@@ -1,4 +1,4 @@
-// filename: internal/align/schema/loader.go
+// internal/align/schema/loader.go
 package schema
 
 import (

--- a/internal/align/schema/loader_test.go
+++ b/internal/align/schema/loader_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/schema/loader_test.go
+// internal/align/schema/loader_test.go
 package schema
 
 import (

--- a/internal/align/strategy.go
+++ b/internal/align/strategy.go
@@ -1,4 +1,4 @@
-// filename: internal/align/strategy.go
+// internal/align/strategy.go
 package align
 
 import "github.com/hashicorp/hcl/v2/hclwrite"

--- a/internal/align/strategy_fuzz_test.go
+++ b/internal/align/strategy_fuzz_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/strategy_fuzz_test.go
+// internal/align/strategy_fuzz_test.go
 package align
 
 import (

--- a/internal/align/terraform.go
+++ b/internal/align/terraform.go
@@ -1,4 +1,4 @@
-// filename: internal/align/terraform.go
+// internal/align/terraform.go
 package align
 
 import (

--- a/internal/align/terraform_test.go
+++ b/internal/align/terraform_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/terraform_test.go
+// internal/align/terraform_test.go
 package align_test
 
 import (

--- a/internal/align/types_test.go
+++ b/internal/align/types_test.go
@@ -1,4 +1,4 @@
-// filename: internal/align/types_test.go
+// internal/align/types_test.go
 package align_test
 
 import (

--- a/internal/align/variable.go
+++ b/internal/align/variable.go
@@ -1,4 +1,4 @@
-// filename: internal/align/variable.go
+// internal/align/variable.go
 package align
 
 import (

--- a/internal/ci/covercheck/doc.go
+++ b/internal/ci/covercheck/doc.go
@@ -1,2 +1,2 @@
-// filename: internal/ci/covercheck/doc.go
+// internal/ci/covercheck/doc.go
 package main

--- a/internal/ci/covercheck/main.go
+++ b/internal/ci/covercheck/main.go
@@ -1,4 +1,4 @@
-// filename: internal/ci/covercheck/main.go
+// internal/ci/covercheck/main.go
 package main
 
 import (

--- a/internal/ci/covercheck/run_test.go
+++ b/internal/ci/covercheck/run_test.go
@@ -1,4 +1,4 @@
-// filename: internal/ci/covercheck/run_test.go
+// internal/ci/covercheck/run_test.go
 package main
 
 import (

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,4 +1,4 @@
-// filename: internal/diff/diff.go
+// internal/diff/diff.go
 package diff
 
 import (

--- a/internal/diff/diff_bom_test.go
+++ b/internal/diff/diff_bom_test.go
@@ -1,4 +1,4 @@
-// filename: internal/diff/diff_bom_test.go
+// internal/diff/diff_bom_test.go
 package diff
 
 import (

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,4 +1,4 @@
-// filename: internal/diff/diff_test.go
+// internal/diff/diff_test.go
 package diff
 
 import (

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/engine.go
+// internal/engine/engine.go
 package engine
 
 import (

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/engine_test.go
+// internal/engine/engine_test.go
 package engine
 
 import (

--- a/internal/engine/error_test.go
+++ b/internal/engine/error_test.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/error_test.go
+// internal/engine/error_test.go
 package engine
 
 import (

--- a/internal/engine/fuzz_process_reader_test.go
+++ b/internal/engine/fuzz_process_reader_test.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/fuzz_process_reader_test.go
+// internal/engine/fuzz_process_reader_test.go
 package engine
 
 import (

--- a/internal/engine/non_variable_test.go
+++ b/internal/engine/non_variable_test.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/non_variable_test.go
+// internal/engine/non_variable_test.go
 package engine
 
 import (

--- a/internal/engine/phases_test.go
+++ b/internal/engine/phases_test.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/phases_test.go
+// internal/engine/phases_test.go
 package engine
 
 import (

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/pipeline.go
+// internal/engine/pipeline.go
 package engine
 
 import (

--- a/internal/engine/process_reader_test.go
+++ b/internal/engine/process_reader_test.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/process_reader_test.go
+// internal/engine/process_reader_test.go
 package engine_test
 
 import (

--- a/internal/engine/reader.go
+++ b/internal/engine/reader.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/reader.go
+// internal/engine/reader.go
 package engine
 
 import (

--- a/internal/engine/scan.go
+++ b/internal/engine/scan.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/scan.go
+// internal/engine/scan.go
 package engine
 
 import (

--- a/internal/engine/scan_test.go
+++ b/internal/engine/scan_test.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/scan_test.go
+// internal/engine/scan_test.go
 package engine
 
 import (

--- a/internal/engine/schema.go
+++ b/internal/engine/schema.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/schema.go
+// internal/engine/schema.go
 package engine
 
 import (

--- a/internal/engine/schema_test.go
+++ b/internal/engine/schema_test.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/schema_test.go
+// internal/engine/schema_test.go
 package engine
 
 import (

--- a/internal/engine/write_error_test.go
+++ b/internal/engine/write_error_test.go
@@ -1,4 +1,4 @@
-// filename: internal/engine/write_error_test.go
+// internal/engine/write_error_test.go
 package engine_test
 
 import (

--- a/internal/fmt/runner.go
+++ b/internal/fmt/runner.go
@@ -1,4 +1,4 @@
-// filename: internal/fmt/runner.go
+// internal/fmt/runner.go
 package terraformfmt
 
 import (

--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -1,4 +1,4 @@
-// filename: internal/fmt/terraformfmt.go
+// internal/fmt/terraformfmt.go
 package terraformfmt
 
 import (

--- a/internal/fmt/terraformfmt_test.go
+++ b/internal/fmt/terraformfmt_test.go
@@ -1,4 +1,4 @@
-// filename: internal/fmt/terraformfmt_test.go
+// internal/fmt/terraformfmt_test.go
 package terraformfmt
 
 import (

--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -1,4 +1,4 @@
-// filename: internal/fs/atomic.go
+// internal/fs/atomic.go
 package fs
 
 import (

--- a/internal/fs/atomic_test.go
+++ b/internal/fs/atomic_test.go
@@ -1,4 +1,4 @@
-// filename: internal/fs/atomic_test.go
+// internal/fs/atomic_test.go
 package fs
 
 import (

--- a/internal/fs/atomic_windows_test.go
+++ b/internal/fs/atomic_windows_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-// filename: internal/fs/atomic_windows_test.go
+// internal/fs/atomic_windows_test.go
 package fs
 
 import (

--- a/internal/fs/ewindows_other.go
+++ b/internal/fs/ewindows_other.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-// filename: internal/fs/ewindows_other.go
+// internal/fs/ewindows_other.go
 package fs
 
 func isErrWindows(err error) bool {

--- a/internal/fs/ewindows_windows.go
+++ b/internal/fs/ewindows_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-// filename: internal/fs/ewindows_windows.go
+// internal/fs/ewindows_windows.go
 package fs
 
 import (

--- a/internal/fs/hints_test.go
+++ b/internal/fs/hints_test.go
@@ -1,4 +1,4 @@
-// filename: internal/fs/hints_test.go
+// internal/fs/hints_test.go
 package fs
 
 import (

--- a/internal/fs/stdio.go
+++ b/internal/fs/stdio.go
@@ -1,4 +1,4 @@
-// filename: internal/fs/stdio.go
+// internal/fs/stdio.go
 package fs
 
 import "io"

--- a/internal/hcl/fuzz_tokens_test.go
+++ b/internal/hcl/fuzz_tokens_test.go
@@ -1,4 +1,4 @@
-// filename: internal/hcl/fuzz_tokens_test.go
+// internal/hcl/fuzz_tokens_test.go
 package hcl
 
 import (

--- a/internal/hcl/tokens.go
+++ b/internal/hcl/tokens.go
@@ -1,4 +1,4 @@
-// filename: internal/hcl/tokens.go
+// internal/hcl/tokens.go
 package hcl
 
 import (

--- a/internal/hcl/tokens_test.go
+++ b/internal/hcl/tokens_test.go
@@ -1,4 +1,4 @@
-// filename: internal/hcl/tokens_test.go
+// internal/hcl/tokens_test.go
 package hcl
 
 import (

--- a/patternmatching/patternmatching.go
+++ b/patternmatching/patternmatching.go
@@ -1,4 +1,4 @@
-// filename: patternmatching/patternmatching.go
+// patternmatching/patternmatching.go
 package patternmatching
 
 import (

--- a/patternmatching/patternmatching_test.go
+++ b/patternmatching/patternmatching_test.go
@@ -1,4 +1,4 @@
-// filename: patternmatching/patternmatching_test.go
+// patternmatching/patternmatching_test.go
 package patternmatching_test
 
 import (

--- a/tests/cases/crlf_bom/fmt.tf
+++ b/tests/cases/crlf_bom/fmt.tf
@@ -2,5 +2,4 @@
   type    = number
   default = 1
 }
-
 }

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -1,4 +1,4 @@
-// filename: tests/cli/cli_test.go
+// tests/cli/cli_test.go
 package cli_test
 
 import (

--- a/tools/stripcomments/main.go
+++ b/tools/stripcomments/main.go
@@ -1,4 +1,4 @@
-// filename: tools/stripcomments/main.go
+// tools/stripcomments/main.go
 package main
 
 import (
@@ -90,7 +90,7 @@ func process(root, path string) error {
 	if len(tags) > 0 {
 		out.WriteByte('\n')
 	}
-	out.WriteString("// filename: " + filepath.ToSlash(rel) + "\n")
+	out.WriteString("// " + filepath.ToSlash(rel) + "\n")
 	out.Write(formatted)
 	b := out.Bytes()
 	if len(b) == 0 || b[len(b)-1] != '\n' {

--- a/tools/stripcomments/main_test.go
+++ b/tools/stripcomments/main_test.go
@@ -1,4 +1,4 @@
-// filename: tools/stripcomments/main_test.go
+// tools/stripcomments/main_test.go
 package main
 
 import (
@@ -35,7 +35,7 @@ func TestProcess(t *testing.T) {
 	expected := strings.Join([]string{
 		"//go:build tag",
 		"",
-		"// filename: x.go",
+		"// x.go",
 		"package main",
 		"",
 		"import \"fmt\"",
@@ -85,7 +85,7 @@ func TestMainRepoRoot(t *testing.T) {
 	expected := strings.Join([]string{
 		"//go:build tag",
 		"",
-		"// filename: x.go",
+		"// x.go",
 		"package main",
 		"",
 		"import \"fmt\"",


### PR DESCRIPTION
## Summary
- drop `filename:` prefix from generated file header comment
- enforce new `// <repo-relative-path>` banner in commentcheck
- regenerate go files with updated stripcomments

## Testing
- `go run ./tools/stripcomments --repo-root .`
- `go test ./...`
- `go run ./cmd/commentcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b35f44037c8323ae2c62e3960dd45d