### PR TITLE
Preserve hints around terraform fmt

### DIFF
--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -67,3 +67,69 @@ func TestProcessFileSkipTerraformFmt(t *testing.T) {
 	require.Equal(t, 0, formatCalls)
 	require.Equal(t, 0, runCalls)
 }
+
+func TestProcessFileTerraformFmtPreservesCRLF(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.tf")
+	hints := internalfs.Hints{Newline: "\r\n"}
+	content := internalfs.ApplyHints([]byte("variable \"a\" {type=string}\n"), hints)
+	require.NoError(t, os.WriteFile(file, content, 0o644))
+
+	origFormat := terraformFmtFormatFile
+	origRun := terraformFmtRun
+	terraformFmtFormatFile = func(ctx context.Context, path string) (bool, error) {
+		formatted := []byte("variable \"a\" {\n  type = string\n}\n")
+		return true, os.WriteFile(path, formatted, 0o644)
+	}
+	terraformFmtRun = func(ctx context.Context, b []byte) ([]byte, internalfs.Hints, error) {
+		return b, internalfs.Hints{}, nil
+	}
+	t.Cleanup(func() {
+		terraformFmtFormatFile = origFormat
+		terraformFmtRun = origRun
+	})
+
+	p := &Processor{cfg: &config.Config{Mode: config.ModeWrite}}
+	changed, _, err := p.processFile(context.Background(), file)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	out, err := os.ReadFile(file)
+	require.NoError(t, err)
+	h := internalfs.DetectHintsFromBytes(out)
+	require.Equal(t, "\r\n", h.Newline)
+	require.False(t, h.HasBOM)
+}
+
+func TestProcessFileTerraformFmtPreservesBOM(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.tf")
+	hints := internalfs.Hints{HasBOM: true, Newline: "\r\n"}
+	content := internalfs.ApplyHints([]byte("variable \"a\" {type=string}\n"), hints)
+	require.NoError(t, os.WriteFile(file, content, 0o644))
+
+	origFormat := terraformFmtFormatFile
+	origRun := terraformFmtRun
+	terraformFmtFormatFile = func(ctx context.Context, path string) (bool, error) {
+		formatted := []byte("variable \"a\" {\n  type = string\n}\n")
+		return true, os.WriteFile(path, formatted, 0o644)
+	}
+	terraformFmtRun = func(ctx context.Context, b []byte) ([]byte, internalfs.Hints, error) {
+		return b, internalfs.Hints{}, nil
+	}
+	t.Cleanup(func() {
+		terraformFmtFormatFile = origFormat
+		terraformFmtRun = origRun
+	})
+
+	p := &Processor{cfg: &config.Config{Mode: config.ModeWrite}}
+	changed, _, err := p.processFile(context.Background(), file)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	out, err := os.ReadFile(file)
+	require.NoError(t, err)
+	h := internalfs.DetectHintsFromBytes(out)
+	require.Equal(t, "\r\n", h.Newline)
+	require.True(t, h.HasBOM)
+}


### PR DESCRIPTION
## Summary
- record file permissions and newline/BOM hints before running terraform fmt
- run terraform fmt on a temporary copy and reapply original hints on write
- add CRLF and BOM preservation tests for pipeline

## Testing
- `go test ./...` *(fails: formatter and internal/fmt tests contain compile errors)*
- `go test ./internal/engine -run TestProcessFile`


------
https://chatgpt.com/codex/tasks/task_e_68b43a95d2a48323a1ac7455d0bff0d3