### PR TITLE
feat: order output ephemeral attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 The default schema orders variable attributes as `description → type → default → sensitive → nullable → validation`. Additional block types have their own canonical order:
 
-- **output:** `description`, `value`, `sensitive`, `depends_on`
+- **output:** `description`, `value`, `sensitive`, `ephemeral`, `depends_on`
 - **module:** `source`, `version`, `providers`, `count`, `for_each`, `depends_on`, then input variables alphabetically
 - **provider:** `alias` followed by other attributes alphabetically
 - **terraform:** `required_version`, `experiments`, `required_providers` (entries sorted alphabetically), `backend`, `cloud`, then remaining attributes and blocks in their original order

--- a/internal/align/canonical.go
+++ b/internal/align/canonical.go
@@ -5,7 +5,7 @@ import "github.com/oferchen/hclalign/config"
 
 var CanonicalBlockAttrOrder = map[string][]string{
 	"variable": config.CanonicalOrder,
-	"output":   {"description", "value", "sensitive", "depends_on"},
+	"output":   {"description", "value", "sensitive", "ephemeral", "depends_on"},
 	"module":   {"source", "version", "providers", "count", "for_each", "depends_on"},
 	"provider": {"alias"},
 	"resource": {"provider", "count", "for_each", "depends_on"},

--- a/internal/align/output_test.go
+++ b/internal/align/output_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOutputAttributeOrder(t *testing.T) {
+func TestOutputEphemeralPlacement(t *testing.T) {
 	src := []byte(`output "ephemeral" {
   value      = var.v
   depends_on = [var.x]
@@ -24,8 +24,8 @@ func TestOutputAttributeOrder(t *testing.T) {
 	exp := `output "ephemeral" {
   value      = var.v
   sensitive  = false
-  depends_on = [var.x]
   ephemeral  = true
+  depends_on = [var.x]
 }`
 	require.Equal(t, exp, got)
 }

--- a/tests/cases/output/in.tf
+++ b/tests/cases/output/in.tf
@@ -13,10 +13,10 @@ output "unknown" {
 
 output "depends" {
   foo        = "bar"
-  ephemeral  = true
-  sensitive  = false
-  depends_on = [var.x]
   value      = var.c
+  sensitive  = false
+  ephemeral  = true
+  depends_on = [var.x]
 }
 
 output "already" {

--- a/tests/cases/output/out.tf
+++ b/tests/cases/output/out.tf
@@ -14,9 +14,9 @@ output "unknown" {
 output "depends" {
   value      = var.c
   sensitive  = false
+  ephemeral  = true
   depends_on = [var.x]
   foo        = "bar"
-  ephemeral  = true
 }
 
 output "already" {


### PR DESCRIPTION
## Summary
- ensure `ephemeral` is part of canonical output attribute order
- document output attribute order including `ephemeral`
- update output fixtures and tests for `ephemeral` placement

## Testing
- `make tidy`
- `make lint` *(fails: unsupported version in golangci-lint typecheck)*
- `make test`
- `make cover` *(fails: coverage 88.1% < 95%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b384fe5b288323ba7593264adef32d