### PR TITLE
Cache Terraform path lookup

### DIFF
--- a/internal/fmt/runner.go
+++ b/internal/fmt/runner.go
@@ -4,16 +4,27 @@ package terraformfmt
 import (
 	"context"
 	"os/exec"
+	"sync"
 
 	"github.com/oferchen/hclalign/formatter"
 	internalfs "github.com/oferchen/hclalign/internal/fs"
 )
 
+var terraformPath string
+var terraformPathOnce sync.Once
+
+func terraformBinary() string {
+	terraformPathOnce.Do(func() {
+		terraformPath, _ = exec.LookPath("terraform")
+	})
+	return terraformPath
+}
+
 func Run(ctx context.Context, src []byte) ([]byte, internalfs.Hints, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, internalfs.Hints{}, err
 	}
-	if _, err := exec.LookPath("terraform"); err == nil {
+	if terraformBinary() != "" {
 		return formatBinary(ctx, src)
 	}
 	return formatter.Format(src, "")

--- a/internal/fmt/terraformfmt.go
+++ b/internal/fmt/terraformfmt.go
@@ -39,7 +39,11 @@ func formatBinary(ctx context.Context, src []byte) ([]byte, internalfs.Hints, er
 	if len(src) > 0 && !utf8.Valid(src) {
 		return nil, hints, fmt.Errorf("input is not valid UTF-8")
 	}
-	cmd := exec.CommandContext(ctx, "terraform", "fmt", "-no-color", "-list=false", "-write=false", "-")
+	path := terraformBinary()
+	if path == "" {
+		return nil, hints, fmt.Errorf("terraform binary not found")
+	}
+	cmd := exec.CommandContext(ctx, path, "fmt", "-no-color", "-list=false", "-write=false", "-")
 	cmd.Stdin = bytes.NewReader(src)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
## Summary
- cache Terraform binary path once using sync.Once
- fall back to Go formatter when Terraform CLI isn't available

## Testing
- `make tidy`
- `make lint` *(fails: internal lint error and test syntax errors)*
- `make test` *(fails: syntax errors in tests)*
- `make cover` *(fails: syntax errors in tests)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b42d3fc04883238f03d0fb04c2b797