### PR TITLE
engine: copy reader input before formatting

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -77,7 +77,7 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 		return false, err
 	}
 
-	original := data
+	original := append([]byte(nil), data...)
 	hadNewline := len(data) > 0 && data[len(data)-1] == '\n'
 	formatted, err := terraformfmt.Format(data, "stdin", "")
 	if err != nil {


### PR DESCRIPTION
## Summary
- copy reader input before formatting so original data isn't modified
- compute changes by comparing formatted output to copied original

## Testing
- `go test ./internal/engine -run TestPhases/templates -count=1`
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b375350c388323a50ce2f2eeb7cfb4