### PR TITLE
Sort module variables alphabetically

### DIFF
--- a/internal/align/module.go
+++ b/internal/align/module.go
@@ -42,9 +42,7 @@ func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 			vars = append(vars, name)
 		}
 	}
-	if opts != nil && opts.PrefixOrder {
-		sort.Strings(vars)
-	}
+	sort.Strings(vars)
 
 	order = append(order, vars...)
 

--- a/tests/cases/module/out.tf
+++ b/tests/cases/module/out.tf
@@ -10,10 +10,10 @@ module "complex" {
   count      = 1
   for_each   = {}
   depends_on = []
-  z          = 0
   a          = 1
-  c          = 3
   b          = 2
+  c          = 3
+  z          = 0
 
   foo {
     x = 1
@@ -21,7 +21,7 @@ module "complex" {
 }
 
 module "vars_only" {
-  c = 3
-  b = 2
   a = 1
+  b = 2
+  c = 3
 }

--- a/tests/cases/prefix_order/out.tf
+++ b/tests/cases/prefix_order/out.tf
@@ -10,7 +10,7 @@ module "m" {
     azurerm = azurerm
     aws     = aws.us
   }
-  c = 3
   a = 1
   b = 2
+  c = 3
 }


### PR DESCRIPTION
## Summary
- ensure module alignment always alphabetizes non-canonical attributes
- update module and prefix-order fixtures for new attribute order

## Testing
- `go test ./internal/align -run TestPrefixOrder -count=1`
- `go test ./internal/align -run TestGolden/non_variable -count=1`
- `go test ./internal/align -count=1`
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b43f4e23208323b9f81bce0275d366