### PR TITLE
Preserve provider attribute order after alias

### DIFF
--- a/internal/align/provider.go
+++ b/internal/align/provider.go
@@ -2,9 +2,8 @@
 package align
 
 import (
-	"sort"
-
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	ihcl "github.com/oferchen/hclalign/internal/hcl"
 )
 
 type providerStrategy struct{}
@@ -24,15 +23,13 @@ func (providerStrategy) Align(block *hclwrite.Block, opts *Options) error {
 		reserved[name] = struct{}{}
 	}
 
-	others := make([]string, 0, len(attrs))
-	for name := range attrs {
+	original := ihcl.AttributeOrder(block.Body(), attrs)
+	for _, name := range original {
 		if _, ok := reserved[name]; ok {
 			continue
 		}
-		others = append(others, name)
+		names = append(names, name)
 	}
-	sort.Strings(others)
-	names = append(names, others...)
 
 	return reorderBlock(block, names)
 }

--- a/internal/align/provider_test.go
+++ b/internal/align/provider_test.go
@@ -43,8 +43,8 @@ func TestProviderAttributeOrder(t *testing.T) {
 	got := string(file.Bytes())
 	exp := `provider "aws" {
   alias   = "west"
-  profile = "default"
   region  = "us-east-1"
+  profile = "default"
 }`
 	require.Equal(t, exp, got)
 }

--- a/tests/cases/non_variable/out.tf
+++ b/tests/cases/non_variable/out.tf
@@ -9,8 +9,8 @@ data "d" "t" {
 }
 
 provider "p" {
-  a = 2
   b = 1
+  a = 2
 }
 
 module "m" {

--- a/tests/cases/provider/out.tf
+++ b/tests/cases/provider/out.tf
@@ -1,10 +1,10 @@
 provider "aws" {
   # alias comment
   alias = "east"
-  # access key comment
-  access_key = "foo"
   # region comment
   region = "us-east-1"
+  # access key comment
+  access_key = "foo"
   # secret key comment
   secret_key = "bar"
 


### PR DESCRIPTION
## Summary
- ensure provider attributes retain their original order after `alias`
- adjust provider attribute ordering test expectations
- update provider golden fixtures for new attribute order

## Testing
- `make lint` *(fails: could not import unicode/utf8; unsupported version 2)*
- `make test`
- `make cover` *(fails: coverage 87.2% is below 95%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b4773985348323b0a81cede55df772