### PR TITLE
ci: use MINCOV for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - run: make test-race
       - run: make cover
         env:
-          COVER_THRESH: 95
+          MINCOV: 95
       - run: make build
       - name: Upload coverage
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- use MINCOV environment variable for coverage threshold in CI

## Testing
- `make cover` *(fails: coverage 87.0% is below 95%)*
- `MINCOV=50 make cover`
- `make lint` *(fails: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b46880fc9083239811fcdf0c324be4