### PR TITLE
Handle ephemeral variable attribute

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 var (
 	DefaultInclude = []string{"**/*.tf"}
 	DefaultExclude = []string{".terraform/**", "**/.terraform/**", "vendor/**", ".git/**", "**/.git/**"}
-	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
+	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable", "ephemeral"}
 )
 
 const (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,7 @@ func TestValidateOrder_EmptyAttribute(t *testing.T) {
 }
 
 func TestCanonicalOrderMatchesBuiltInAttributes(t *testing.T) {
-	expected := []string{"description", "type", "default", "sensitive", "nullable"}
+	expected := []string{"description", "type", "default", "sensitive", "nullable", "ephemeral"}
 	if !reflect.DeepEqual(CanonicalOrder, expected) {
 		t.Fatalf("expected CanonicalOrder to be %v, got %v", expected, CanonicalOrder)
 	}

--- a/internal/align/canonical.go
+++ b/internal/align/canonical.go
@@ -4,7 +4,7 @@ package align
 import "github.com/oferchen/hclalign/config"
 
 var CanonicalBlockAttrOrder = map[string][]string{
-	"variable": config.CanonicalOrder,
+	"variable": append([]string(nil), config.CanonicalOrder...),
 	"output":   {"description", "value", "sensitive", "ephemeral", "depends_on"},
 	"module":   {"source", "version", "providers", "count", "for_each", "depends_on"},
 	"provider": {"alias"},

--- a/internal/align/golden_test.go
+++ b/internal/align/golden_test.go
@@ -62,19 +62,9 @@ func TestGolden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("format input: %v", err)
 			}
-
-			fmtBytes, _, err := terraformfmt.Format(context.Background(), inBytes, inPath, string(terraformfmt.StrategyGo))
-			if err != nil {
-				t.Fatalf("format input: %v", err)
-			}
 			hadNewline := len(inBytes) > 0 && inBytes[len(inBytes)-1] == '\n'
 			if !hadNewline && len(fmtBytes) > 0 && fmtBytes[len(fmtBytes)-1] == '\n' {
 				fmtBytes = fmtBytes[:len(fmtBytes)-1]
-			}
-
-			againFmt, _, err := terraformfmt.Format(context.Background(), fmtBytes, inPath, string(terraformfmt.StrategyGo))
-			if err != nil {
-				t.Fatalf("format fmt: %v", err)
 			}
 
 			againFmt, _, err := terraformfmt.Format(context.Background(), fmtBytes, inPath, string(terraformfmt.StrategyGo))

--- a/internal/align/phases_test.go
+++ b/internal/align/phases_test.go
@@ -2,10 +2,10 @@
 package align_test
 
 import (
-        "context"
-        "os"
-        "path/filepath"
-        "testing"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -36,18 +36,12 @@ func TestPhases(t *testing.T) {
 			fmtBytes, _, err := terraformfmt.Format(context.Background(), inBytes, inPath, string(terraformfmt.StrategyGo))
 			require.NoError(t, err)
 
-                        fmtBytes, _, err := terraformfmt.Format(context.Background(), inBytes, inPath, string(terraformfmt.StrategyGo))
-                        require.NoError(t, err)
-
 			hadNewline := len(inBytes) > 0 && inBytes[len(inBytes)-1] == '\n'
 			if !hadNewline && len(fmtBytes) > 0 && fmtBytes[len(fmtBytes)-1] == '\n' {
 				fmtBytes = fmtBytes[:len(fmtBytes)-1]
 			}
 			againFmt, _, err := terraformfmt.Format(context.Background(), fmtBytes, inPath, string(terraformfmt.StrategyGo))
 			require.NoError(t, err)
-
-                        againFmt, _, err := terraformfmt.Format(context.Background(), fmtBytes, inPath, string(terraformfmt.StrategyGo))
-                        require.NoError(t, err)
 			hadFmtNewline := len(fmtBytes) > 0 && fmtBytes[len(fmtBytes)-1] == '\n'
 			if !hadFmtNewline && len(againFmt) > 0 && againFmt[len(againFmt)-1] == '\n' {
 				againFmt = againFmt[:len(againFmt)-1]
@@ -79,8 +73,4 @@ func TestPhases(t *testing.T) {
 		_, _, err := terraformfmt.Format(context.Background(), []byte("variable \"a\" {"), "bad.hcl", string(terraformfmt.StrategyGo))
 		require.Error(t, err)
 	})
-
-                _, _, err := terraformfmt.Format(context.Background(), []byte("variable \"a\" {"), "bad.hcl", string(terraformfmt.StrategyGo))
-                require.Error(t, err)
-        })
 }

--- a/tests/cases/variable-ephemeral/in.tf
+++ b/tests/cases/variable-ephemeral/in.tf
@@ -1,0 +1,8 @@
+variable "example" {
+  ephemeral  = true
+  nullable   = true
+  description = "example"
+  type        = number
+  default     = 1
+  sensitive   = true
+}

--- a/tests/cases/variable-ephemeral/out.tf
+++ b/tests/cases/variable-ephemeral/out.tf
@@ -1,0 +1,8 @@
+variable "example" {
+  description = "example"
+  type        = number
+  default     = 1
+  sensitive   = true
+  nullable    = true
+  ephemeral   = true
+}


### PR DESCRIPTION
## Summary
- include `ephemeral` in canonical variable attribute order
- align variables using shared canonical list
- test ephemeral attribute ordering in variables

## Testing
- `go test ./internal/align -run TestGolden -count=1` (fails: aligned mismatch for non_variable)
- `go test ./config -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b43809e9348323a8a30b1893f396a7