### PR TITLE
formatter: remove duplicate Format

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -2,16 +2,15 @@
 package formatter
 
 import (
-        "bytes"
-        "fmt"
-        "unicode/utf8"
+	"bytes"
+	"fmt"
+	"unicode/utf8"
 
-        "github.com/hashicorp/hcl/v2"
-        "github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 
-        internalfs "github.com/oferchen/hclalign/internal/fs"
+	internalfs "github.com/oferchen/hclalign/internal/fs"
 )
-
 
 func Format(src []byte, filename string) (formatted []byte, hints internalfs.Hints, err error) {
 	hints = internalfs.DetectHintsFromBytes(src)
@@ -30,33 +29,9 @@ func Format(src []byte, filename string) (formatted []byte, hints internalfs.Hin
 	}
 	formatted = hclwrite.Format(f.Bytes())
 	formatted = bytes.ReplaceAll(formatted, []byte("\r\n"), []byte("\n"))
-
 	if len(formatted) > 0 {
 		formatted = bytes.TrimRight(formatted, "\n")
 		formatted = append(formatted, '\n')
 	}
 	return
-
-func Format(src []byte, filename string) ([]byte, internalfs.Hints, error) {
-        hints := internalfs.DetectHintsFromBytes(src)
-        if bom := hints.BOM(); len(bom) > 0 {
-                src = src[len(bom):]
-        }
-        if len(src) > 0 && !utf8.Valid(src) {
-                return nil, internalfs.Hints{}, fmt.Errorf("input is not valid UTF-8")
-        }
-
-        f, diags := hclwrite.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
-        if diags.HasErrors() {
-                return nil, internalfs.Hints{}, diags
-        }
-        formatted := hclwrite.Format(f.Bytes())
-        formatted = bytes.ReplaceAll(formatted, []byte("\r\n"), []byte("\n"))
-
-        if len(formatted) > 0 {
-                formatted = bytes.TrimRight(formatted, "\n")
-                formatted = append(formatted, '\n')
-        }
-
-        return formatted, hints, nil
 }


### PR DESCRIPTION
## Summary
- remove unfinished Format function
- normalize trailing newline through a single Format implementation

## Testing
- `make tidy`
- `make lint` *(fails: internal/fs and other packages have typecheck errors)*
- `make test` *(fails: syntax errors in internal packages and tests)*
- `make cover` *(fails: build errors across packages)*
- `make build` *(fails: syntax errors in internal fmt package)*

------
https://chatgpt.com/codex/tasks/task_e_68b392b0f9988323ac1b0938a5353a43