### PR TITLE
Disable dynamic, lifecycle, and provisioner alignment

### DIFF
--- a/internal/align/dynamic.go
+++ b/internal/align/dynamic.go
@@ -1,31 +1,14 @@
 // internal/align/dynamic.go
 package align
 
-import (
-	"sort"
-
-	"github.com/hashicorp/hcl/v2/hclwrite"
-)
+import "github.com/hashicorp/hcl/v2/hclwrite"
 
 type dynamicStrategy struct{}
 
 func (dynamicStrategy) Name() string { return "dynamic" }
 
 func (dynamicStrategy) Align(block *hclwrite.Block, opts *Options) error {
-	attrs := block.Body().Attributes()
-	allowed := map[string]struct{}{"for_each": {}, "iterator": {}}
-	var known, unknown []string
-	for name := range attrs {
-		if _, ok := allowed[name]; ok {
-			known = append(known, name)
-		} else {
-			unknown = append(unknown, name)
-		}
-	}
-	sort.Strings(known)
-	sort.Strings(unknown)
-	names := append(known, unknown...)
-	return reorderBlock(block, names)
+	return nil
 }
 
 func init() { Register(dynamicStrategy{}) }

--- a/internal/align/dynamic_test.go
+++ b/internal/align/dynamic_test.go
@@ -21,9 +21,9 @@ func TestDynamicAttributeOrderAndComments(t *testing.T) {
 	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
 	got := string(file.Bytes())
 	exp := `dynamic "x" {
+  foo      = 1        // foo inline
+  iterator = "it"     // iterator inline
   for_each = var.list // for_each inline
-  iterator = "it" // iterator inline
-  foo      = 1 // foo inline
 }`
 	require.Equal(t, exp, got)
 	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))

--- a/internal/align/lifecycle.go
+++ b/internal/align/lifecycle.go
@@ -1,42 +1,14 @@
 // internal/align/lifecycle.go
 package align
 
-import (
-	"github.com/hashicorp/hcl/v2/hclwrite"
-	ihcl "github.com/oferchen/hclalign/internal/hcl"
-)
+import "github.com/hashicorp/hcl/v2/hclwrite"
 
 type lifecycleStrategy struct{}
 
 func (lifecycleStrategy) Name() string { return "lifecycle" }
 
 func (lifecycleStrategy) Align(block *hclwrite.Block, opts *Options) error {
-	body := block.Body()
-	attrs := body.Attributes()
-	allowed := map[string]struct{}{
-		"create_before_destroy": {},
-		"prevent_destroy":       {},
-		"ignore_changes":        {},
-		"replace_triggered_by":  {},
-	}
-	names := make([]string, 0, len(attrs))
-	for _, name := range []string{
-		"create_before_destroy",
-		"prevent_destroy",
-		"ignore_changes",
-		"replace_triggered_by",
-	} {
-		if _, ok := attrs[name]; ok {
-			names = append(names, name)
-		}
-	}
-	original := ihcl.AttributeOrder(body, attrs)
-	for _, name := range original {
-		if _, ok := allowed[name]; !ok {
-			names = append(names, name)
-		}
-	}
-	return reorderBlock(block, names)
+	return nil
 }
 
 func init() { Register(lifecycleStrategy{}) }

--- a/internal/align/provisioner.go
+++ b/internal/align/provisioner.go
@@ -1,134 +1,13 @@
 // internal/align/provisioner.go
 package align
 
-import (
-	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/hashicorp/hcl/v2/hclwrite"
-
-	ihcl "github.com/oferchen/hclalign/internal/hcl"
-)
+import "github.com/hashicorp/hcl/v2/hclwrite"
 
 type provisionerStrategy struct{}
 
 func (provisionerStrategy) Name() string { return "provisioner" }
 
 func (provisionerStrategy) Align(block *hclwrite.Block, opts *Options) error {
-	body := block.Body()
-	attrs := body.Attributes()
-
-	ordered := []string{"when", "on_failure"}
-	allowed := map[string]struct{}{ordered[0]: {}, ordered[1]: {}}
-
-	type item struct {
-		name  string
-		attr  bool
-		block *hclwrite.Block
-	}
-
-	tokens := body.BuildTokens(nil)
-	depth := 0
-	blocks := body.Blocks()
-	blockMap := map[string][]*hclwrite.Block{}
-	for _, b := range blocks {
-		blockMap[b.Type()] = append(blockMap[b.Type()], b)
-	}
-
-	var items []item
-	for i := 0; i < len(tokens); i++ {
-		tok := tokens[i]
-		switch tok.Type {
-		case hclsyntax.TokenOBrace, hclsyntax.TokenOParen:
-			depth++
-		case hclsyntax.TokenCBrace, hclsyntax.TokenCParen:
-			if depth > 0 {
-				depth--
-			}
-		case hclsyntax.TokenIdent:
-			if depth != 0 {
-				continue
-			}
-			name := string(tok.Bytes)
-			j := i + 1
-			for j < len(tokens) && (tokens[j].Type == hclsyntax.TokenNewline || tokens[j].Type == hclsyntax.TokenComment) {
-				j++
-			}
-			if j >= len(tokens) {
-				continue
-			}
-			switch tokens[j].Type {
-			case hclsyntax.TokenEqual:
-				items = append(items, item{name: name, attr: true})
-			case hclsyntax.TokenOBrace:
-				if bs := blockMap[name]; len(bs) > 0 {
-					items = append(items, item{name: name, block: bs[0]})
-					blockMap[name] = bs[1:]
-				}
-			}
-		}
-	}
-
-	attrTokensMap := map[string]ihcl.AttrTokens{}
-	for name, attr := range attrs {
-		attrTokensMap[name] = ihcl.ExtractAttrTokens(attr)
-		body.RemoveAttribute(name)
-	}
-	for _, b := range blocks {
-		body.RemoveBlock(b)
-	}
-
-	var order []item
-	for _, k := range ordered {
-		if _, ok := attrs[k]; ok {
-			order = append(order, item{name: k, attr: true})
-		}
-	}
-	for _, it := range items {
-		if it.attr {
-			if _, ok := allowed[it.name]; ok {
-				continue
-			}
-			order = append(order, it)
-			continue
-		}
-		order = append(order, it)
-	}
-
-	newline := ihcl.DetectLineEnding(tokens)
-	trailingComma := ihcl.HasTrailingComma(tokens)
-
-	body.Clear()
-	if len(order) > 0 {
-		body.AppendUnstructuredTokens(hclwrite.Tokens{
-			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: newline},
-		})
-	}
-	appendAttr := func(name string) {
-		if tok, ok := attrTokensMap[name]; ok {
-			body.AppendUnstructuredTokens(tok.LeadTokens)
-			body.SetAttributeRaw(name, tok.ExprTokens)
-		}
-	}
-	for _, it := range order {
-		if it.attr {
-			appendAttr(it.name)
-			continue
-		}
-		body.AppendUnstructuredTokens(hclwrite.Tokens{
-			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: newline},
-		})
-		body.AppendBlock(it.block)
-	}
-	if trailingComma && len(order) > 0 {
-		body.AppendUnstructuredTokens(hclwrite.Tokens{
-			&hclwrite.Token{Type: hclsyntax.TokenComma, Bytes: []byte(",")},
-		})
-	}
-	toks := body.BuildTokens(nil)
-	if len(toks) > 0 && toks[len(toks)-1].Type != hclsyntax.TokenNewline {
-		body.AppendUnstructuredTokens(hclwrite.Tokens{
-			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: newline},
-		})
-	}
 	return nil
 }
 

--- a/internal/align/provisioner_test.go
+++ b/internal/align/provisioner_test.go
@@ -22,10 +22,10 @@ func TestProvisionerAttributeOrderAndComments(t *testing.T) {
 	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
 	got := string(file.Bytes())
 	exp := `provisioner "local-exec" {
-  when       = "destroy" // when inline
+  bar        = "bar"      // bar inline
+  foo        = "foo"      // foo inline
+  when       = "destroy"  // when inline
   on_failure = "continue" // on_failure inline
-  bar        = "bar" // bar inline
-  foo        = "foo" // foo inline
 }`
 	require.Equal(t, exp, got)
 	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))

--- a/tests/cases/connection/out.tf
+++ b/tests/cases/connection/out.tf
@@ -7,7 +7,6 @@ resource "null_resource" "example" {
   }
 
   provisioner "local-exec" {
-
     connection {
       host    = "127.0.0.1"
       timeout = "1m"

--- a/tests/cases/lifecycle/aligned.tf
+++ b/tests/cases/lifecycle/aligned.tf
@@ -1,12 +1,12 @@
 resource "null_resource" "example" {
 
   lifecycle {
+    foo                   = "foo"
     create_before_destroy = true
+    bar                   = "bar"
     prevent_destroy       = true
     ignore_changes        = []
-    replace_triggered_by  = []
-    foo                   = "foo"
-    bar                   = "bar"
     baz                   = "baz"
+    replace_triggered_by  = []
   }
 }

--- a/tests/cases/lifecycle/out.tf
+++ b/tests/cases/lifecycle/out.tf
@@ -1,12 +1,12 @@
 resource "null_resource" "example" {
 
   lifecycle {
+    foo                   = "foo"
     create_before_destroy = true
+    bar                   = "bar"
     prevent_destroy       = true
     ignore_changes        = []
-    replace_triggered_by  = []
-    foo                   = "foo"
-    bar                   = "bar"
     baz                   = "baz"
+    replace_triggered_by  = []
   }
 }

--- a/tests/cases/non_variable/out.tf
+++ b/tests/cases/non_variable/out.tf
@@ -45,7 +45,6 @@ import {
 
 dynamic "d" {
   for_each = [1]
-
   content {
     b = 1
     a = 2
@@ -53,8 +52,8 @@ dynamic "d" {
 }
 
 lifecycle {
-  create_before_destroy = true
   prevent_destroy       = false
+  create_before_destroy = true
 
   precondition {
     error_message = "pre"

--- a/tests/cases/provisioner/aligned.tf
+++ b/tests/cases/provisioner/aligned.tf
@@ -1,13 +1,11 @@
 resource "null_resource" "example" {
-
   provisioner "local-exec" {
-    when       = "destroy"
-    on_failure = "continue"
-    bar        = "b"
-
+    bar  = "b"
+    when = "destroy"
     connection {
       host = "example.com"
     }
-    foo = "f"
+    foo        = "f"
+    on_failure = "continue"
   }
 }


### PR DESCRIPTION
## Summary
- make dynamic, lifecycle, and provisioner aligners no-ops
- update unit tests and golden cases to keep original ordering

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b38522fac883239ebe2fc1b4042382