### PR TITLE
cleanup: dedupe formatter tests

### DIFF
--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -6,11 +6,6 @@ import (
 	"testing"
 
 	internalfs "github.com/oferchen/hclalign/internal/fs"
-
-        "bytes"
-        "testing"
-
-        internalfs "github.com/oferchen/hclalign/internal/fs"
 )
 
 func TestFormatHints(t *testing.T) {
@@ -51,17 +46,6 @@ func TestFormatHints(t *testing.T) {
 			}
 		})
 	}
-
-                        got, hints, err := Format(tc.input, "test.hcl")
-                        if err != nil {
-                                t.Fatalf("Format returned error: %v", err)
-                        }
-                        styled := internalfs.ApplyHints(got, hints)
-                        if !bytes.Equal(styled, tc.want) {
-                                t.Fatalf("unexpected output\nwant: %q\n got: %q", tc.want, styled)
-                        }
-                })
-        }
 }
 
 func TestFormatTrailingNewline(t *testing.T) {
@@ -107,17 +91,6 @@ func TestFormatTrailingNewline(t *testing.T) {
 			}
 		})
 	}
-
-                        got, hints, err := Format(tc.input, "test.hcl")
-                        if err != nil {
-                                t.Fatalf("Format returned error: %v", err)
-                        }
-                        styled := internalfs.ApplyHints(got, hints)
-                        if !bytes.Equal(styled, tc.want) {
-                                t.Fatalf("unexpected output\nwant: %q\n got: %q", tc.want, styled)
-                        }
-                })
-        }
 }
 
 func TestFormatRejectsInvalidUTF8(t *testing.T) {
@@ -125,8 +98,4 @@ func TestFormatRejectsInvalidUTF8(t *testing.T) {
 	if _, _, err := Format(invalid, "test.hcl"); err == nil {
 		t.Fatalf("expected error for invalid UTF-8 input")
 	}
-
-        if _, _, err := Format(invalid, "test.hcl"); err == nil {
-                t.Fatalf("expected error for invalid UTF-8 input")
-        }
 }


### PR DESCRIPTION
## Summary
- remove duplicated import block and test loops in formatter tests
- ensure tests for hints and trailing newline each run once

## Testing
- `go test ./formatter -run . -v`


------
https://chatgpt.com/codex/tasks/task_e_68b43d02d9d483238d50106d95ccac1d