### PR TITLE
Consolidate terraformfmt test imports

### DIFF
--- a/internal/fmt/terraformfmt_test.go
+++ b/internal/fmt/terraformfmt_test.go
@@ -2,13 +2,23 @@
 package terraformfmt
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"sync"
 	"testing"
 
+	"github.com/oferchen/hclalign/formatter"
+	internalfs "github.com/oferchen/hclalign/internal/fs"
 	"github.com/stretchr/testify/require"
 )
+
+func resetTerraformPath() {
+	terraformPath = ""
+	terraformPathOnce = sync.Once{}
+}
 
 func TestGoMatchesBinary(t *testing.T) {
 	if _, err := exec.LookPath("terraform"); err != nil {
@@ -19,7 +29,7 @@ func TestGoMatchesBinary(t *testing.T) {
 	require.NoError(t, err)
 	binFmt, _, err := Format(context.Background(), src, "test.tf", string(StrategyBinary))
 	require.NoError(t, err)
-	require.Equal(t, string(binFmt), string(goFmt))
+	require.Equal(t, goFmt, binFmt)
 }
 
 func TestAutoUsesGoFormatter(t *testing.T) {
@@ -28,7 +38,7 @@ func TestAutoUsesGoFormatter(t *testing.T) {
 	require.NoError(t, err)
 	goFmt, _, err := Format(context.Background(), src, "test.tf", string(StrategyGo))
 	require.NoError(t, err)
-	require.Equal(t, string(goFmt), string(autoFmt))
+	require.Equal(t, goFmt, autoFmt)
 }
 
 func TestIdempotent(t *testing.T) {
@@ -37,7 +47,7 @@ func TestIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	second, _, err := Format(context.Background(), first, "test.tf", string(StrategyGo))
 	require.NoError(t, err)
-	require.Equal(t, string(first), string(second))
+	require.Equal(t, first, second)
 }
 
 func TestBinaryPreservesHints(t *testing.T) {
@@ -45,13 +55,18 @@ func TestBinaryPreservesHints(t *testing.T) {
 		t.Skip("terraform binary not found")
 	}
 	src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {\r\n  type = string\r\n}\r\n")...)
-	_, hints, err := Format(context.Background(), src, "test.tf", string(StrategyBinary))
+	formatted, hints, err := Format(context.Background(), src, "test.tf", string(StrategyBinary))
 	require.NoError(t, err)
 	require.True(t, hints.HasBOM)
 	require.Equal(t, "\r\n", hints.Newline)
+	require.False(t, bytes.HasPrefix(formatted, []byte{0xef, 0xbb, 0xbf}))
+	require.False(t, bytes.Contains(formatted, []byte("\r\n")))
+	styled := internalfs.ApplyHints(formatted, hints)
+	require.Equal(t, src, styled)
 }
 
 func TestRunPreservesHints(t *testing.T) {
+	resetTerraformPath()
 	src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {\r\n  type = string\r\n}\r\n")...)
 	_, hints, err := Run(context.Background(), src)
 	require.NoError(t, err)
@@ -70,115 +85,62 @@ func TestBinaryInvalidUTF8(t *testing.T) {
 }
 
 func TestBinaryMissingTerraform(t *testing.T) {
+	resetTerraformPath()
 	oldPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", oldPath)
 	os.Setenv("PATH", "")
 	_, _, err := Format(context.Background(), []byte("variable \"a\" {}\n"), "test.tf", string(StrategyBinary))
 	require.Error(t, err)
-
-        internalfs "github.com/oferchen/hclalign/internal/fs"
-        "github.com/oferchen/hclalign/formatter"
-        "github.com/stretchr/testify/require"
-)
+}
 
 func TestRunUsesTerraformCLI(t *testing.T) {
-        dir := t.TempDir()
-        bin := filepath.Join(dir, "terraform")
-        script := []byte("#!/bin/sh\ncat >/dev/null\nprintf 'bin\\n'")
-        if err := os.WriteFile(bin, script, 0o755); err != nil {
-                t.Fatalf("write fake terraform: %v", err)
-        }
-        oldPath := os.Getenv("PATH")
-        defer os.Setenv("PATH", oldPath)
-        os.Setenv("PATH", dir)
-        out, hints, err := Run(context.Background(), []byte("input\n"))
-        require.NoError(t, err)
-        require.Equal(t, "bin\n", string(out))
-        require.Equal(t, internalfs.Hints{Newline: "\n"}, hints)
+	resetTerraformPath()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "terraform")
+	script := []byte("#!/bin/sh\ncat >/dev/null\nprintf 'bin\\n'")
+	if err := os.WriteFile(bin, script, 0o755); err != nil {
+		t.Fatalf("write fake terraform: %v", err)
+	}
+	oldPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oldPath)
+	os.Setenv("PATH", dir)
+	out, hints, err := Run(context.Background(), []byte("input\n"))
+	require.NoError(t, err)
+	require.Equal(t, "bin\n", string(out))
+	require.Equal(t, internalfs.Hints{Newline: "\n"}, hints)
 }
 
 func TestRunFallsBackToGoFormatter(t *testing.T) {
-        oldPath := os.Getenv("PATH")
-        defer os.Setenv("PATH", oldPath)
-        os.Setenv("PATH", "")
-        src := []byte("variable \"a\" {\n  type = string\n}\n")
-        want, wantHints, err := formatter.Format(src, "test.tf")
-        require.NoError(t, err)
-        got, gotHints, err := Run(context.Background(), src)
-        require.NoError(t, err)
-        require.Equal(t, want, got)
-        require.Equal(t, wantHints, gotHints)
+	resetTerraformPath()
+	oldPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oldPath)
+	os.Setenv("PATH", "")
+	src := []byte("variable \"a\" {\n  type = string\n}\n")
+	want, wantHints, err := formatter.Format(src, "test.tf")
+	require.NoError(t, err)
+	got, gotHints, err := Run(context.Background(), src)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	require.Equal(t, wantHints, gotHints)
 }
 
 func TestRunPropagatesHints(t *testing.T) {
-        src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {}\r\n")...)
-        formatted, hints, err := Run(context.Background(), src)
-        require.NoError(t, err)
-        require.True(t, hints.HasBOM)
-        require.Equal(t, "\r\n", hints.Newline)
-        require.False(t, bytes.HasPrefix(formatted, []byte{0xef, 0xbb, 0xbf}))
-        require.False(t, bytes.Contains(formatted, []byte("\r\n")))
-        styled := internalfs.ApplyHints(formatted, hints)
-        require.Equal(t, append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {}\r\n")...), styled)
+	resetTerraformPath()
+	src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {}\r\n")...)
+	formatted, hints, err := Run(context.Background(), src)
+	require.NoError(t, err)
+	require.True(t, hints.HasBOM)
+	require.Equal(t, "\r\n", hints.Newline)
+	require.False(t, bytes.HasPrefix(formatted, []byte{0xef, 0xbb, 0xbf}))
+	require.False(t, bytes.Contains(formatted, []byte("\r\n")))
+	styled := internalfs.ApplyHints(formatted, hints)
+	require.Equal(t, append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {}\r\n")...), styled)
 }
 
 func TestRunContextCanceled(t *testing.T) {
-        ctx, cancel := context.WithCancel(context.Background())
-        cancel()
-        _, _, err := Run(ctx, []byte("variable \"a\" {}\n"))
-        require.ErrorIs(t, err, context.Canceled)
-}
-
-func TestGoMatchesBinary(t *testing.T) {
-        if _, err := exec.LookPath("terraform"); err != nil {
-                t.Skip("terraform binary not found")
-        }
-        src := []byte("variable \"a\" {\n  type = string\n}\n")
-        goFmt, _, err := Format(context.Background(), src, "test.tf", string(StrategyGo))
-        require.NoError(t, err)
-        binFmt, _, err := Format(context.Background(), src, "test.tf", string(StrategyBinary))
-        require.NoError(t, err)
-        require.Equal(t, goFmt, binFmt)
-}
-
-func TestIdempotent(t *testing.T) {
-        src := []byte("variable \"a\" {\n  type = string\n}\n")
-        first, _, err := Format(context.Background(), src, "test.tf", string(StrategyGo))
-        require.NoError(t, err)
-        second, _, err := Format(context.Background(), first, "test.tf", string(StrategyGo))
-        require.NoError(t, err)
-        require.Equal(t, first, second)
-}
-
-func TestBinaryPreservesHints(t *testing.T) {
-        if _, err := exec.LookPath("terraform"); err != nil {
-                t.Skip("terraform binary not found")
-        }
-        src := append([]byte{0xef, 0xbb, 0xbf}, []byte("variable \"a\" {\r\n  type = string\r\n}\r\n")...)
-        formatted, hints, err := Format(context.Background(), src, "test.tf", string(StrategyBinary))
-        require.NoError(t, err)
-        require.True(t, hints.HasBOM)
-        require.Equal(t, "\r\n", hints.Newline)
-        require.False(t, bytes.HasPrefix(formatted, []byte{0xef, 0xbb, 0xbf}))
-        require.False(t, bytes.Contains(formatted, []byte("\r\n")))
-        styled := internalfs.ApplyHints(formatted, hints)
-        require.Equal(t, src, styled)
-}
-
-func TestUnknownStrategy(t *testing.T) {
-        _, _, err := Format(context.Background(), []byte("{}"), "test.tf", "bogus")
-        require.Error(t, err)
-}
-
-func TestBinaryInvalidUTF8(t *testing.T) {
-        _, _, err := Format(context.Background(), []byte{0xff, 0xfe}, "test.tf", string(StrategyBinary))
-        require.Error(t, err)
-}
-
-func TestBinaryMissingTerraform(t *testing.T) {
-        oldPath := os.Getenv("PATH")
-        defer os.Setenv("PATH", oldPath)
-        os.Setenv("PATH", "")
-        _, _, err := Format(context.Background(), []byte("variable \"a\" {}\n"), "test.tf", string(StrategyBinary))
-        require.Error(t, err)
+	resetTerraformPath()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := Run(ctx, []byte("variable \"a\" {}\n"))
+	require.ErrorIs(t, err, context.Canceled)
 }


### PR DESCRIPTION
## Summary
- consolidate terraformfmt test imports into a single block
- remove stray import block and reset cached terraform path between tests

## Testing
- `go test ./internal/fmt`
- `go test ./...` *(fails: aligned mismatch for non_variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b43db636e483239628185502da9504