### PR TITLE
Add context-aware Format to Terraform formatter

### DIFF
--- a/internal/align/golden_test.go
+++ b/internal/align/golden_test.go
@@ -3,6 +3,7 @@ package align_test
 
 import (
 	"bytes"
+	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -57,29 +58,29 @@ func TestGolden(t *testing.T) {
 				t.Fatalf("read out: %v", err)
 			}
 
-			fmtBytes, _, err := terraformfmt.Format(inBytes, inPath, string(terraformfmt.StrategyGo))
+			fmtBytes, _, err := terraformfmt.Format(context.Background(), inBytes, inPath, string(terraformfmt.StrategyGo))
 			if err != nil {
 				t.Fatalf("format input: %v", err)
 			}
 
-                        fmtBytes, _, err := terraformfmt.Format(inBytes, inPath, string(terraformfmt.StrategyGo))
-                        if err != nil {
-                                t.Fatalf("format input: %v", err)
-                        }
+			fmtBytes, _, err := terraformfmt.Format(context.Background(), inBytes, inPath, string(terraformfmt.StrategyGo))
+			if err != nil {
+				t.Fatalf("format input: %v", err)
+			}
 			hadNewline := len(inBytes) > 0 && inBytes[len(inBytes)-1] == '\n'
 			if !hadNewline && len(fmtBytes) > 0 && fmtBytes[len(fmtBytes)-1] == '\n' {
 				fmtBytes = fmtBytes[:len(fmtBytes)-1]
 			}
 
-			againFmt, _, err := terraformfmt.Format(fmtBytes, inPath, string(terraformfmt.StrategyGo))
+			againFmt, _, err := terraformfmt.Format(context.Background(), fmtBytes, inPath, string(terraformfmt.StrategyGo))
 			if err != nil {
 				t.Fatalf("format fmt: %v", err)
 			}
 
-                        againFmt, _, err := terraformfmt.Format(fmtBytes, inPath, string(terraformfmt.StrategyGo))
-                        if err != nil {
-                                t.Fatalf("format fmt: %v", err)
-                        }
+			againFmt, _, err := terraformfmt.Format(context.Background(), fmtBytes, inPath, string(terraformfmt.StrategyGo))
+			if err != nil {
+				t.Fatalf("format fmt: %v", err)
+			}
 			hadFmtNewline := len(fmtBytes) > 0 && fmtBytes[len(fmtBytes)-1] == '\n'
 			if !hadFmtNewline && len(againFmt) > 0 && againFmt[len(againFmt)-1] == '\n' {
 				againFmt = againFmt[:len(againFmt)-1]

--- a/internal/align/phases_test.go
+++ b/internal/align/phases_test.go
@@ -2,9 +2,10 @@
 package align_test
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+        "context"
+        "os"
+        "path/filepath"
+        "testing"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -32,20 +33,20 @@ func TestPhases(t *testing.T) {
 			wantOut, err := os.ReadFile(outPath)
 			require.NoError(t, err)
 
-			fmtBytes, _, err := terraformfmt.Format(inBytes, inPath, string(terraformfmt.StrategyGo))
+			fmtBytes, _, err := terraformfmt.Format(context.Background(), inBytes, inPath, string(terraformfmt.StrategyGo))
 			require.NoError(t, err)
 
-                        fmtBytes, _, err := terraformfmt.Format(inBytes, inPath, string(terraformfmt.StrategyGo))
+                        fmtBytes, _, err := terraformfmt.Format(context.Background(), inBytes, inPath, string(terraformfmt.StrategyGo))
                         require.NoError(t, err)
 
 			hadNewline := len(inBytes) > 0 && inBytes[len(inBytes)-1] == '\n'
 			if !hadNewline && len(fmtBytes) > 0 && fmtBytes[len(fmtBytes)-1] == '\n' {
 				fmtBytes = fmtBytes[:len(fmtBytes)-1]
 			}
-			againFmt, _, err := terraformfmt.Format(fmtBytes, inPath, string(terraformfmt.StrategyGo))
+			againFmt, _, err := terraformfmt.Format(context.Background(), fmtBytes, inPath, string(terraformfmt.StrategyGo))
 			require.NoError(t, err)
 
-                        againFmt, _, err := terraformfmt.Format(fmtBytes, inPath, string(terraformfmt.StrategyGo))
+                        againFmt, _, err := terraformfmt.Format(context.Background(), fmtBytes, inPath, string(terraformfmt.StrategyGo))
                         require.NoError(t, err)
 			hadFmtNewline := len(fmtBytes) > 0 && fmtBytes[len(fmtBytes)-1] == '\n'
 			if !hadFmtNewline && len(againFmt) > 0 && againFmt[len(againFmt)-1] == '\n' {
@@ -75,11 +76,11 @@ func TestPhases(t *testing.T) {
 	}
 
 	t.Run("error", func(t *testing.T) {
-		_, _, err := terraformfmt.Format([]byte("variable \"a\" {"), "bad.hcl", string(terraformfmt.StrategyGo))
+		_, _, err := terraformfmt.Format(context.Background(), []byte("variable \"a\" {"), "bad.hcl", string(terraformfmt.StrategyGo))
 		require.Error(t, err)
 	})
 
-                _, _, err := terraformfmt.Format([]byte("variable \"a\" {"), "bad.hcl", string(terraformfmt.StrategyGo))
+                _, _, err := terraformfmt.Format(context.Background(), []byte("variable \"a\" {"), "bad.hcl", string(terraformfmt.StrategyGo))
                 require.Error(t, err)
         })
 }

--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -20,14 +20,17 @@ const (
 	StrategyGo     Strategy = "go"
 )
 
-func Format(src []byte, filename, strategy string) ([]byte, internalfs.Hints, error) {
+func Format(ctx context.Context, src []byte, filename, strategy string) ([]byte, internalfs.Hints, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, internalfs.Hints{}, err
+	}
 	switch Strategy(strategy) {
 	case StrategyGo:
 		return formatter.Format(src, filename)
 	case StrategyBinary:
-		return formatBinary(context.Background(), src)
+		return formatBinary(ctx, src)
 	case StrategyAuto, "":
-		return Run(context.Background(), src)
+		return Run(ctx, src)
 	default:
 		return nil, internalfs.Hints{}, fmt.Errorf("unknown fmt strategy %q", strategy)
 	}

--- a/internal/fmt/terraformfmt_test.go
+++ b/internal/fmt/terraformfmt_test.go
@@ -17,27 +17,27 @@ func TestGoMatchesBinary(t *testing.T) {
 		t.Skip("terraform binary not found")
 	}
 	src := []byte("variable \"a\" {\n  type = string\n}\n")
-	goFmt, _, err := Format(src, "test.tf", string(StrategyGo))
+	goFmt, _, err := Format(context.Background(), src, "test.tf", string(StrategyGo))
 	require.NoError(t, err)
-	binFmt, _, err := Format(src, "test.tf", string(StrategyBinary))
+	binFmt, _, err := Format(context.Background(), src, "test.tf", string(StrategyBinary))
 	require.NoError(t, err)
 	require.Equal(t, string(binFmt), string(goFmt))
 }
 
 func TestAutoUsesGoFormatter(t *testing.T) {
 	src := []byte("variable \"a\" {\n  type = string\n}\n")
-	autoFmt, _, err := Format(src, "test.tf", string(StrategyAuto))
+	autoFmt, _, err := Format(context.Background(), src, "test.tf", string(StrategyAuto))
 	require.NoError(t, err)
-	goFmt, _, err := Format(src, "test.tf", string(StrategyGo))
+	goFmt, _, err := Format(context.Background(), src, "test.tf", string(StrategyGo))
 	require.NoError(t, err)
 	require.Equal(t, string(goFmt), string(autoFmt))
 }
 
 func TestIdempotent(t *testing.T) {
 	src := []byte("variable \"a\" {\n  type = string\n}\n")
-	first, _, err := Format(src, "test.tf", string(StrategyGo))
+	first, _, err := Format(context.Background(), src, "test.tf", string(StrategyGo))
 	require.NoError(t, err)
-	second, _, err := Format(first, "test.tf", string(StrategyGo))
+	second, _, err := Format(context.Background(), first, "test.tf", string(StrategyGo))
 	require.NoError(t, err)
 	require.Equal(t, string(first), string(second))
 }
@@ -47,7 +47,7 @@ func TestBinaryPreservesHints(t *testing.T) {
 		t.Skip("terraform binary not found")
 	}
 	src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {\r\n  type = string\r\n}\r\n")...)
-	_, hints, err := Format(src, "test.tf", string(StrategyBinary))
+	_, hints, err := Format(context.Background(), src, "test.tf", string(StrategyBinary))
 	require.NoError(t, err)
 	require.True(t, hints.HasBOM)
 	require.Equal(t, "\r\n", hints.Newline)
@@ -62,12 +62,12 @@ func TestRunPreservesHints(t *testing.T) {
 }
 
 func TestUnknownStrategy(t *testing.T) {
-	_, _, err := Format([]byte("{}"), "test.tf", "bogus")
+	_, _, err := Format(context.Background(), []byte("{}"), "test.tf", "bogus")
 	require.Error(t, err)
 }
 
 func TestBinaryInvalidUTF8(t *testing.T) {
-	_, _, err := Format([]byte{0xff, 0xfe}, "test.tf", string(StrategyBinary))
+	_, _, err := Format(context.Background(), []byte{0xff, 0xfe}, "test.tf", string(StrategyBinary))
 	require.Error(t, err)
 }
 
@@ -75,7 +75,7 @@ func TestBinaryMissingTerraform(t *testing.T) {
 	oldPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", oldPath)
 	os.Setenv("PATH", "")
-	_, _, err := Format([]byte("variable \"a\" {}\n"), "test.tf", string(StrategyBinary))
+	_, _, err := Format(context.Background(), []byte("variable \"a\" {}\n"), "test.tf", string(StrategyBinary))
 	require.Error(t, err)
 
         internalfs "github.com/oferchen/hclalign/internal/fs"
@@ -136,18 +136,18 @@ func TestGoMatchesBinary(t *testing.T) {
                 t.Skip("terraform binary not found")
         }
         src := []byte("variable \"a\" {\n  type = string\n}\n")
-        goFmt, _, err := Format(src, "test.tf", string(StrategyGo))
+        goFmt, _, err := Format(context.Background(), src, "test.tf", string(StrategyGo))
         require.NoError(t, err)
-        binFmt, _, err := Format(src, "test.tf", string(StrategyBinary))
+        binFmt, _, err := Format(context.Background(), src, "test.tf", string(StrategyBinary))
         require.NoError(t, err)
         require.Equal(t, goFmt, binFmt)
 }
 
 func TestIdempotent(t *testing.T) {
         src := []byte("variable \"a\" {\n  type = string\n}\n")
-        first, _, err := Format(src, "test.tf", string(StrategyGo))
+        first, _, err := Format(context.Background(), src, "test.tf", string(StrategyGo))
         require.NoError(t, err)
-        second, _, err := Format(first, "test.tf", string(StrategyGo))
+        second, _, err := Format(context.Background(), first, "test.tf", string(StrategyGo))
         require.NoError(t, err)
         require.Equal(t, first, second)
 }
@@ -157,7 +157,7 @@ func TestBinaryPreservesHints(t *testing.T) {
                 t.Skip("terraform binary not found")
         }
         src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {\r\n  type = string\r\n}\r\n")...)
-        formatted, hints, err := Format(src, "test.tf", string(StrategyBinary))
+        formatted, hints, err := Format(context.Background(), src, "test.tf", string(StrategyBinary))
         require.NoError(t, err)
         require.True(t, hints.HasBOM)
         require.Equal(t, "\r\n", hints.Newline)
@@ -168,12 +168,12 @@ func TestBinaryPreservesHints(t *testing.T) {
 }
 
 func TestUnknownStrategy(t *testing.T) {
-        _, _, err := Format([]byte("{}"), "test.tf", "bogus")
+        _, _, err := Format(context.Background(), []byte("{}"), "test.tf", "bogus")
         require.Error(t, err)
 }
 
 func TestBinaryInvalidUTF8(t *testing.T) {
-        _, _, err := Format([]byte{0xff, 0xfe}, "test.tf", string(StrategyBinary))
+        _, _, err := Format(context.Background(), []byte{0xff, 0xfe}, "test.tf", string(StrategyBinary))
         require.Error(t, err)
 }
 
@@ -181,6 +181,6 @@ func TestBinaryMissingTerraform(t *testing.T) {
         oldPath := os.Getenv("PATH")
         defer os.Setenv("PATH", oldPath)
         os.Setenv("PATH", "")
-        _, _, err := Format([]byte("variable \"a\" {}\n"), "test.tf", string(StrategyBinary))
+        _, _, err := Format(context.Background(), []byte("variable \"a\" {}\n"), "test.tf", string(StrategyBinary))
         require.Error(t, err)
 }


### PR DESCRIPTION
## Summary
- accept `context.Context` in `terraformfmt.Format`
- propagate context cancellation to `formatBinary` and `Run`
- update tests to pass a context

## Testing
- `go test ./...` *(fails: formatter/formatter_test.go:63:18: expected declaration, found ')'; internal/align/phases_test.go:85:10: expected declaration, found ')'; internal/fmt/terraformfmt_test.go:81:20: expected ';', found "github.com/oferchen/hclalign/internal/fs")*

------
https://chatgpt.com/codex/tasks/task_e_68b42d48894483239b2286774f40cd83