### PR TITLE
Avoid symlink loops during scan traversal

### DIFF
--- a/internal/engine/scan_test.go
+++ b/internal/engine/scan_test.go
@@ -30,3 +30,49 @@ func TestScanDefaultExcludeDirectories(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{filepath.Join(dir, "main.tf")}, files)
 }
+
+func TestScanFollowSymlinksSelfCycle(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(""), 0o644))
+	require.NoError(t, os.Symlink(".", filepath.Join(dir, "self")))
+
+	cfg := &config.Config{
+		Target:         dir,
+		Include:        config.DefaultInclude,
+		Exclude:        config.DefaultExclude,
+		FollowSymlinks: true,
+	}
+
+	files, err := scan(context.Background(), cfg)
+	require.NoError(t, err)
+	require.Equal(t, []string{filepath.Join(dir, "main.tf")}, files)
+}
+
+func TestScanFollowSymlinksCycle(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	a := filepath.Join(root, "a")
+	b := filepath.Join(root, "b")
+	require.NoError(t, os.Mkdir(a, 0o755))
+	require.NoError(t, os.Mkdir(b, 0o755))
+	fileA := filepath.Join(a, "a.tf")
+	fileB := filepath.Join(b, "b.tf")
+	require.NoError(t, os.WriteFile(fileA, []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(fileB, []byte(""), 0o644))
+	require.NoError(t, os.Symlink(b, filepath.Join(a, "link")))
+	require.NoError(t, os.Symlink(a, filepath.Join(b, "link")))
+
+	cfg := &config.Config{
+		Target:         root,
+		Include:        config.DefaultInclude,
+		Exclude:        config.DefaultExclude,
+		FollowSymlinks: true,
+	}
+
+	files, err := scan(context.Background(), cfg)
+	require.NoError(t, err)
+	require.Equal(t, []string{fileA, filepath.Join(a, "link", "b.tf")}, files)
+}


### PR DESCRIPTION
## Summary
- track visited real paths when following symlinks during scanning
- skip revisiting directories via symlink loops
- add tests covering self-referential and cyclical symlink structures

## Testing
- `make tidy`
- `make lint` *(fails: unsupported version: 2)*
- `make test`
- `make cover` *(fails: coverage 86.9% is below 95%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b448b22e8483239cdd577093a6ce58