### PR TITLE
refactor terraform formatter strategy dispatch

### DIFF
--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -15,9 +15,9 @@ import (
 type Strategy string
 
 const (
-        StrategyAuto   Strategy = "auto"
-        StrategyBinary Strategy = "binary"
-        StrategyGo     Strategy = "go"
+	StrategyAuto   Strategy = "auto"
+	StrategyBinary Strategy = "binary"
+	StrategyGo     Strategy = "go"
 )
 
 func Format(src []byte, filename, strategy string) ([]byte, internalfs.Hints, error) {
@@ -58,42 +58,4 @@ func formatBinary(ctx context.Context, src []byte) ([]byte, internalfs.Hints, er
 		formatted = append(formatted, '\n')
 	}
 	return formatted, hints, nil
-
-        switch Strategy(strategy) {
-        case StrategyGo:
-                return formatter.Format(src, filename)
-        case StrategyBinary:
-                return formatBinary(context.Background(), src)
-        case StrategyAuto, "":
-                return Run(context.Background(), src)
-        default:
-                return nil, internalfs.Hints{}, fmt.Errorf("unknown fmt strategy %q", strategy)
-        }
-}
-
-func formatBinary(ctx context.Context, src []byte) ([]byte, internalfs.Hints, error) {
-        hints := internalfs.DetectHintsFromBytes(src)
-        src = internalfs.PrepareForParse(src, hints)
-        if len(src) > 0 && !utf8.Valid(src) {
-                return nil, internalfs.Hints{}, fmt.Errorf("input is not valid UTF-8")
-        }
-        cmd := exec.CommandContext(ctx, "terraform", "fmt", "-no-color", "-list=false", "-write=false", "-")
-        cmd.Stdin = bytes.NewReader(src)
-        var stdout bytes.Buffer
-        var stderr bytes.Buffer
-        cmd.Stdout = &stdout
-        cmd.Stderr = &stderr
-        if err := cmd.Run(); err != nil {
-                if stderrStr := stderr.String(); stderrStr != "" {
-                        return nil, internalfs.Hints{}, fmt.Errorf("terraform fmt failed: %w: %s", err, stderrStr)
-                }
-                return nil, internalfs.Hints{}, fmt.Errorf("terraform fmt failed: %w", err)
-        }
-        formatted := stdout.Bytes()
-
-        if len(formatted) > 0 {
-                formatted = bytes.TrimRight(formatted, "\n")
-                formatted = append(formatted, '\n')
-        }
-        return formatted, hints, nil
 }


### PR DESCRIPTION
## Summary
- remove duplicate formatters in `terraformfmt`
- implement single `Format` dispatcher
- keep one `formatBinary` helper for Terraform CLI invocation

## Testing
- `go test ./...` *(fails: expected declaration, found ')')*


------
https://chatgpt.com/codex/tasks/task_e_68b392ae9b348323a367d06cb97fed88