### PR TITLE
fix: ensure template idempotency change detection

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -121,7 +121,7 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 		formatted = formatted[:len(formatted)-1]
 	}
 
-	styled := internalfs.ApplyHints(formatted, hints)
+	styled := internalfs.ApplyHints(append([]byte(nil), formatted...), hints)
 	changed := !bytes.Equal(originalWithHints, styled)
 
 	switch cfg.Mode {

--- a/internal/engine/phases_test.go
+++ b/internal/engine/phases_test.go
@@ -57,13 +57,14 @@ func TestTemplatesIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	cfg := &config.Config{Stdout: true}
 	var out bytes.Buffer
-	_, err = ProcessReader(context.Background(), bytes.NewReader(inBytes), &out, cfg)
+	changed, err := ProcessReader(context.Background(), bytes.NewReader(inBytes), &out, cfg)
 	require.NoError(t, err)
+	require.False(t, changed)
 
 	first := out.Bytes()
 	out.Reset()
 
-	changed, err := ProcessReader(context.Background(), bytes.NewReader(first), &out, cfg)
+	changed, err = ProcessReader(context.Background(), bytes.NewReader(first), &out, cfg)
 	require.NoError(t, err)
 	require.False(t, changed)
 	require.Equal(t, string(first), out.String())
@@ -76,11 +77,12 @@ func TestTemplatesProcessReaderTwice(t *testing.T) {
 
 	cfg := &config.Config{Stdout: true}
 	var first bytes.Buffer
-	_, err = ProcessReader(context.Background(), bytes.NewReader(inBytes), &first, cfg)
+	changed, err := ProcessReader(context.Background(), bytes.NewReader(inBytes), &first, cfg)
 	require.NoError(t, err)
+	require.False(t, changed)
 
 	var second bytes.Buffer
-	changed, err := ProcessReader(context.Background(), bytes.NewReader(first.Bytes()), &second, cfg)
+	changed, err = ProcessReader(context.Background(), bytes.NewReader(first.Bytes()), &second, cfg)
 	require.NoError(t, err)
 	require.False(t, changed)
 	require.Equal(t, first.String(), second.String())

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -216,7 +216,7 @@ func (p *Processor) processFile(ctx context.Context, filePath string) (bool, []b
 		formatted = formatted[:len(formatted)-1]
 	}
 
-	styled := internalfs.ApplyHints(formatted, hints)
+	styled := internalfs.ApplyHints(append([]byte(nil), formatted...), hints)
 	changed := !bytes.Equal(originalWithHints, styled)
 
 	var out []byte


### PR DESCRIPTION
## Summary
- avoid comparing original and formatted buffers that share memory
- extend template tests to assert no change when already formatted

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b442bbea808323979b550d1c2b9def