### PR TITLE
feat: defer fs hints to engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Pipeline
 
-1. **fmt** – runs `terraform fmt` semantics, invoking the Terraform CLI when available and falling back to a pure Go formatter otherwise.
+1. **fmt** – detects the Terraform CLI with `exec.LookPath`; if found it runs `terraform fmt`, otherwise a pure Go formatter is used. Newline and BOM hints are carried through and applied only when writing the result.
 2. **align** – reorders attributes to match a configurable schema.
 
 `terraform fmt` is run again after alignment to ensure canonical layout. This process is idempotent: running the tool multiple times yields the same result.

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -2,37 +2,36 @@
 package formatter
 
 import (
-	"bytes"
-	"fmt"
-	"unicode/utf8"
+        "bytes"
+        "fmt"
+        "unicode/utf8"
 
-	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclwrite"
+        "github.com/hashicorp/hcl/v2"
+        "github.com/hashicorp/hcl/v2/hclwrite"
 
-	internalfs "github.com/oferchen/hclalign/internal/fs"
+        internalfs "github.com/oferchen/hclalign/internal/fs"
 )
 
-func Format(src []byte, filename string) ([]byte, error) {
-	hints := internalfs.DetectHintsFromBytes(src)
-	if bom := hints.BOM(); len(bom) > 0 {
-		src = src[len(bom):]
-	}
-	if len(src) > 0 && !utf8.Valid(src) {
-		return nil, fmt.Errorf("input is not valid UTF-8")
-	}
+func Format(src []byte, filename string) ([]byte, internalfs.Hints, error) {
+        hints := internalfs.DetectHintsFromBytes(src)
+        if bom := hints.BOM(); len(bom) > 0 {
+                src = src[len(bom):]
+        }
+        if len(src) > 0 && !utf8.Valid(src) {
+                return nil, internalfs.Hints{}, fmt.Errorf("input is not valid UTF-8")
+        }
 
-	f, diags := hclwrite.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
-	if diags.HasErrors() {
-		return nil, diags
-	}
-	formatted := hclwrite.Format(f.Bytes())
-	formatted = bytes.ReplaceAll(formatted, []byte("\r\n"), []byte("\n"))
+        f, diags := hclwrite.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
+        if diags.HasErrors() {
+                return nil, internalfs.Hints{}, diags
+        }
+        formatted := hclwrite.Format(f.Bytes())
+        formatted = bytes.ReplaceAll(formatted, []byte("\r\n"), []byte("\n"))
 
-	if len(formatted) > 0 {
-		formatted = bytes.TrimRight(formatted, "\n")
-		formatted = append(formatted, '\n')
-	}
+        if len(formatted) > 0 {
+                formatted = bytes.TrimRight(formatted, "\n")
+                formatted = append(formatted, '\n')
+        }
 
-	formatted = internalfs.ApplyHints(formatted, hints)
-	return formatted, nil
+        return formatted, hints, nil
 }

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -2,8 +2,10 @@
 package formatter
 
 import (
-	"bytes"
-	"testing"
+        "bytes"
+        "testing"
+
+        internalfs "github.com/oferchen/hclalign/internal/fs"
 )
 
 func TestFormatHints(t *testing.T) {
@@ -28,15 +30,16 @@ func TestFormatHints(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Format(tc.input, "test.hcl")
-			if err != nil {
-				t.Fatalf("Format returned error: %v", err)
-			}
-			if !bytes.Equal(got, tc.want) {
-				t.Fatalf("unexpected output\nwant: %q\n got: %q", tc.want, got)
-			}
-		})
-	}
+                        got, hints, err := Format(tc.input, "test.hcl")
+                        if err != nil {
+                                t.Fatalf("Format returned error: %v", err)
+                        }
+                        styled := internalfs.ApplyHints(got, hints)
+                        if !bytes.Equal(styled, tc.want) {
+                                t.Fatalf("unexpected output\nwant: %q\n got: %q", tc.want, styled)
+                        }
+                })
+        }
 }
 
 func TestFormatTrailingNewline(t *testing.T) {
@@ -65,20 +68,21 @@ func TestFormatTrailingNewline(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Format(tc.input, "test.hcl")
-			if err != nil {
-				t.Fatalf("Format returned error: %v", err)
-			}
-			if !bytes.Equal(got, tc.want) {
-				t.Fatalf("unexpected output\nwant: %q\n got: %q", tc.want, got)
-			}
-		})
-	}
+                        got, hints, err := Format(tc.input, "test.hcl")
+                        if err != nil {
+                                t.Fatalf("Format returned error: %v", err)
+                        }
+                        styled := internalfs.ApplyHints(got, hints)
+                        if !bytes.Equal(styled, tc.want) {
+                                t.Fatalf("unexpected output\nwant: %q\n got: %q", tc.want, styled)
+                        }
+                })
+        }
 }
 
 func TestFormatRejectsInvalidUTF8(t *testing.T) {
 	invalid := []byte{0xff, 0xfe, 0xfd}
-	if _, err := Format(invalid, "test.hcl"); err == nil {
-		t.Fatalf("expected error for invalid UTF-8 input")
-	}
+        if _, _, err := Format(invalid, "test.hcl"); err == nil {
+                t.Fatalf("expected error for invalid UTF-8 input")
+        }
 }

--- a/internal/align/golden_test.go
+++ b/internal/align/golden_test.go
@@ -57,18 +57,18 @@ func TestGolden(t *testing.T) {
 				t.Fatalf("read out: %v", err)
 			}
 
-			fmtBytes, err := terraformfmt.Format(inBytes, inPath, string(terraformfmt.StrategyGo))
-			if err != nil {
-				t.Fatalf("format input: %v", err)
-			}
+                        fmtBytes, _, err := terraformfmt.Format(inBytes, inPath, string(terraformfmt.StrategyGo))
+                        if err != nil {
+                                t.Fatalf("format input: %v", err)
+                        }
 			hadNewline := len(inBytes) > 0 && inBytes[len(inBytes)-1] == '\n'
 			if !hadNewline && len(fmtBytes) > 0 && fmtBytes[len(fmtBytes)-1] == '\n' {
 				fmtBytes = fmtBytes[:len(fmtBytes)-1]
 			}
-			againFmt, err := terraformfmt.Format(fmtBytes, inPath, string(terraformfmt.StrategyGo))
-			if err != nil {
-				t.Fatalf("format fmt: %v", err)
-			}
+                        againFmt, _, err := terraformfmt.Format(fmtBytes, inPath, string(terraformfmt.StrategyGo))
+                        if err != nil {
+                                t.Fatalf("format fmt: %v", err)
+                        }
 			hadFmtNewline := len(fmtBytes) > 0 && fmtBytes[len(fmtBytes)-1] == '\n'
 			if !hadFmtNewline && len(againFmt) > 0 && againFmt[len(againFmt)-1] == '\n' {
 				againFmt = againFmt[:len(againFmt)-1]

--- a/internal/align/phases_test.go
+++ b/internal/align/phases_test.go
@@ -32,14 +32,14 @@ func TestPhases(t *testing.T) {
 			wantOut, err := os.ReadFile(outPath)
 			require.NoError(t, err)
 
-			fmtBytes, err := terraformfmt.Format(inBytes, inPath, string(terraformfmt.StrategyGo))
-			require.NoError(t, err)
+                        fmtBytes, _, err := terraformfmt.Format(inBytes, inPath, string(terraformfmt.StrategyGo))
+                        require.NoError(t, err)
 			hadNewline := len(inBytes) > 0 && inBytes[len(inBytes)-1] == '\n'
 			if !hadNewline && len(fmtBytes) > 0 && fmtBytes[len(fmtBytes)-1] == '\n' {
 				fmtBytes = fmtBytes[:len(fmtBytes)-1]
 			}
-			againFmt, err := terraformfmt.Format(fmtBytes, inPath, string(terraformfmt.StrategyGo))
-			require.NoError(t, err)
+                        againFmt, _, err := terraformfmt.Format(fmtBytes, inPath, string(terraformfmt.StrategyGo))
+                        require.NoError(t, err)
 			hadFmtNewline := len(fmtBytes) > 0 && fmtBytes[len(fmtBytes)-1] == '\n'
 			if !hadFmtNewline && len(againFmt) > 0 && againFmt[len(againFmt)-1] == '\n' {
 				againFmt = againFmt[:len(againFmt)-1]
@@ -68,7 +68,7 @@ func TestPhases(t *testing.T) {
 	}
 
 	t.Run("error", func(t *testing.T) {
-		_, err := terraformfmt.Format([]byte("variable \"a\" {"), "bad.hcl", string(terraformfmt.StrategyGo))
-		require.Error(t, err)
-	})
+                _, _, err := terraformfmt.Format([]byte("variable \"a\" {"), "bad.hcl", string(terraformfmt.StrategyGo))
+                require.Error(t, err)
+        })
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -72,19 +72,19 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 		w = os.Stdout
 	}
 
-	data, hints, err := internalfs.ReadAllWithHints(r)
-	if err != nil {
-		return false, err
-	}
+        data, hints, err := internalfs.ReadAllWithHints(r)
+        if err != nil {
+                return false, err
+        }
 
-	original := append([]byte(nil), data...)
-	hadNewline := len(data) > 0 && data[len(data)-1] == '\n'
-	formatted, err := terraformfmt.Format(data, "stdin", "")
-	if err != nil {
-		return false, fmt.Errorf("parsing error: %w", err)
-	}
+        original := append([]byte(nil), data...)
+        hadNewline := len(data) > 0 && data[len(data)-1] == '\n'
+        formatted, _, err := terraformfmt.Run(ctx, data)
+        if err != nil {
+                return false, fmt.Errorf("parsing error: %w", err)
+        }
 
-	parseData := internalfs.PrepareForParse(formatted, hints)
+        parseData := internalfs.PrepareForParse(formatted, hints)
 
 	file, diags := hclwrite.ParseConfig(parseData, "stdin", hcl.InitialPos)
 	if diags.HasErrors() {
@@ -101,13 +101,13 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 			typesMap[t] = struct{}{}
 		}
 	}
-	if err := align.Apply(file, &align.Options{Order: cfg.Order, Schemas: schemas, Types: typesMap, PrefixOrder: cfg.PrefixOrder}); err != nil {
-		return false, err
-	}
-	formatted, err = terraformfmt.Format(file.Bytes(), "stdin", "")
-	if err != nil {
-		return false, err
-	}
+        if err := align.Apply(file, &align.Options{Order: cfg.Order, Schemas: schemas, Types: typesMap, PrefixOrder: cfg.PrefixOrder}); err != nil {
+                return false, err
+        }
+        formatted, _, err = terraformfmt.Run(ctx, file.Bytes())
+        if err != nil {
+                return false, err
+        }
 
 	if !hadNewline && len(formatted) > 0 && formatted[len(formatted)-1] == '\n' {
 		formatted = formatted[:len(formatted)-1]

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -128,12 +128,12 @@ func (p *Processor) processFile(ctx context.Context, filePath string) (bool, []b
 
 	original := data
 	hadNewline := len(data) > 0 && data[len(data)-1] == '\n'
-	formatted, err := terraformfmt.Run(ctx, data)
-	if err != nil {
-		return false, nil, fmt.Errorf("parsing error in file %s: %w", filePath, err)
-	}
+        formatted, _, err := terraformfmt.Run(ctx, data)
+        if err != nil {
+                return false, nil, fmt.Errorf("parsing error in file %s: %w", filePath, err)
+        }
 
-	parseData := internalfs.PrepareForParse(formatted, hints)
+        parseData := internalfs.PrepareForParse(formatted, hints)
 
 	file, diags := hclwrite.ParseConfig(parseData, filePath, hcl.InitialPos)
 	if diags.HasErrors() {
@@ -155,10 +155,10 @@ func (p *Processor) processFile(ctx context.Context, filePath string) (bool, []b
 	if testHookAfterReorder != nil {
 		testHookAfterReorder()
 	}
-	formatted, err = terraformfmt.Run(ctx, file.Bytes())
-	if err != nil {
-		return false, nil, err
-	}
+        formatted, _, err = terraformfmt.Run(ctx, file.Bytes())
+        if err != nil {
+                return false, nil, err
+        }
 
 	if !hadNewline && len(formatted) > 0 && formatted[len(formatted)-1] == '\n' {
 		formatted = formatted[:len(formatted)-1]

--- a/internal/fmt/runner.go
+++ b/internal/fmt/runner.go
@@ -2,11 +2,23 @@
 package terraformfmt
 
 import (
-	"context"
+        "context"
+        "os/exec"
 
-	"github.com/oferchen/hclalign/formatter"
+        internalfs "github.com/oferchen/hclalign/internal/fs"
+        "github.com/oferchen/hclalign/formatter"
 )
 
-func Run(ctx context.Context, src []byte) ([]byte, error) {
-	return formatter.Format(src, "")
+func Run(ctx context.Context, src []byte) ([]byte, internalfs.Hints, error) {
+        if err := ctx.Err(); err != nil {
+                return nil, internalfs.Hints{}, err
+        }
+        if _, err := exec.LookPath("terraform"); err == nil {
+                return formatBinary(ctx, src)
+        }
+        formatted, hints, err := formatter.Format(src, "")
+        if err != nil {
+                return nil, internalfs.Hints{}, err
+        }
+        return formatted, hints, nil
 }

--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -15,48 +15,47 @@ import (
 type Strategy string
 
 const (
-	StrategyAuto   Strategy = "auto"
-	StrategyBinary Strategy = "binary"
-	StrategyGo     Strategy = "go"
+        StrategyAuto   Strategy = "auto"
+        StrategyBinary Strategy = "binary"
+        StrategyGo     Strategy = "go"
 )
 
-func Format(src []byte, filename, strategy string) ([]byte, error) {
-	switch Strategy(strategy) {
-	case StrategyGo:
-		return formatter.Format(src, filename)
-	case StrategyBinary:
-		return formatBinary(context.Background(), src)
-	case StrategyAuto, "":
-		return Run(context.Background(), src)
-	default:
-		return nil, fmt.Errorf("unknown fmt strategy %q", strategy)
-	}
+func Format(src []byte, filename, strategy string) ([]byte, internalfs.Hints, error) {
+        switch Strategy(strategy) {
+        case StrategyGo:
+                return formatter.Format(src, filename)
+        case StrategyBinary:
+                return formatBinary(context.Background(), src)
+        case StrategyAuto, "":
+                return Run(context.Background(), src)
+        default:
+                return nil, internalfs.Hints{}, fmt.Errorf("unknown fmt strategy %q", strategy)
+        }
 }
 
-func formatBinary(ctx context.Context, src []byte) ([]byte, error) {
-	hints := internalfs.DetectHintsFromBytes(src)
-	src = internalfs.PrepareForParse(src, hints)
-	if len(src) > 0 && !utf8.Valid(src) {
-		return nil, fmt.Errorf("input is not valid UTF-8")
-	}
-	cmd := exec.CommandContext(ctx, "terraform", "fmt", "-no-color", "-list=false", "-write=false", "-")
-	cmd.Stdin = bytes.NewReader(src)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		if stderrStr := stderr.String(); stderrStr != "" {
-			return nil, fmt.Errorf("terraform fmt failed: %w: %s", err, stderrStr)
-		}
-		return nil, fmt.Errorf("terraform fmt failed: %w", err)
-	}
-	formatted := stdout.Bytes()
+func formatBinary(ctx context.Context, src []byte) ([]byte, internalfs.Hints, error) {
+        hints := internalfs.DetectHintsFromBytes(src)
+        src = internalfs.PrepareForParse(src, hints)
+        if len(src) > 0 && !utf8.Valid(src) {
+                return nil, internalfs.Hints{}, fmt.Errorf("input is not valid UTF-8")
+        }
+        cmd := exec.CommandContext(ctx, "terraform", "fmt", "-no-color", "-list=false", "-write=false", "-")
+        cmd.Stdin = bytes.NewReader(src)
+        var stdout bytes.Buffer
+        var stderr bytes.Buffer
+        cmd.Stdout = &stdout
+        cmd.Stderr = &stderr
+        if err := cmd.Run(); err != nil {
+                if stderrStr := stderr.String(); stderrStr != "" {
+                        return nil, internalfs.Hints{}, fmt.Errorf("terraform fmt failed: %w: %s", err, stderrStr)
+                }
+                return nil, internalfs.Hints{}, fmt.Errorf("terraform fmt failed: %w", err)
+        }
+        formatted := stdout.Bytes()
 
-	if len(formatted) > 0 {
-		formatted = bytes.TrimRight(formatted, "\n")
-		formatted = append(formatted, '\n')
-	}
-	formatted = internalfs.ApplyHints(formatted, hints)
-	return formatted, nil
+        if len(formatted) > 0 {
+                formatted = bytes.TrimRight(formatted, "\n")
+                formatted = append(formatted, '\n')
+        }
+        return formatted, hints, nil
 }

--- a/internal/fmt/terraformfmt_test.go
+++ b/internal/fmt/terraformfmt_test.go
@@ -2,80 +2,116 @@
 package terraformfmt
 
 import (
-	"context"
-	"os"
-	"os/exec"
-	"testing"
+        "bytes"
+        "context"
+        "os"
+        "os/exec"
+        "path/filepath"
+        "testing"
 
-	internalfs "github.com/oferchen/hclalign/internal/fs"
-	"github.com/stretchr/testify/require"
+        internalfs "github.com/oferchen/hclalign/internal/fs"
+        "github.com/oferchen/hclalign/formatter"
+        "github.com/stretchr/testify/require"
 )
 
-func TestGoMatchesBinary(t *testing.T) {
-	if _, err := exec.LookPath("terraform"); err != nil {
-		t.Skip("terraform binary not found")
-	}
-	src := []byte("variable \"a\" {\n  type = string\n}\n")
-	goFmt, err := Format(src, "test.tf", string(StrategyGo))
-	require.NoError(t, err)
-	binFmt, err := Format(src, "test.tf", string(StrategyBinary))
-	require.NoError(t, err)
-	require.Equal(t, string(binFmt), string(goFmt))
+func TestRunUsesTerraformCLI(t *testing.T) {
+        dir := t.TempDir()
+        bin := filepath.Join(dir, "terraform")
+        script := []byte("#!/bin/sh\ncat >/dev/null\nprintf 'bin\\n'")
+        if err := os.WriteFile(bin, script, 0o755); err != nil {
+                t.Fatalf("write fake terraform: %v", err)
+        }
+        oldPath := os.Getenv("PATH")
+        defer os.Setenv("PATH", oldPath)
+        os.Setenv("PATH", dir)
+        out, hints, err := Run(context.Background(), []byte("input\n"))
+        require.NoError(t, err)
+        require.Equal(t, "bin\n", string(out))
+        require.Equal(t, internalfs.Hints{Newline: "\n"}, hints)
 }
 
-func TestAutoUsesGoFormatter(t *testing.T) {
-	src := []byte("variable \"a\" {\n  type = string\n}\n")
-	autoFmt, err := Format(src, "test.tf", string(StrategyAuto))
-	require.NoError(t, err)
-	goFmt, err := Format(src, "test.tf", string(StrategyGo))
-	require.NoError(t, err)
-	require.Equal(t, string(goFmt), string(autoFmt))
+func TestRunFallsBackToGoFormatter(t *testing.T) {
+        oldPath := os.Getenv("PATH")
+        defer os.Setenv("PATH", oldPath)
+        os.Setenv("PATH", "")
+        src := []byte("variable \"a\" {\n  type = string\n}\n")
+        want, wantHints, err := formatter.Format(src, "test.tf")
+        require.NoError(t, err)
+        got, gotHints, err := Run(context.Background(), src)
+        require.NoError(t, err)
+        require.Equal(t, want, got)
+        require.Equal(t, wantHints, gotHints)
+}
+
+func TestRunPropagatesHints(t *testing.T) {
+        src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {}\r\n")...)
+        formatted, hints, err := Run(context.Background(), src)
+        require.NoError(t, err)
+        require.True(t, hints.HasBOM)
+        require.Equal(t, "\r\n", hints.Newline)
+        require.False(t, bytes.HasPrefix(formatted, []byte{0xef, 0xbb, 0xbf}))
+        require.False(t, bytes.Contains(formatted, []byte("\r\n")))
+        styled := internalfs.ApplyHints(formatted, hints)
+        require.Equal(t, append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {}\r\n")...), styled)
+}
+
+func TestRunContextCanceled(t *testing.T) {
+        ctx, cancel := context.WithCancel(context.Background())
+        cancel()
+        _, _, err := Run(ctx, []byte("variable \"a\" {}\n"))
+        require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestGoMatchesBinary(t *testing.T) {
+        if _, err := exec.LookPath("terraform"); err != nil {
+                t.Skip("terraform binary not found")
+        }
+        src := []byte("variable \"a\" {\n  type = string\n}\n")
+        goFmt, _, err := Format(src, "test.tf", string(StrategyGo))
+        require.NoError(t, err)
+        binFmt, _, err := Format(src, "test.tf", string(StrategyBinary))
+        require.NoError(t, err)
+        require.Equal(t, goFmt, binFmt)
 }
 
 func TestIdempotent(t *testing.T) {
-	src := []byte("variable \"a\" {\n  type = string\n}\n")
-	first, err := Format(src, "test.tf", string(StrategyGo))
-	require.NoError(t, err)
-	second, err := Format(first, "test.tf", string(StrategyGo))
-	require.NoError(t, err)
-	require.Equal(t, string(first), string(second))
+        src := []byte("variable \"a\" {\n  type = string\n}\n")
+        first, _, err := Format(src, "test.tf", string(StrategyGo))
+        require.NoError(t, err)
+        second, _, err := Format(first, "test.tf", string(StrategyGo))
+        require.NoError(t, err)
+        require.Equal(t, first, second)
 }
 
 func TestBinaryPreservesHints(t *testing.T) {
-	if _, err := exec.LookPath("terraform"); err != nil {
-		t.Skip("terraform binary not found")
-	}
-	src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {\r\n  type = string\r\n}\r\n")...)
-	formatted, err := Format(src, "test.tf", string(StrategyBinary))
-	require.NoError(t, err)
-	hints := internalfs.DetectHintsFromBytes(formatted)
-	require.True(t, hints.HasBOM)
-	require.Equal(t, "\r\n", hints.Newline)
-}
-
-func TestRunPreservesHints(t *testing.T) {
-	src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {\r\n  type = string\r\n}\r\n")...)
-	formatted, err := Run(context.Background(), src)
-	require.NoError(t, err)
-	hints := internalfs.DetectHintsFromBytes(formatted)
-	require.True(t, hints.HasBOM)
-	require.Equal(t, "\r\n", hints.Newline)
+        if _, err := exec.LookPath("terraform"); err != nil {
+                t.Skip("terraform binary not found")
+        }
+        src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {\r\n  type = string\r\n}\r\n")...)
+        formatted, hints, err := Format(src, "test.tf", string(StrategyBinary))
+        require.NoError(t, err)
+        require.True(t, hints.HasBOM)
+        require.Equal(t, "\r\n", hints.Newline)
+        require.False(t, bytes.HasPrefix(formatted, []byte{0xef, 0xbb, 0xbf}))
+        require.False(t, bytes.Contains(formatted, []byte("\r\n")))
+        styled := internalfs.ApplyHints(formatted, hints)
+        require.Equal(t, src, styled)
 }
 
 func TestUnknownStrategy(t *testing.T) {
-	_, err := Format([]byte("{}"), "test.tf", "bogus")
-	require.Error(t, err)
+        _, _, err := Format([]byte("{}"), "test.tf", "bogus")
+        require.Error(t, err)
 }
 
 func TestBinaryInvalidUTF8(t *testing.T) {
-	_, err := Format([]byte{0xff, 0xfe}, "test.tf", string(StrategyBinary))
-	require.Error(t, err)
+        _, _, err := Format([]byte{0xff, 0xfe}, "test.tf", string(StrategyBinary))
+        require.Error(t, err)
 }
 
 func TestBinaryMissingTerraform(t *testing.T) {
-	oldPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", oldPath)
-	os.Setenv("PATH", "")
-	_, err := Format([]byte("variable \"a\" {}\n"), "test.tf", string(StrategyBinary))
-	require.Error(t, err)
+        oldPath := os.Getenv("PATH")
+        defer os.Setenv("PATH", oldPath)
+        os.Setenv("PATH", "")
+        _, _, err := Format([]byte("variable \"a\" {}\n"), "test.tf", string(StrategyBinary))
+        require.Error(t, err)
 }


### PR DESCRIPTION
## Summary
- check for Terraform CLI in fmt runner and fall back to Go formatter
- plumb fs.Hints through formatter and engine so they're applied only on write
- add tests for CLI detection, hint propagation, and context cancellation

## Testing
- `make tidy`
- `make lint` *(fails: could not import unicode/utf8 (unsupported version: 2))*
- `make test`
- `make cover` *(fails: coverage 88.5% is below 95%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b384f99924832390d1f9dda60120af