### PR TITLE
Wrap terraform fmt errors and avoid empty stderr

### DIFF
--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -46,7 +46,10 @@ func formatBinary(ctx context.Context, src []byte) ([]byte, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("terraform fmt failed: %v: %s", err, stderr.String())
+		if stderrStr := stderr.String(); stderrStr != "" {
+			return nil, fmt.Errorf("terraform fmt failed: %w: %s", err, stderrStr)
+		}
+		return nil, fmt.Errorf("terraform fmt failed: %w", err)
 	}
 	formatted := stdout.Bytes()
 


### PR DESCRIPTION
## Summary
- Wrap `terraform fmt` errors with `%w`
- Append stderr output only when present to avoid trailing colon

## Testing
- `go test ./internal/fmt -run TestBinaryMissingTerraform -count=1`
- `go test ./internal/engine -run ContextCancelled -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b3752cbeb083239fdfbbbd190f0fb1