### PR TITLE
align: preserve module blocks

### DIFF
--- a/internal/align/module.go
+++ b/internal/align/module.go
@@ -4,6 +4,7 @@ package align
 import (
 	"sort"
 
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	ihcl "github.com/oferchen/hclalign/internal/hcl"
 )
@@ -13,30 +14,129 @@ type moduleStrategy struct{}
 func (moduleStrategy) Name() string { return "module" }
 
 func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
-	attrs := block.Body().Attributes()
-
+	body := block.Body()
+	attrs := body.Attributes()
 	canonical := CanonicalBlockAttrOrder["module"]
-	order := make([]string, 0, len(attrs))
-	reserved := make(map[string]struct{}, len(canonical))
-	for _, name := range canonical {
-		if _, ok := attrs[name]; ok {
-			order = append(order, name)
+
+	tokens := body.BuildTokens(nil)
+	newline := ihcl.DetectLineEnding(tokens)
+	trailingComma := ihcl.HasTrailingComma(tokens)
+
+	attrTokens := make(map[string]ihcl.AttrTokens, len(attrs))
+	for name, attr := range attrs {
+		attrTokens[name] = ihcl.ExtractAttrTokens(attr)
+	}
+	blocks := body.Blocks()
+
+	type segment struct {
+		attrs []string
+		block *hclwrite.Block
+	}
+	segments := []segment{}
+	current := []string{}
+	depth := 0
+	bi := 0
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i]
+		switch tok.Type {
+		case hclsyntax.TokenOBrace, hclsyntax.TokenOParen:
+			depth++
+			continue
+		case hclsyntax.TokenCBrace, hclsyntax.TokenCParen:
+			if depth > 0 {
+				depth--
+			}
+			continue
 		}
-		reserved[name] = struct{}{}
+		if depth == 0 && tok.Type == hclsyntax.TokenIdent {
+			name := string(tok.Bytes)
+			if _, ok := attrs[name]; ok && tokens[i+1].Type == hclsyntax.TokenEqual {
+				current = append(current, name)
+				continue
+			}
+			if bi < len(blocks) {
+				if len(current) > 0 {
+					segments = append(segments, segment{attrs: current})
+					current = nil
+				}
+				segments = append(segments, segment{block: blocks[bi]})
+				btoks := blocks[bi].BuildTokens(nil)
+				bi++
+				i += len(btoks) - 1
+			}
+		}
+	}
+	if len(current) > 0 {
+		segments = append(segments, segment{attrs: current})
 	}
 
-	original := ihcl.AttributeOrder(block.Body(), attrs)
-	vars := []string{}
-	for _, name := range original {
-		if _, ok := reserved[name]; !ok {
-			vars = append(vars, name)
+	for name := range attrs {
+		body.RemoveAttribute(name)
+	}
+	for _, b := range blocks {
+		body.RemoveBlock(b)
+	}
+	body.Clear()
+
+	if len(segments) > 0 {
+		body.AppendUnstructuredTokens(hclwrite.Tokens{
+			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: newline},
+		})
+	}
+	for i, seg := range segments {
+		if i > 0 {
+			body.AppendUnstructuredTokens(hclwrite.Tokens{
+				&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: newline},
+			})
+		}
+		if seg.block != nil {
+			body.AppendBlock(seg.block)
+			continue
+		}
+		ordered := orderModuleAttrs(seg.attrs, canonical)
+		for _, name := range ordered {
+			tok := attrTokens[name]
+			body.AppendUnstructuredTokens(tok.LeadTokens)
+			body.SetAttributeRaw(name, tok.ExprTokens)
+		}
+	}
+
+	if trailingComma && len(segments) > 0 {
+		body.AppendUnstructuredTokens(hclwrite.Tokens{
+			&hclwrite.Token{Type: hclsyntax.TokenComma, Bytes: []byte{','}},
+		})
+	}
+	toks := body.BuildTokens(nil)
+	if len(toks) > 0 && toks[len(toks)-1].Type != hclsyntax.TokenNewline {
+		body.AppendUnstructuredTokens(hclwrite.Tokens{
+			&hclwrite.Token{Type: hclsyntax.TokenNewline, Bytes: newline},
+		})
+	}
+	return nil
+}
+
+func orderModuleAttrs(names, canonical []string) []string {
+	reserved := make(map[string]struct{}, len(canonical))
+	for _, n := range canonical {
+		reserved[n] = struct{}{}
+	}
+	order := make([]string, 0, len(names))
+	for _, n := range canonical {
+		for _, m := range names {
+			if m == n {
+				order = append(order, m)
+			}
+		}
+	}
+	vars := make([]string, 0, len(names))
+	for _, n := range names {
+		if _, ok := reserved[n]; !ok {
+			vars = append(vars, n)
 		}
 	}
 	sort.Strings(vars)
-
 	order = append(order, vars...)
-
-	return reorderBlock(block, order)
+	return order
 }
 
 func init() { Register(moduleStrategy{}) }

--- a/internal/align/module_test.go
+++ b/internal/align/module_test.go
@@ -1,0 +1,41 @@
+// internal/align/module_test.go
+package align_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	alignpkg "github.com/oferchen/hclalign/internal/align"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleProvisionerAndProviders(t *testing.T) {
+	src := []byte(`module "example" {
+  z = 1
+
+  provisioner "local-exec" {}
+
+  source    = "./m"
+  providers = {
+    b = aws.b
+    a = aws.a
+  }
+}`)
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{}))
+	got := string(file.Bytes())
+	exp := `module "example" {
+  z = 1
+
+  provisioner "local-exec" {}
+
+  source = "./m"
+  providers = {
+    b = aws.b
+    a = aws.a
+  }
+}`
+	require.Equal(t, exp, got)
+}

--- a/tests/cases/module/in.tf
+++ b/tests/cases/module/in.tf
@@ -4,10 +4,18 @@ module "m" {
 }
 
 module "complex" {
-  z          = 0
-  for_each   = {}
-  source     = "./complex"
-  providers  = {}
+  z = 0
+
+  provisioner "local-exec" {
+    command = "echo hi"
+  }
+
+  for_each  = {}
+  source    = "./complex"
+  providers = {
+    b = aws.b
+    a = aws.a
+  }
   depends_on = []
   version    = "1.0"
   count      = 1

--- a/tests/cases/module/out.tf
+++ b/tests/cases/module/out.tf
@@ -4,16 +4,24 @@ module "m" {
 }
 
 module "complex" {
-  source     = "./complex"
-  version    = "1.0"
-  providers  = {}
+  z = 0
+
+  provisioner "local-exec" {
+    command = "echo hi"
+  }
+
+  source  = "./complex"
+  version = "1.0"
+  providers = {
+    b = aws.b
+    a = aws.a
+  }
   count      = 1
   for_each   = {}
   depends_on = []
   a          = 1
   b          = 2
   c          = 3
-  z          = 0
 
   foo {
     x = 1


### PR DESCRIPTION
## Summary
- avoid sorting module provider maps
- keep module provisioner blocks in place while reordering attributes
- add tests for provisioner blocks and unsorted provider maps

## Testing
- `go test ./...`
- `make lint` *(fails: could not import unicode/utf8; unsupported version)*

------
https://chatgpt.com/codex/tasks/task_e_68b47a89a17483238ef4b25c7646274a