### PR TITLE
chore: consolidate fuzz target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,10 @@ test: ## run tests
 	$(GO) test -shuffle=on -cover $(PKG)
 
 test-race: ## run tests with race detector
-        $(GO) test -race -shuffle=on $(PKG)
+	$(GO) test -race -shuffle=on $(PKG)
 
 fuzz: ## run fuzz tests
-        $(GO) test ./... -run=^$ -fuzz=Fuzz -fuzztime=5s
-
-fuzz: ## run fuzz tests
+	$(GO) test ./... -run=^$$ -fuzz=Fuzz -fuzztime=5s
 	$(GO) test -run=^$$ -fuzz=Fuzz -fuzztime=10s ./internal/align
 	$(GO) test -run=^$$ -fuzz=Fuzz -fuzztime=10s ./internal/engine
 	$(GO) test -run=^$$ -fuzz=Fuzz -fuzztime=10s ./internal/hcl


### PR DESCRIPTION
## Summary
- merge duplicated fuzz recipes into one target with all fuzz tests

## Testing
- `make tidy`
- `make lint` *(fails: could not import unicode/utf8; unsupported version)*
- `make test`
- `make cover` *(fails: coverage 88.5% below 95% threshold)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b37776b32c832394ff622cdde35c0c