### PR TITLE
Fix ProcessReader change detection and stabilize atomic temp test

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -122,7 +122,7 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 	}
 
 	styled := internalfs.ApplyHints(append([]byte(nil), formatted...), hints)
-	changed := !bytes.Equal(internalfs.PrepareForParse(originalWithHints, hints), internalfs.PrepareForParse(styled, hints))
+	changed := !bytes.Equal(originalWithHints, styled)
 
 	switch cfg.Mode {
 	case config.ModeDiff:

--- a/internal/fs/atomic_test.go
+++ b/internal/fs/atomic_test.go
@@ -19,7 +19,6 @@ type (
 )
 
 func TestWriteFileAtomic(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name     string
 		data     []byte
@@ -56,6 +55,8 @@ func TestWriteFileAtomic(t *testing.T) {
 			data: []byte("x"),
 			perm: 0o600,
 			setup: func(t *testing.T, dir, path string) any {
+				tmp := t.TempDir()
+				t.Setenv("TMPDIR", tmp)
 				entries, err := os.ReadDir(os.TempDir())
 				if err != nil {
 					t.Fatalf("readdir: %v", err)


### PR DESCRIPTION
## Summary
- ensure ProcessReader detects changes by comparing original and styled bytes directly
- isolate temporary directory in atomic file writer tests to avoid cross-test interference

## Testing
- `go test -coverprofile=coverage.out ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b4615e61908323b53b54d9ab8fe8cc