### PR TITLE
Remove skip-terraform-fmt flag and simplify formatting pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,3 @@ make build
 
 We appreciate your help in improving `hclalign`!
 
-## Testing Flags
-
-For development and test scenarios, a hidden CLI flag `--skip-terraform-fmt` is available to bypass Terraform formatting.

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -41,8 +41,6 @@ func newTestRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().StringSlice("types", []string{"variable"}, "comma-separated list of block types to align")
 	cmd.Flags().Bool("all", false, "align all block types")
 	cmd.Flags().Bool("prefix-order", false, "lexicographically sort unknown attributes and module provider maps")
-	cmd.Flags().Bool("skip-terraform-fmt", false, "skip running terraform fmt")
-	cmd.Flags().MarkHidden("skip-terraform-fmt")
 	cmd.MarkFlagsMutuallyExclusive("types", "all")
 	if exclusive {
 		cmd.MarkFlagsMutuallyExclusive("write", "check", "diff")

--- a/cli/parse.go
+++ b/cli/parse.go
@@ -32,7 +32,6 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 	types := getStringSlice(cmd, "types", &err)
 	all := getBool(cmd, "all", &err)
 	prefixOrder := getBool(cmd, "prefix-order", &err)
-	skipTerraformFmt := getBool(cmd, "skip-terraform-fmt", &err)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +85,6 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 		FollowSymlinks:     followSymlinks,
 		Types:              cfgTypes,
 		PrefixOrder:        prefixOrder,
-		SkipTerraformFmt:   skipTerraformFmt,
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -74,11 +74,3 @@ func TestParseConfigPrefixOrder(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, cfg.PrefixOrder)
 }
-
-func TestParseConfigSkipTerraformFmt(t *testing.T) {
-	cmd := newRootCmd(true)
-	require.NoError(t, cmd.ParseFlags([]string{"--skip-terraform-fmt"}))
-	cfg, err := parseConfig(cmd, []string{"target"})
-	require.NoError(t, err)
-	require.True(t, cfg.SkipTerraformFmt)
-}

--- a/cmd/hclalign/main.go
+++ b/cmd/hclalign/main.go
@@ -45,8 +45,6 @@ func run(args []string) int {
 	rootCmd.Flags().StringSlice("types", []string{"variable"}, "comma-separated list of block types to align")
 	rootCmd.Flags().Bool("all", false, "align all block types")
 	rootCmd.Flags().Bool("prefix-order", false, "lexicographically sort unknown attributes and module provider maps")
-	rootCmd.Flags().Bool("skip-terraform-fmt", false, "skip running terraform fmt")
-	rootCmd.Flags().MarkHidden("skip-terraform-fmt")
 	rootCmd.MarkFlagsMutuallyExclusive("types", "all")
 
 	rootCmd.SetArgs(args)

--- a/cmd/hclalign/main_test.go
+++ b/cmd/hclalign/main_test.go
@@ -78,30 +78,6 @@ func TestRunMutuallyExclusiveFlags(t *testing.T) {
 	}
 }
 
-func TestRunSkipTerraformFmtFlag(t *testing.T) {
-	oldRunE := runE
-	t.Cleanup(func() { runE = oldRunE })
-
-	runE = func(cmd *cobra.Command, args []string) error {
-		f := cmd.Flags().Lookup("skip-terraform-fmt")
-		if f == nil || !f.Hidden {
-			t.Fatalf("flag not hidden")
-		}
-		v, err := cmd.Flags().GetBool("skip-terraform-fmt")
-		if err != nil {
-			t.Fatalf("get flag: %v", err)
-		}
-		if !v {
-			t.Fatalf("expected flag true")
-		}
-		return nil
-	}
-
-	if code := run([]string{"--skip-terraform-fmt"}); code != 0 {
-		t.Fatalf("expected exit code 0, got %d", code)
-	}
-}
-
 func TestRunWrappedExitCode(t *testing.T) {
 	oldRunE := runE
 	t.Cleanup(func() { runE = oldRunE })

--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,6 @@ type Config struct {
 	UseTerraformSchema bool
 	Types              []string
 	PrefixOrder        bool
-	SkipTerraformFmt   bool
 }
 
 var (

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -40,34 +40,6 @@ func TestProcessFileTerraformFmt(t *testing.T) {
 	require.Equal(t, 2, runCalls)
 }
 
-func TestProcessFileSkipTerraformFmt(t *testing.T) {
-	dir := t.TempDir()
-	file := filepath.Join(dir, "a.tf")
-	require.NoError(t, os.WriteFile(file, []byte("variable \"a\" { type = string }"), 0o644))
-
-	var formatCalls, runCalls int
-	origFormat := terraformFmtFormatFile
-	origRun := terraformFmtRun
-	terraformFmtFormatFile = func(ctx context.Context, path string) (bool, error) {
-		formatCalls++
-		return false, nil
-	}
-	terraformFmtRun = func(ctx context.Context, b []byte) ([]byte, internalfs.Hints, error) {
-		runCalls++
-		return b, internalfs.Hints{}, nil
-	}
-	t.Cleanup(func() {
-		terraformFmtFormatFile = origFormat
-		terraformFmtRun = origRun
-	})
-
-	p := &Processor{cfg: &config.Config{Mode: config.ModeWrite, SkipTerraformFmt: true}}
-	_, _, err := p.processFile(context.Background(), file)
-	require.NoError(t, err)
-	require.Equal(t, 0, formatCalls)
-	require.Equal(t, 0, runCalls)
-}
-
 func TestProcessFileTerraformFmtPreservesCRLF(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "a.tf")

--- a/internal/engine/write_error_test.go
+++ b/internal/engine/write_error_test.go
@@ -43,8 +43,6 @@ func newRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().StringSlice("types", []string{"variable"}, "comma-separated list of block types to align")
 	cmd.Flags().Bool("all", false, "align all block types")
 	cmd.Flags().Bool("prefix-order", false, "lexicographically sort unknown attributes and module provider maps")
-	cmd.Flags().Bool("skip-terraform-fmt", false, "skip running terraform fmt")
-	cmd.Flags().MarkHidden("skip-terraform-fmt")
 	cmd.MarkFlagsMutuallyExclusive("types", "all")
 	if exclusive {
 		cmd.MarkFlagsMutuallyExclusive("write", "check", "diff")


### PR DESCRIPTION
## Summary
- drop hidden `--skip-terraform-fmt` flag and related config handling
- always run `terraform fmt` in the processing pipeline
- clean up docs and tests referencing the removed flag

## Testing
- `make tidy`
- `make lint` *(fails: could not load export data: unsupported version)*
- `make test`
- `make cover` *(fails: coverage 87.0% is below 95%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b4465781808323b18c85c42f82a279