### PR TITLE
Sort module providers map with prefix-order

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The default schema orders variable attributes as `description → type → defau
 - **terraform:** `required_version`, `experiments`, `required_providers` (entries sorted alphabetically), `backend`, `cloud`, then remaining attributes and blocks in their original order
 - **resource/data:** `provider`, `count`, `for_each`, `depends_on`, `lifecycle`, `provisioner`, then provider schema attributes grouped as required → optional → computed (each alphabetical)
 
-Validation blocks are placed immediately after canonical attributes. Attributes not in the canonical list or provider schema are appended in their original order. Use `--prefix-order` to sort them alphabetically.
+Validation blocks are placed immediately after canonical attributes. Attributes not in the canonical list or provider schema are appended in their original order. Use `--prefix-order` to sort them alphabetically; module provider maps are sorted as well.
 
 Entries within `required_providers` are sorted alphabetically by provider name. Other `terraform` attributes follow `required_version`, `experiments`, `backend`, and `cloud` in that order.
 
@@ -77,7 +77,7 @@ hclalign . --types module --order value,description,type
 Resource and data blocks can be ordered according to provider schemas. Supply a
 schema file via `--providers-schema` or let `hclalign` invoke `terraform
 providers schema -json` by passing `--use-terraform-schema`. Unknown attributes
-keep their original order unless `--prefix-order` is used.
+keep their original order unless `--prefix-order` is used, which also sorts module provider maps.
 
 ## CLI Flags
 
@@ -94,7 +94,7 @@ keep their original order unless `--prefix-order` is used.
 - `--use-terraform-schema`: derive schema via `terraform providers schema -json`
 - `--types`: comma-separated list of block types to align (defaults to `variable`)
 - `--all`: align all supported block types (mutually exclusive with `--types`)
-- `--prefix-order`: lexicographically sort attributes not covered by the schema; by default, unknown attributes preserve their input order
+- `--prefix-order`: lexicographically sort attributes not covered by the schema and module provider maps; by default, unknown attributes preserve their input order
 
 
 ## Exit Codes

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -40,7 +40,7 @@ func newTestRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().Bool("follow-symlinks", false, "follow symlinks when traversing directories")
 	cmd.Flags().StringSlice("types", []string{"variable"}, "comma-separated list of block types to align")
 	cmd.Flags().Bool("all", false, "align all block types")
-	cmd.Flags().Bool("prefix-order", false, "lexicographically sort unknown attributes")
+	cmd.Flags().Bool("prefix-order", false, "lexicographically sort unknown attributes and module provider maps")
 	cmd.MarkFlagsMutuallyExclusive("types", "all")
 	if exclusive {
 		cmd.MarkFlagsMutuallyExclusive("write", "check", "diff")

--- a/cmd/hclalign/main.go
+++ b/cmd/hclalign/main.go
@@ -44,7 +44,7 @@ func run(args []string) int {
 	rootCmd.Flags().Bool("follow-symlinks", false, "follow symlinks when traversing directories")
 	rootCmd.Flags().StringSlice("types", []string{"variable"}, "comma-separated list of block types to align")
 	rootCmd.Flags().Bool("all", false, "align all block types")
-	rootCmd.Flags().Bool("prefix-order", false, "lexicographically sort unknown attributes")
+	rootCmd.Flags().Bool("prefix-order", false, "lexicographically sort unknown attributes and module provider maps")
 	rootCmd.MarkFlagsMutuallyExclusive("types", "all")
 
 	rootCmd.SetArgs(args)

--- a/internal/align/module.go
+++ b/internal/align/module.go
@@ -4,6 +4,7 @@ package align
 import (
 	"sort"
 
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
@@ -13,6 +14,15 @@ func (moduleStrategy) Name() string { return "module" }
 
 func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrs := block.Body().Attributes()
+	if opts != nil && opts.PrefixOrder {
+		if attr, ok := attrs["providers"]; ok {
+			toks := attr.Expr().BuildTokens(nil)
+			if len(toks) > 0 && toks[0].Type == hclsyntax.TokenOBrace {
+				sortProviders(block.Body(), attr)
+				attrs = block.Body().Attributes()
+			}
+		}
+	}
 
 	canonical := CanonicalBlockAttrOrder["module"]
 	order := make([]string, 0, len(attrs))
@@ -35,6 +45,69 @@ func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	order = append(order, vars...)
 
 	return reorderBlock(block, order)
+}
+
+func sortProviders(body *hclwrite.Body, attr *hclwrite.Attribute) {
+	tokens := attr.Expr().BuildTokens(nil)
+	if len(tokens) < 3 || tokens[0].Type != hclsyntax.TokenOBrace {
+		return
+	}
+	prefix := hclwrite.Tokens{}
+	i := 1
+	for i < len(tokens)-1 && tokens[i].Type != hclsyntax.TokenIdent {
+		prefix = append(prefix, tokens[i])
+		i++
+	}
+	start := i
+	type kv struct {
+		name   string
+		tokens hclwrite.Tokens
+	}
+	var kvs []kv
+	for start < len(tokens)-1 {
+		if tokens[start].Type != hclsyntax.TokenIdent {
+			break
+		}
+		name := string(tokens[start].Bytes)
+		i := start + 1
+		depth := 0
+		for i < len(tokens)-1 {
+			t := tokens[i]
+			switch t.Type {
+			case hclsyntax.TokenOBrace, hclsyntax.TokenOBrack, hclsyntax.TokenOParen:
+				depth++
+			case hclsyntax.TokenCBrace, hclsyntax.TokenCBrack, hclsyntax.TokenCParen:
+				if depth > 0 {
+					depth--
+				}
+			case hclsyntax.TokenComma:
+				if depth == 0 {
+					i++
+					if i < len(tokens)-1 && tokens[i].Type == hclsyntax.TokenNewline {
+						i++
+					}
+					goto set
+				}
+			case hclsyntax.TokenNewline:
+				if depth == 0 {
+					i++
+					goto set
+				}
+			}
+			i++
+		}
+	set:
+		kvs = append(kvs, kv{name: name, tokens: append(hclwrite.Tokens{}, tokens[start:i]...)})
+		start = i
+	}
+	sort.Slice(kvs, func(i, j int) bool { return kvs[i].name < kvs[j].name })
+	expr := hclwrite.Tokens{tokens[0]}
+	expr = append(expr, prefix...)
+	for _, kv := range kvs {
+		expr = append(expr, kv.tokens...)
+	}
+	expr = append(expr, tokens[len(tokens)-1])
+	body.SetAttributeRaw("providers", expr)
 }
 
 func init() { Register(moduleStrategy{}) }

--- a/internal/align/prefix_order_test.go
+++ b/internal/align/prefix_order_test.go
@@ -39,7 +39,7 @@ func TestPrefixOrder(t *testing.T) {
 			if diags.HasErrors() {
 				t.Fatalf("parse input: %v", diags)
 			}
-			if err := alignpkg.Apply(file, &alignpkg.Options{Schemas: schemas, PrefixOrder: tc.prefix, Types: map[string]struct{}{"resource": {}}}); err != nil {
+			if err := alignpkg.Apply(file, &alignpkg.Options{Schemas: schemas, PrefixOrder: tc.prefix, Types: map[string]struct{}{"resource": {}, "module": {}}}); err != nil {
 				t.Fatalf("align: %v", err)
 			}
 			got := hclwrite.Format(file.Bytes())
@@ -54,7 +54,7 @@ func TestPrefixOrder(t *testing.T) {
 			if diags.HasErrors() {
 				t.Fatalf("parse expected: %v", diags)
 			}
-			if err := alignpkg.Apply(file2, &alignpkg.Options{Schemas: schemas, PrefixOrder: tc.prefix, Types: map[string]struct{}{"resource": {}}}); err != nil {
+			if err := alignpkg.Apply(file2, &alignpkg.Options{Schemas: schemas, PrefixOrder: tc.prefix, Types: map[string]struct{}{"resource": {}, "module": {}}}); err != nil {
 				t.Fatalf("reapply: %v", err)
 			}
 			if !bytes.Equal(want, hclwrite.Format(file2.Bytes())) {

--- a/internal/engine/write_error_test.go
+++ b/internal/engine/write_error_test.go
@@ -42,7 +42,7 @@ func newRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().Bool("follow-symlinks", false, "follow symlinks when traversing directories")
 	cmd.Flags().StringSlice("types", []string{"variable"}, "comma-separated list of block types to align")
 	cmd.Flags().Bool("all", false, "align all block types")
-	cmd.Flags().Bool("prefix-order", false, "lexicographically sort unknown attributes")
+	cmd.Flags().Bool("prefix-order", false, "lexicographically sort unknown attributes and module provider maps")
 	cmd.MarkFlagsMutuallyExclusive("types", "all")
 	if exclusive {
 		cmd.MarkFlagsMutuallyExclusive("write", "check", "diff")

--- a/tests/cases/prefix_order/in.tf
+++ b/tests/cases/prefix_order/in.tf
@@ -3,3 +3,11 @@ resource "aws_s3_bucket" "r" {
   foo    = 1
   bar    = 2
 }
+
+module "m" {
+  source = "./m"
+  providers = {
+    azurerm = azurerm
+    aws     = aws.us
+  }
+}

--- a/tests/cases/prefix_order/out.tf
+++ b/tests/cases/prefix_order/out.tf
@@ -3,3 +3,11 @@ resource "aws_s3_bucket" "r" {
   foo    = 1
   bar    = 2
 }
+
+module "m" {
+  source = "./m"
+  providers = {
+    azurerm = azurerm
+    aws     = aws.us
+  }
+}

--- a/tests/cases/prefix_order/sorted.tf
+++ b/tests/cases/prefix_order/sorted.tf
@@ -3,3 +3,11 @@ resource "aws_s3_bucket" "r" {
   bar    = 2
   foo    = 1
 }
+
+module "m" {
+  source = "./m"
+  providers = {
+    aws     = aws.us
+    azurerm = azurerm
+  }
+}


### PR DESCRIPTION
## Summary
- sort module providers map when `--prefix-order` is enabled
- test provider map ordering on prefix-order option
- document provider map sorting in README and CLI

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b3850443048323b41eb7f6454fb84f