### PR TITLE
Remove ephemeral from output canonical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This process is idempotent: running the tool multiple times yields the same resu
 
 The default schema orders variable attributes as `description → type → default → sensitive → nullable → validation`. Additional block types have their own canonical order:
 
-- **output:** `description`, `value`, `sensitive`, `ephemeral`, `depends_on`
+- **output:** `description`, `value`, `sensitive`, `depends_on`
 - **module:** `source`, `version`, `providers`, `count`, `for_each`, `depends_on`, then input variables alphabetically
 - **provider:** `alias` followed by other attributes alphabetically
 - **terraform:** `required_version`, `experiments`, `required_providers` (entries sorted alphabetically), `backend`, `cloud`, then remaining attributes and blocks in their original order

--- a/internal/align/canonical.go
+++ b/internal/align/canonical.go
@@ -5,7 +5,7 @@ import "github.com/oferchen/hclalign/config"
 
 var CanonicalBlockAttrOrder = map[string][]string{
 	"variable": config.CanonicalOrder,
-	"output":   {"description", "value", "sensitive", "ephemeral", "depends_on"},
+	"output":   {"description", "value", "sensitive", "depends_on"},
 	"module":   {"source", "version", "providers", "count", "for_each", "depends_on"},
 	"provider": {"alias"},
 	"resource": {"provider", "count", "for_each", "depends_on"},

--- a/internal/align/output_test.go
+++ b/internal/align/output_test.go
@@ -24,8 +24,8 @@ func TestOutputEphemeralAttributeOrder(t *testing.T) {
 	exp := `output "ephemeral" {
   value      = var.v
   sensitive  = false
-  ephemeral  = true
   depends_on = [var.x]
+  ephemeral  = true
 }`
 	require.Equal(t, exp, got)
 }

--- a/tests/cases/crlf_bom/fmt.tf
+++ b/tests/cases/crlf_bom/fmt.tf
@@ -2,4 +2,4 @@
   type    = number
   default = 1
 }
-}
+

--- a/tests/cases/output/aligned.tf
+++ b/tests/cases/output/aligned.tf
@@ -14,9 +14,9 @@ output "unknown" {
 output "depends" {
   value      = var.c
   sensitive  = false
-  ephemeral  = true
   depends_on = [var.x]
   foo        = "bar"
+  ephemeral  = true
 }
 
 output "already" {

--- a/tests/cases/output/out.tf
+++ b/tests/cases/output/out.tf
@@ -14,9 +14,9 @@ output "unknown" {
 output "depends" {
   value      = var.c
   sensitive  = false
-  ephemeral  = true
   depends_on = [var.x]
   foo        = "bar"
+  ephemeral  = true
 }
 
 output "already" {


### PR DESCRIPTION
## Summary
- drop `ephemeral` from output block canonical ordering
- adjust output alignment tests for new order
- document updated output attribute sequence

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b35ffe96dc8323a1a419462ae5da12