### PR TITLE
refactor: implement fmt runner

### DIFF
--- a/internal/fmt/runner.go
+++ b/internal/fmt/runner.go
@@ -2,29 +2,19 @@
 package terraformfmt
 
 import (
-        "context"
-        "os/exec"
+	"context"
+	"os/exec"
 
 	"github.com/oferchen/hclalign/formatter"
 	internalfs "github.com/oferchen/hclalign/internal/fs"
 )
 
 func Run(ctx context.Context, src []byte) ([]byte, internalfs.Hints, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, internalfs.Hints{}, err
+	}
+	if _, err := exec.LookPath("terraform"); err == nil {
+		return formatBinary(ctx, src)
+	}
 	return formatter.Format(src, "")
-        internalfs "github.com/oferchen/hclalign/internal/fs"
-        "github.com/oferchen/hclalign/formatter"
-)
-
-func Run(ctx context.Context, src []byte) ([]byte, internalfs.Hints, error) {
-        if err := ctx.Err(); err != nil {
-                return nil, internalfs.Hints{}, err
-        }
-        if _, err := exec.LookPath("terraform"); err == nil {
-                return formatBinary(ctx, src)
-        }
-        formatted, hints, err := formatter.Format(src, "")
-        if err != nil {
-                return nil, internalfs.Hints{}, err
-        }
-        return formatted, hints, nil
 }


### PR DESCRIPTION
## Summary
- clean up fmt runner imports and duplicate function
- implement Run that selects terraform binary or Go formatter

## Testing
- `make tidy`
- `make lint` *(fails: expected declaration, found ')')*
- `make test` *(fails: expected declaration)*
- `make cover` *(fails: expected declaration)*
- `make build` *(fails: syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68b392ab40d48323a5d33f9465083362