### PR TITLE
Exclude git directories from scanning

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 
 var (
 	DefaultInclude = []string{"**/*.tf"}
-	DefaultExclude = []string{".terraform/**", "**/.terraform/**", "vendor/**"}
+	DefaultExclude = []string{".terraform/**", "**/.terraform/**", "vendor/**", ".git/**", "**/.git/**"}
 	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,7 +38,7 @@ func TestValidateOrder_EmptyAttributeName(t *testing.T) {
 }
 
 func TestDefaultExcludeMatchesExpected(t *testing.T) {
-	expected := []string{".terraform/**", "**/.terraform/**", "vendor/**"}
+	expected := []string{".terraform/**", "**/.terraform/**", "vendor/**", ".git/**", "**/.git/**"}
 	if !reflect.DeepEqual(DefaultExclude, expected) {
 		t.Fatalf("expected DefaultExclude to be %v, got %v", expected, DefaultExclude)
 	}

--- a/internal/engine/scan_test.go
+++ b/internal/engine/scan_test.go
@@ -3,6 +3,7 @@ package engine
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -14,6 +15,10 @@ func TestScanDefaultExcludeDirectories(t *testing.T) {
 	t.Parallel()
 
 	dir := filepath.Join("..", "..", "tests", "cases", "default_excludes")
+	gitIgnored := filepath.Join(dir, ".git", "ignored.tf")
+	require.NoError(t, os.MkdirAll(filepath.Dir(gitIgnored), 0o755))
+	require.NoError(t, os.WriteFile(gitIgnored, []byte(""), 0o644))
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(gitIgnored)) })
 
 	cfg := &config.Config{
 		Target:  dir,


### PR DESCRIPTION
## Summary
- include `.git/**` patterns in default exclusion list
- adjust config and scan tests for updated defaults

## Testing
- `go test ./config`
- `go test ./internal/engine -run Scan`


------
https://chatgpt.com/codex/tasks/task_e_68b3753d3ba88323852a8cf0ce384082