### PR TITLE
feat: canonical lifecycle ordering

### DIFF
--- a/internal/align/lifecycle.go
+++ b/internal/align/lifecycle.go
@@ -2,9 +2,8 @@
 package align
 
 import (
-	"sort"
-
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	ihcl "github.com/oferchen/hclalign/internal/hcl"
 )
 
 type lifecycleStrategy struct{}
@@ -12,24 +11,31 @@ type lifecycleStrategy struct{}
 func (lifecycleStrategy) Name() string { return "lifecycle" }
 
 func (lifecycleStrategy) Align(block *hclwrite.Block, opts *Options) error {
-	attrs := block.Body().Attributes()
+	body := block.Body()
+	attrs := body.Attributes()
 	allowed := map[string]struct{}{
 		"create_before_destroy": {},
 		"prevent_destroy":       {},
 		"ignore_changes":        {},
 		"replace_triggered_by":  {},
 	}
-	var known, unknown []string
-	for name := range attrs {
-		if _, ok := allowed[name]; ok {
-			known = append(known, name)
-		} else {
-			unknown = append(unknown, name)
+	names := make([]string, 0, len(attrs))
+	for _, name := range []string{
+		"create_before_destroy",
+		"prevent_destroy",
+		"ignore_changes",
+		"replace_triggered_by",
+	} {
+		if _, ok := attrs[name]; ok {
+			names = append(names, name)
 		}
 	}
-	sort.Strings(known)
-	sort.Strings(unknown)
-	names := append(known, unknown...)
+	original := ihcl.AttributeOrder(body, attrs)
+	for _, name := range original {
+		if _, ok := allowed[name]; !ok {
+			names = append(names, name)
+		}
+	}
 	return reorderBlock(block, names)
 }
 

--- a/tests/cases/crlf_bom/fmt.tf
+++ b/tests/cases/crlf_bom/fmt.tf
@@ -2,5 +2,3 @@
   type    = number
   default = 1
 }
-
-}

--- a/tests/cases/lifecycle/aligned.tf
+++ b/tests/cases/lifecycle/aligned.tf
@@ -1,0 +1,12 @@
+resource "null_resource" "example" {
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = true
+    ignore_changes        = []
+    replace_triggered_by  = []
+    foo                   = "foo"
+    bar                   = "bar"
+    baz                   = "baz"
+  }
+}

--- a/tests/cases/lifecycle/fmt.tf
+++ b/tests/cases/lifecycle/fmt.tf
@@ -1,0 +1,11 @@
+resource "null_resource" "example" {
+  lifecycle {
+    foo                   = "foo"
+    create_before_destroy = true
+    bar                   = "bar"
+    prevent_destroy       = true
+    ignore_changes        = []
+    baz                   = "baz"
+    replace_triggered_by  = []
+  }
+}

--- a/tests/cases/lifecycle/in.tf
+++ b/tests/cases/lifecycle/in.tf
@@ -1,0 +1,11 @@
+resource "null_resource" "example" {
+  lifecycle {
+    foo                   = "foo"
+    create_before_destroy = true
+    bar                   = "bar"
+    prevent_destroy       = true
+    ignore_changes        = []
+    baz                   = "baz"
+    replace_triggered_by  = []
+  }
+}

--- a/tests/cases/lifecycle/out.tf
+++ b/tests/cases/lifecycle/out.tf
@@ -1,0 +1,12 @@
+resource "null_resource" "example" {
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = true
+    ignore_changes        = []
+    replace_triggered_by  = []
+    foo                   = "foo"
+    bar                   = "bar"
+    baz                   = "baz"
+  }
+}


### PR DESCRIPTION
## Summary
- enforce explicit lifecycle attribute order
- keep unknown lifecycle attributes in source order
- add lifecycle golden test and repair CRLF fixture

## Testing
- `make test` *(fails: missing separator in Makefile)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b36fd152dc8323aa61585be227ac44