### PR TITLE
Drop deprecated ephemeral/experiments attributes from canonical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@
 
 The default schema orders variable attributes as `description → type → default → sensitive → nullable → validation`. Additional block types have their own canonical order:
 
-- **output:** `description`, `value`, `sensitive`, `ephemeral`, `depends_on`
+- **output:** `description`, `value`, `sensitive`, `depends_on`
 - **module:** `source`, `version`, `providers`, `count`, `for_each`, `depends_on`, then input variables alphabetically
 - **provider:** `alias` followed by other attributes alphabetically
-- **terraform:** `required_version`, `experiments`, `required_providers` (entries sorted alphabetically), `backend`, `cloud`, then remaining attributes and blocks in their original order
+- **terraform:** `required_version`, `required_providers` (entries sorted alphabetically), `backend`, `cloud`, then remaining attributes and blocks in their original order
 - **resource/data:** `provider`, `count`, `for_each`, `depends_on`, `lifecycle`, `provisioner`, then provider schema attributes grouped as required → optional → computed (each alphabetical)
 
 Validation blocks are placed immediately after canonical attributes. Attributes not in the canonical list or provider schema are appended in their original order.
 
-Entries within `required_providers` are sorted alphabetically by provider name. Other `terraform` attributes follow `required_version`, `experiments`, `backend`, and `cloud` in that order.
+Entries within `required_providers` are sorted alphabetically by provider name. Other `terraform` attributes follow `required_version`, `backend`, and `cloud` in that order.
 
 ### `required_providers` sorting
 

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 var (
 	DefaultInclude = []string{"**/*.tf"}
 	DefaultExclude = []string{".terraform/**", "**/.terraform/**", "vendor/**"}
-	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable", "ephemeral"}
+	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
 )
 
 const (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,7 @@ func TestValidateOrder_EmptyAttribute(t *testing.T) {
 }
 
 func TestCanonicalOrderMatchesBuiltInAttributes(t *testing.T) {
-	expected := []string{"description", "type", "default", "sensitive", "nullable", "ephemeral"}
+	expected := []string{"description", "type", "default", "sensitive", "nullable"}
 	if !reflect.DeepEqual(CanonicalOrder, expected) {
 		t.Fatalf("expected CanonicalOrder to be %v, got %v", expected, CanonicalOrder)
 	}

--- a/internal/align/canonical.go
+++ b/internal/align/canonical.go
@@ -5,14 +5,13 @@ import "github.com/oferchen/hclalign/config"
 
 var CanonicalBlockAttrOrder = map[string][]string{
 	"variable": append([]string(nil), config.CanonicalOrder...),
-	"output":   {"description", "value", "sensitive", "ephemeral", "depends_on"},
+	"output":   {"description", "value", "sensitive", "depends_on"},
 	"module":   {"source", "version", "providers", "count", "for_each", "depends_on"},
 	"provider": {"alias"},
 	"resource": {"provider", "count", "for_each", "depends_on"},
 	"data":     {"provider", "count", "for_each", "depends_on"},
 	"terraform": {
 		"required_version",
-		"experiments",
 		"required_providers",
 		"backend",
 		"cloud",

--- a/internal/align/canonical_test.go
+++ b/internal/align/canonical_test.go
@@ -9,6 +9,6 @@ import (
 )
 
 func TestCanonicalTerraformOrder(t *testing.T) {
-	exp := []string{"required_version", "experiments", "required_providers", "backend", "cloud"}
+	exp := []string{"required_version", "required_providers", "backend", "cloud"}
 	require.Equal(t, exp, alignpkg.CanonicalBlockAttrOrder["terraform"])
 }

--- a/internal/align/output_test.go
+++ b/internal/align/output_test.go
@@ -10,22 +10,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOutputEphemeralPlacement(t *testing.T) {
-	src := []byte(`output "ephemeral" {
-  value      = var.v
-  depends_on = [var.x]
-  ephemeral  = true
-  sensitive  = false
+func TestOutputAttributeOrder(t *testing.T) {
+	src := []byte(`output "example" {
+  depends_on  = [var.x]
+  value       = var.v
+  description = "desc"
+  sensitive   = true
 }`)
 	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
 	require.False(t, diags.HasErrors())
 	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
 	got := string(file.Bytes())
-	exp := `output "ephemeral" {
-  value      = var.v
-  sensitive  = false
-  ephemeral  = true
-  depends_on = [var.x]
+	exp := `output "example" {
+  description = "desc"
+  value       = var.v
+  sensitive   = true
+  depends_on  = [var.x]
 }`
 	require.Equal(t, exp, got)
 }

--- a/internal/align/terraform_test.go
+++ b/internal/align/terraform_test.go
@@ -14,7 +14,6 @@ func TestTerraformAttributeOrderAndBlocks(t *testing.T) {
 	src := []byte(`terraform {
   backend "s3" {}
   required_providers {}
-  experiments = ["test"]
   required_version = ">= 1.2.0"
   other = 1
   cloud {}
@@ -25,7 +24,6 @@ func TestTerraformAttributeOrderAndBlocks(t *testing.T) {
 	got := string(file.Bytes())
 	exp := `terraform {
   required_version = ">= 1.2.0"
-  experiments      = ["test"]
 
   required_providers {}
 

--- a/tests/cases/output/in.tf
+++ b/tests/cases/output/in.tf
@@ -15,7 +15,6 @@ output "depends" {
   foo        = "bar"
   value      = var.c
   sensitive  = false
-  ephemeral  = true
   depends_on = [var.x]
 }
 

--- a/tests/cases/output/out.tf
+++ b/tests/cases/output/out.tf
@@ -14,7 +14,6 @@ output "unknown" {
 output "depends" {
   value      = var.c
   sensitive  = false
-  ephemeral  = true
   depends_on = [var.x]
   foo        = "bar"
 }

--- a/tests/cases/variable-ephemeral/in.tf
+++ b/tests/cases/variable-ephemeral/in.tf
@@ -1,8 +1,0 @@
-variable "example" {
-  ephemeral  = true
-  nullable   = true
-  description = "example"
-  type        = number
-  default     = 1
-  sensitive   = true
-}

--- a/tests/cases/variable-ephemeral/out.tf
+++ b/tests/cases/variable-ephemeral/out.tf
@@ -1,8 +1,0 @@
-variable "example" {
-  description = "example"
-  type        = number
-  default     = 1
-  sensitive   = true
-  nullable    = true
-  ephemeral   = true
-}


### PR DESCRIPTION
## Summary
- omit `ephemeral` from variable defaults and output canonical order
- remove `experiments` from `terraform` canonical attributes
- update tests and fixtures; drop ephemeral-specific cases

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b475d478f08323a421fa0f4a3a8745