### PR TITLE
Use canonical order for terraform block

### DIFF
--- a/internal/align/canonical.go
+++ b/internal/align/canonical.go
@@ -10,4 +10,11 @@ var CanonicalBlockAttrOrder = map[string][]string{
 	"provider": {"alias"},
 	"resource": {"provider", "count", "for_each", "depends_on"},
 	"data":     {"provider", "count", "for_each", "depends_on"},
+	"terraform": {
+		"required_version",
+		"experiments",
+		"required_providers",
+		"backend",
+		"cloud",
+	},
 }

--- a/internal/align/canonical_test.go
+++ b/internal/align/canonical_test.go
@@ -1,0 +1,14 @@
+// internal/align/canonical_test.go
+package align_test
+
+import (
+	"testing"
+
+	alignpkg "github.com/oferchen/hclalign/internal/align"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalTerraformOrder(t *testing.T) {
+	exp := []string{"required_version", "experiments", "required_providers", "backend", "cloud"}
+	require.Equal(t, exp, alignpkg.CanonicalBlockAttrOrder["terraform"])
+}

--- a/internal/align/terraform.go
+++ b/internal/align/terraform.go
@@ -31,45 +31,45 @@ func (terraformStrategy) Align(block *hclwrite.Block, opts *Options) error {
 		body.RemoveAttribute(name)
 	}
 
-	for _, b := range blocks {
-		body.RemoveBlock(b)
+	canonical := CanonicalBlockAttrOrder["terraform"]
+	canonicalSet := make(map[string]struct{}, len(canonical))
+	for _, name := range canonical {
+		canonicalSet[name] = struct{}{}
 	}
 
-	type item struct {
-		name   string
-		block  *hclwrite.Block
-		isAttr bool
-	}
-
-	var requiredProviders, backendBlock, cloudBlock *hclwrite.Block
+	blockByType := make(map[string]*hclwrite.Block, len(blocks))
 	var otherBlocks []*hclwrite.Block
 	for _, b := range blocks {
-		switch b.Type() {
-		case "required_providers":
-			requiredProviders = b
-		case "backend":
-			backendBlock = b
-		case "cloud":
-			cloudBlock = b
-		default:
+		body.RemoveBlock(b)
+		if _, ok := canonicalSet[b.Type()]; ok {
+			blockByType[b.Type()] = b
+		} else {
 			otherBlocks = append(otherBlocks, b)
 		}
 	}
-	if requiredProviders != nil {
-		rpAttrs := requiredProviders.Body().Attributes()
+
+	if rp := blockByType["required_providers"]; rp != nil {
+		rpAttrs := rp.Body().Attributes()
 		names := make([]string, 0, len(rpAttrs))
 		for name := range rpAttrs {
 			names = append(names, name)
 		}
 		sort.Strings(names)
-		if err := reorderBlock(requiredProviders, names); err != nil {
+		if err := reorderBlock(rp, names); err != nil {
 			return err
+		}
+	}
+
+	canonicalAttrs := make(map[string]struct{}, len(canonical))
+	for _, name := range canonical {
+		if _, ok := attrTokens[name]; ok {
+			canonicalAttrs[name] = struct{}{}
 		}
 	}
 
 	var otherAttrs []string
 	for _, name := range order {
-		if name == "required_version" || name == "experiments" {
+		if _, ok := canonicalAttrs[name]; ok {
 			continue
 		}
 		otherAttrs = append(otherAttrs, name)
@@ -78,21 +78,21 @@ func (terraformStrategy) Align(block *hclwrite.Block, opts *Options) error {
 		sort.Strings(otherAttrs)
 	}
 
+	type item struct {
+		name   string
+		block  *hclwrite.Block
+		isAttr bool
+	}
+
 	var items []item
-	if _, ok := attrTokens["required_version"]; ok {
-		items = append(items, item{name: "required_version", isAttr: true})
-	}
-	if _, ok := attrTokens["experiments"]; ok {
-		items = append(items, item{name: "experiments", isAttr: true})
-	}
-	if requiredProviders != nil {
-		items = append(items, item{block: requiredProviders})
-	}
-	if backendBlock != nil {
-		items = append(items, item{block: backendBlock})
-	}
-	if cloudBlock != nil {
-		items = append(items, item{block: cloudBlock})
+	for _, name := range canonical {
+		if _, ok := attrTokens[name]; ok {
+			items = append(items, item{name: name, isAttr: true})
+			continue
+		}
+		if b, ok := blockByType[name]; ok {
+			items = append(items, item{block: b})
+		}
 	}
 	for _, name := range otherAttrs {
 		items = append(items, item{name: name, isAttr: true})


### PR DESCRIPTION
## Summary
- include `terraform` in `CanonicalBlockAttrOrder`
- refactor terraform alignment to use canonical map
- add test for terraform canonical order

## Testing
- `go test ./...`
- `go test ./internal/align -run TestCanonicalTerraformOrder -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b4687f5c9c8323b23c0cb6c13f351a