### PR TITLE
fix: use Go formatter regardless of Terraform binary

### DIFF
--- a/internal/fmt/runner.go
+++ b/internal/fmt/runner.go
@@ -3,14 +3,10 @@ package terraformfmt
 
 import (
 	"context"
-	"os/exec"
 
 	"github.com/oferchen/hclalign/formatter"
 )
 
 func Run(ctx context.Context, src []byte) ([]byte, error) {
-	if _, err := exec.LookPath("terraform"); err != nil {
-		return formatter.Format(src, "")
-	}
-	return formatBinary(ctx, src)
+	return formatter.Format(src, "")
 }

--- a/internal/fmt/terraformfmt_test.go
+++ b/internal/fmt/terraformfmt_test.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	internalfs "github.com/oferchen/hclalign/internal/fs"
@@ -25,25 +23,13 @@ func TestGoMatchesBinary(t *testing.T) {
 	require.Equal(t, string(binFmt), string(goFmt))
 }
 
-func TestAutoPrefersTerraformBinary(t *testing.T) {
-	tmpDir := t.TempDir()
-	argsOut := filepath.Join(tmpDir, "args.txt")
-	script := filepath.Join(tmpDir, "terraform")
-	content := "#!/bin/sh\n" + "cat -\n" + "echo \"$@\" > \"$MOCK_TF_ARGS_OUT\"\n"
-	require.NoError(t, os.WriteFile(script, []byte(content), 0o755))
-	oldPath := os.Getenv("PATH")
-	require.NoError(t, os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath))
-	defer os.Setenv("PATH", oldPath)
-	require.NoError(t, os.Setenv("MOCK_TF_ARGS_OUT", argsOut))
+func TestAutoUsesGoFormatter(t *testing.T) {
 	src := []byte("variable \"a\" {\n  type = string\n}\n")
-	formatted, err := Format(src, "test.tf", string(StrategyAuto))
+	autoFmt, err := Format(src, "test.tf", string(StrategyAuto))
 	require.NoError(t, err)
-	require.Equal(t, string(src), string(formatted))
-	argsBytes, err := os.ReadFile(argsOut)
+	goFmt, err := Format(src, "test.tf", string(StrategyGo))
 	require.NoError(t, err)
-	fields := strings.Fields(string(argsBytes))
-	require.Greater(t, len(fields), 0)
-	require.Equal(t, "-", fields[len(fields)-1])
+	require.Equal(t, string(goFmt), string(autoFmt))
 }
 
 func TestIdempotent(t *testing.T) {
@@ -68,9 +54,6 @@ func TestBinaryPreservesHints(t *testing.T) {
 }
 
 func TestRunPreservesHints(t *testing.T) {
-	if _, err := exec.LookPath("terraform"); err != nil {
-		t.Skip("terraform binary not found")
-	}
 	src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {\r\n  type = string\r\n}\r\n")...)
 	formatted, err := Run(context.Background(), src)
 	require.NoError(t, err)
@@ -95,28 +78,4 @@ func TestBinaryMissingTerraform(t *testing.T) {
 	os.Setenv("PATH", "")
 	_, err := Format([]byte("variable \"a\" {}\n"), "test.tf", string(StrategyBinary))
 	require.Error(t, err)
-}
-
-func TestRunMissingTerraform(t *testing.T) {
-	oldPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", oldPath)
-	os.Setenv("PATH", "")
-	src := []byte("variable \"a\" {\n  type = string\n}\n")
-	formatted, err := Run(context.Background(), src)
-	require.NoError(t, err)
-	goFmt, err := Format(src, "test.tf", string(StrategyGo))
-	require.NoError(t, err)
-	require.Equal(t, string(goFmt), string(formatted))
-}
-
-func TestAutoFallsBackToGo(t *testing.T) {
-	oldPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", oldPath)
-	os.Setenv("PATH", "")
-	src := []byte("variable \"a\" {\n  type = string\n}\n")
-	autoFmt, err := Format(src, "test.tf", string(StrategyAuto))
-	require.NoError(t, err)
-	goFmt, err := Format(src, "test.tf", string(StrategyGo))
-	require.NoError(t, err)
-	require.Equal(t, string(goFmt), string(autoFmt))
 }


### PR DESCRIPTION
## Summary
- default `Run` to builtin Go formatter even when `terraform` is present
- adjust fmt tests to reflect auto mode using Go formatter

## Testing
- `go test ./internal/engine -run TestPhases/templates -count=1 -v`
- `go test -coverprofile=coverage.out ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b37cda028083238711f9b2d67c033f