### PR TITLE
Detect conflicting mode flags

### DIFF
--- a/cli/parse.go
+++ b/cli/parse.go
@@ -35,6 +35,10 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 		return nil, err
 	}
 
+	if (writeMode && checkMode) || (writeMode && diffMode) || (checkMode && diffMode) {
+		return nil, &ExitCodeError{Err: fmt.Errorf("cannot specify more than one of --write, --check, or --diff"), Code: 2}
+	}
+
 	attrOrder, err := config.ParseOrder(orderRaw)
 	if err != nil {
 		return nil, &ExitCodeError{Err: err, Code: 2}

--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -39,11 +39,14 @@ func TestParseConfigStdinRequiresStdout(t *testing.T) {
 	require.Equal(t, 2, exitErr.Code)
 }
 
-func TestParseConfigMutuallyExclusiveFlags(t *testing.T) {
-	cmd := newRootCmd(true)
-	cmd.SetArgs([]string{"--check", "--diff"})
-	_, err := cmd.ExecuteC()
+func TestParseConfigModeConflict(t *testing.T) {
+	cmd := newRootCmd(false)
+	require.NoError(t, cmd.ParseFlags([]string{"--check", "--diff"}))
+	_, err := parseConfig(cmd, []string{"target"})
 	require.Error(t, err)
+	var exitErr *ExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 2, exitErr.Code)
 }
 
 func TestParseConfigNoTarget(t *testing.T) {


### PR DESCRIPTION
## Summary
- error on conflicting --write/--check/--diff flags when parsing CLI config
- add unit test for mode conflict

## Testing
- `go test ./cli`


------
https://chatgpt.com/codex/tasks/task_e_68b47de510648323bb79b3099d3919e5