### PR TITLE
refactor: narrow default exclude patterns

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 
 var (
 	DefaultInclude = []string{"**/*.tf"}
-	DefaultExclude = []string{".terraform/**", "**/.terraform/**", "vendor/**", ".git/**", "**/.git/**"}
+	DefaultExclude = []string{".terraform/**", "**/.terraform/**", "vendor/**"}
 	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable", "ephemeral"}
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,7 +38,7 @@ func TestValidateOrder_EmptyAttributeName(t *testing.T) {
 }
 
 func TestDefaultExcludeMatchesExpected(t *testing.T) {
-	expected := []string{".terraform/**", "**/.terraform/**", "vendor/**", ".git/**", "**/.git/**"}
+	expected := []string{".terraform/**", "**/.terraform/**", "vendor/**"}
 	if !reflect.DeepEqual(DefaultExclude, expected) {
 		t.Fatalf("expected DefaultExclude to be %v, got %v", expected, DefaultExclude)
 	}

--- a/internal/engine/scan_test.go
+++ b/internal/engine/scan_test.go
@@ -15,10 +15,6 @@ func TestScanDefaultExcludeDirectories(t *testing.T) {
 	t.Parallel()
 
 	dir := filepath.Join("..", "..", "tests", "cases", "default_excludes")
-	gitIgnored := filepath.Join(dir, ".git", "ignored.tf")
-	require.NoError(t, os.MkdirAll(filepath.Dir(gitIgnored), 0o755))
-	require.NoError(t, os.WriteFile(gitIgnored, []byte(""), 0o644))
-	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(gitIgnored)) })
 
 	cfg := &config.Config{
 		Target:  dir,


### PR DESCRIPTION
## Summary
- drop `.git` from default exclusions and keep `.terraform/**`, `**/.terraform/**`, `vendor/**`
- update tests to reflect new exclusion set

## Testing
- `make tidy`
- `make lint` *(fails: unsupported version in golangci-lint import)*
- `make test`
- `make cover` *(fails: terraform fmt binary not found)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b44c4366c48323b4fa87bebe19bd04