### PR TITLE
engine: normalize hint comparison for templates

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -78,7 +78,7 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 	}
 
 	original := append([]byte(nil), data...)
-	originalWithHints := append(append([]byte(nil), hints.BOM()...), original...)
+	originalStyled := internalfs.ApplyHints(internalfs.PrepareForParse(original, hints), hints)
 	hadNewline := len(data) > 0 && data[len(data)-1] == '\n'
 
 	formatted, _, err := terraformfmt.Run(ctx, data)
@@ -122,13 +122,13 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 	}
 
 	styled := internalfs.ApplyHints(append([]byte(nil), formatted...), hints)
-	changed := !bytes.Equal(originalWithHints, styled)
+	changed := !bytes.Equal(originalStyled, styled)
 
 	switch cfg.Mode {
 	case config.ModeDiff:
 		if changed {
 			styledForDiff := styled
-			originalForDiff := originalWithHints
+			originalForDiff := originalStyled
 			if hints.HasBOM {
 				bom := hints.BOM()
 				if len(styledForDiff) >= len(bom) {

--- a/internal/engine/phases_test.go
+++ b/internal/engine/phases_test.go
@@ -32,6 +32,9 @@ func TestPhases(t *testing.T) {
 			var out bytes.Buffer
 			changed, err := ProcessReader(context.Background(), bytes.NewReader(inBytes), &out, cfg)
 			require.NoError(t, err)
+			if name == "templates" {
+				require.False(t, changed)
+			}
 			require.Equal(t, !bytes.Equal(inBytes, outExp), changed)
 			require.Equal(t, string(outExp), out.String())
 


### PR DESCRIPTION
## Summary
- avoid false positives from template directives by comparing hinted inputs
- add regression test to ensure templates don't flag file as changed

## Testing
- `go test ./internal/engine -run TestPhases/templates -count=1`
- `go test ./internal/engine -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b47ddf29208323a77281dd9b2268ea