### PR TITLE
Preserve provisioner attribute order

### DIFF
--- a/internal/align/provisioner.go
+++ b/internal/align/provisioner.go
@@ -2,9 +2,10 @@
 package align
 
 import (
-	"sort"
-
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+
+	ihcl "github.com/oferchen/hclalign/internal/hcl"
 )
 
 type provisionerStrategy struct{}
@@ -12,20 +13,123 @@ type provisionerStrategy struct{}
 func (provisionerStrategy) Name() string { return "provisioner" }
 
 func (provisionerStrategy) Align(block *hclwrite.Block, opts *Options) error {
-	attrs := block.Body().Attributes()
-	allowed := map[string]struct{}{"when": {}, "on_failure": {}}
-	var known, unknown []string
-	for name := range attrs {
-		if _, ok := allowed[name]; ok {
-			known = append(known, name)
-		} else {
-			unknown = append(unknown, name)
+	body := block.Body()
+	attrs := body.Attributes()
+
+	ordered := []string{"when", "on_failure"}
+	allowed := map[string]struct{}{ordered[0]: {}, ordered[1]: {}}
+
+	type item struct {
+		name  string
+		attr  bool
+		block *hclwrite.Block
+	}
+
+	tokens := body.BuildTokens(nil)
+	depth := 0
+	blocks := body.Blocks()
+	blockMap := map[string][]*hclwrite.Block{}
+	for _, b := range blocks {
+		blockMap[b.Type()] = append(blockMap[b.Type()], b)
+	}
+
+	var items []item
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i]
+		switch tok.Type {
+		case hclsyntax.TokenOBrace, hclsyntax.TokenOParen:
+			depth++
+		case hclsyntax.TokenCBrace, hclsyntax.TokenCParen:
+			if depth > 0 {
+				depth--
+			}
+		case hclsyntax.TokenIdent:
+			if depth != 0 {
+				continue
+			}
+			name := string(tok.Bytes)
+			j := i + 1
+			for j < len(tokens) && (tokens[j].Type == hclsyntax.TokenNewline || tokens[j].Type == hclsyntax.TokenComment) {
+				j++
+			}
+			if j >= len(tokens) {
+				continue
+			}
+			switch tokens[j].Type {
+			case hclsyntax.TokenEqual:
+				items = append(items, item{name: name, attr: true})
+			case hclsyntax.TokenOBrace:
+				if bs := blockMap[name]; len(bs) > 0 {
+					items = append(items, item{name: name, block: bs[0]})
+					blockMap[name] = bs[1:]
+				}
+			}
 		}
 	}
-	sort.Strings(known)
-	sort.Strings(unknown)
-	names := append(known, unknown...)
-	return reorderBlock(block, names)
+
+	attrTokensMap := map[string]ihcl.AttrTokens{}
+	for name, attr := range attrs {
+		attrTokensMap[name] = ihcl.ExtractAttrTokens(attr)
+		body.RemoveAttribute(name)
+	}
+	for _, b := range blocks {
+		body.RemoveBlock(b)
+	}
+
+	var order []item
+	for _, k := range ordered {
+		if _, ok := attrs[k]; ok {
+			order = append(order, item{name: k, attr: true})
+		}
+	}
+	for _, it := range items {
+		if it.attr {
+			if _, ok := allowed[it.name]; ok {
+				continue
+			}
+			order = append(order, it)
+			continue
+		}
+		order = append(order, it)
+	}
+
+	newline := ihcl.DetectLineEnding(tokens)
+	trailingComma := ihcl.HasTrailingComma(tokens)
+
+	body.Clear()
+	if len(order) > 0 {
+		body.AppendUnstructuredTokens(hclwrite.Tokens{
+			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: newline},
+		})
+	}
+	appendAttr := func(name string) {
+		if tok, ok := attrTokensMap[name]; ok {
+			body.AppendUnstructuredTokens(tok.LeadTokens)
+			body.SetAttributeRaw(name, tok.ExprTokens)
+		}
+	}
+	for _, it := range order {
+		if it.attr {
+			appendAttr(it.name)
+			continue
+		}
+		body.AppendUnstructuredTokens(hclwrite.Tokens{
+			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: newline},
+		})
+		body.AppendBlock(it.block)
+	}
+	if trailingComma && len(order) > 0 {
+		body.AppendUnstructuredTokens(hclwrite.Tokens{
+			&hclwrite.Token{Type: hclsyntax.TokenComma, Bytes: []byte(",")},
+		})
+	}
+	toks := body.BuildTokens(nil)
+	if len(toks) > 0 && toks[len(toks)-1].Type != hclsyntax.TokenNewline {
+		body.AppendUnstructuredTokens(hclwrite.Tokens{
+			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: newline},
+		})
+	}
+	return nil
 }
 
 func init() { Register(provisionerStrategy{}) }

--- a/internal/align/provisioner_test.go
+++ b/internal/align/provisioner_test.go
@@ -12,8 +12,9 @@ import (
 
 func TestProvisionerAttributeOrderAndComments(t *testing.T) {
 	src := []byte(`provisioner "local-exec" {
+  bar = "bar" // bar inline
+  foo = "foo" // foo inline
   when = "destroy" // when inline
-  foo = "bar" // foo inline
   on_failure = "continue" // on_failure inline
 }`)
 	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
@@ -21,9 +22,10 @@ func TestProvisionerAttributeOrderAndComments(t *testing.T) {
 	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
 	got := string(file.Bytes())
 	exp := `provisioner "local-exec" {
-  on_failure = "continue" // on_failure inline
   when       = "destroy" // when inline
-  foo        = "bar" // foo inline
+  on_failure = "continue" // on_failure inline
+  bar        = "bar" // bar inline
+  foo        = "foo" // foo inline
 }`
 	require.Equal(t, exp, got)
 	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))

--- a/tests/cases/provisioner/aligned.tf
+++ b/tests/cases/provisioner/aligned.tf
@@ -1,0 +1,13 @@
+resource "null_resource" "example" {
+
+  provisioner "local-exec" {
+    when       = "destroy"
+    on_failure = "continue"
+    bar        = "b"
+
+    connection {
+      host = "example.com"
+    }
+    foo = "f"
+  }
+}

--- a/tests/cases/provisioner/fmt.tf
+++ b/tests/cases/provisioner/fmt.tf
@@ -1,0 +1,11 @@
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    bar  = "b"
+    when = "destroy"
+    connection {
+      host = "example.com"
+    }
+    foo        = "f"
+    on_failure = "continue"
+  }
+}

--- a/tests/cases/provisioner/in.tf
+++ b/tests/cases/provisioner/in.tf
@@ -1,0 +1,11 @@
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    bar = "b"
+    when = "destroy"
+    connection {
+      host = "example.com"
+    }
+    foo = "f"
+    on_failure = "continue"
+  }
+}


### PR DESCRIPTION
## Summary
- ensure provisioner emits `when` then `on_failure` before other attrs
- keep connection blocks and remaining attrs in their original sequence
- add golden case and unit test for provisioner ordering

## Testing
- `go test ./internal/align -run Provisioner`
- `go test ./...` *(fails: TestGolden/crlf_bom fmt mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b36fd6cde48323a6083f760520e01a