### PR TITLE
refactor: refine ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           cache: true
+      - run: make init
       - run: make tidy
       - run: make fmt
+      - run: make strip
       - run: go run ./cmd/hclalign --check tests/cases
       - run: make lint
       - run: make vet
@@ -31,7 +33,6 @@ jobs:
       - name: Vulnerability check
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
         continue-on-error: true
-      - run: make test
       - run: make test-race
       - run: make cover
         env:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ GO ?= go
 init: ## download and verify modules
 	$(GO) mod download
 	$(GO) mod verify
+	$(GO) version
+	@if command -v terraform >/dev/null 2>&1; then \
+	terraform version; \
+	fi
+	$(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1 version
 
 tidy: ## tidy modules
 	$(GO) mod tidy
@@ -18,7 +23,6 @@ tidy: ## tidy modules
 fmt: ## format code and regenerate test fixtures
 	$(GO) run mvdan.cc/gofumpt@v0.6.0 -w .
 	gofmt -s -w .
-	$(MAKE) strip
 	@if command -v terraform >/dev/null 2>&1; then \
 	terraform fmt -recursive; \
 	fi
@@ -65,10 +69,13 @@ check: ## check Terraform files for alignment
 
 
 ci: ## run full CI pipeline
+	$(MAKE) init
 	$(MAKE) tidy
 	$(MAKE) fmt
+	$(MAKE) strip
 	$(MAKE) lint
-	$(MAKE) test
+	$(MAKE) vet
+	$(MAKE) test-race
 	$(MAKE) cover
 	$(MAKE) build
 


### PR DESCRIPTION
## Summary
- print tool versions during `init`
- separate `strip` from `fmt` and streamline `ci` sequence
- align CI workflow with updated Makefile

## Testing
- `make ci` *(fails: could not import unicode/utf8; unsupported version)*

------
https://chatgpt.com/codex/tasks/task_e_68b3850a446c8323931691112cb437b1