### PR TITLE
chore: run fmt with align

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ fmt: ## format code and regenerate test fixtures
 	else \
 	echo "terraform not found; skipping terraform fmt"; \
 	fi
-	$(GO) run ./cmd/hclalign tests/cases
+	go run ./cmd/hclalign --all tests/cases
 
 strip: ## normalize Go file comments and enforce policy
 	$(GO) run ./tools/stripcomments --repo-root "$(PWD)"

--- a/tests/cases/lifecycle/fmt.tf
+++ b/tests/cases/lifecycle/fmt.tf
@@ -1,4 +1,5 @@
 resource "null_resource" "example" {
+
   lifecycle {
     foo                   = "foo"
     create_before_destroy = true

--- a/tests/cases/provisioner/fmt.tf
+++ b/tests/cases/provisioner/fmt.tf
@@ -1,4 +1,5 @@
 resource "null_resource" "example" {
+
   provisioner "local-exec" {
     bar  = "b"
     when = "destroy"


### PR DESCRIPTION
## Summary
- run hclalign with --all when formatting fixtures
- refresh lifecycle and provisioner fmt fixtures

## Testing
- `go clean -testcache && go test ./...` *(fails: TestPhases/templates)*

------
https://chatgpt.com/codex/tasks/task_e_68b4641c56148323a1f626616be2d336