### PR TITLE
Add CRLF BOM fmt fixture without extra brace

### DIFF
--- a/tests/cases/crlf_bom/fmt.tf
+++ b/tests/cases/crlf_bom/fmt.tf
@@ -1,0 +1,4 @@
+﻿variable "crlf" {
+  type    = number
+  default = 1
+}


### PR DESCRIPTION
## Summary
- add fmt.tf for crlf_bom test case
- ensure file uses BOM and CRLF and omit trailing brace

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b37525ff2483239b099a3d5de255ac