### PR TITLE
ci: align workflow sequence with stripcomments target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - run: make init
       - run: make tidy
       - run: make fmt
-      - run: make strip
+      - run: make stripcomments
       - run: go run ./cmd/hclalign --check tests/cases
       - run: make lint
       - run: make vet


### PR DESCRIPTION
## Summary
- update CI workflow to call `make stripcomments`
- keep terraform fmt parity job and ensure step order matches Makefile (`init`, `tidy`, `fmt`, `stripcomments`, `lint`, `vet`, `test-race`, `cover`, `build`)

## Testing
- `go test ./...` *(fails: formatter/formatter.go:40:6: syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68b392c6384c832390c619a1a360d39c