### PR TITLE
Preserve module variable order

### DIFF
--- a/internal/align/module.go
+++ b/internal/align/module.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	ihcl "github.com/oferchen/hclalign/internal/hcl"
 )
 
 type moduleStrategy struct{}
@@ -34,13 +35,16 @@ func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 		reserved[name] = struct{}{}
 	}
 
-	vars := make([]string, 0, len(attrs))
-	for name := range attrs {
+	original := ihcl.AttributeOrder(block.Body(), attrs)
+	vars := []string{}
+	for _, name := range original {
 		if _, ok := reserved[name]; !ok {
 			vars = append(vars, name)
 		}
 	}
-	sort.Strings(vars)
+	if opts != nil && opts.PrefixOrder {
+		sort.Strings(vars)
+	}
 
 	order = append(order, vars...)
 

--- a/internal/align/prefix_order_test.go
+++ b/internal/align/prefix_order_test.go
@@ -39,7 +39,15 @@ func TestPrefixOrder(t *testing.T) {
 			if diags.HasErrors() {
 				t.Fatalf("parse input: %v", diags)
 			}
-			if err := alignpkg.Apply(file, &alignpkg.Options{Schemas: schemas, PrefixOrder: tc.prefix, Types: map[string]struct{}{"resource": {}, "module": {}}}); err != nil {
+			opts := &alignpkg.Options{
+				Schemas:     schemas,
+				PrefixOrder: tc.prefix,
+				Types: map[string]struct{}{
+					"resource": {},
+					"module":   {},
+				},
+			}
+			if err := alignpkg.Apply(file, opts); err != nil {
 				t.Fatalf("align: %v", err)
 			}
 			got := hclwrite.Format(file.Bytes())
@@ -54,7 +62,7 @@ func TestPrefixOrder(t *testing.T) {
 			if diags.HasErrors() {
 				t.Fatalf("parse expected: %v", diags)
 			}
-			if err := alignpkg.Apply(file2, &alignpkg.Options{Schemas: schemas, PrefixOrder: tc.prefix, Types: map[string]struct{}{"resource": {}, "module": {}}}); err != nil {
+			if err := alignpkg.Apply(file2, opts); err != nil {
 				t.Fatalf("reapply: %v", err)
 			}
 			if !bytes.Equal(want, hclwrite.Format(file2.Bytes())) {

--- a/tests/cases/module/out.tf
+++ b/tests/cases/module/out.tf
@@ -10,10 +10,10 @@ module "complex" {
   count      = 1
   for_each   = {}
   depends_on = []
-  a          = 1
-  b          = 2
-  c          = 3
   z          = 0
+  a          = 1
+  c          = 3
+  b          = 2
 
   foo {
     x = 1
@@ -21,7 +21,7 @@ module "complex" {
 }
 
 module "vars_only" {
-  a = 1
-  b = 2
   c = 3
+  b = 2
+  a = 1
 }

--- a/tests/cases/prefix_order/in.tf
+++ b/tests/cases/prefix_order/in.tf
@@ -10,4 +10,7 @@ module "m" {
     azurerm = azurerm
     aws     = aws.us
   }
+  c = 3
+  a = 1
+  b = 2
 }

--- a/tests/cases/prefix_order/out.tf
+++ b/tests/cases/prefix_order/out.tf
@@ -10,4 +10,7 @@ module "m" {
     azurerm = azurerm
     aws     = aws.us
   }
+  c = 3
+  a = 1
+  b = 2
 }

--- a/tests/cases/prefix_order/sorted.tf
+++ b/tests/cases/prefix_order/sorted.tf
@@ -10,4 +10,7 @@ module "m" {
     aws     = aws.us
     azurerm = azurerm
   }
+  a = 1
+  b = 2
+  c = 3
 }


### PR DESCRIPTION
## Summary
- keep module input variables in original order unless `PrefixOrder` flag is set
- cover module prefix-order scenarios in tests
- update module fixtures for new default order

## Testing
- `go build ./internal/align`
- `go test ./internal/align -run PrefixOrder -count=1` *(fails: internal/align/phases_test.go:85:10: expected declaration, found ')')*


------
https://chatgpt.com/codex/tasks/task_e_68b432f7c2f88323b6f5ac09088714b1