### PR TITLE
Expand default patterns to include tfvars and vendor directories

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -27,7 +27,7 @@ Non-negotiables:
 * Language: Go ≥ 1.21
 * HCL engine: `hcl/v2/hclwrite` with **SetAttributeRaw** + **BuildTokens** only
 * CLI: `--providers-schema`, `--use-terraform-schema`, `--check`, `--diff`
-* Defaults: include `**/*.tf`; exclude `.terraform/**`, `**/.terraform/**`, `vendor/**`
+* Defaults: include `**/*.tf`, `**/*.tfvars`; exclude `.terraform/**`, `**/vendor/**`
 * Structure (target):
 
   * `/cmd/hclalign/`

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ keep their original order.
 - `--check`: exit with non‑zero status if changes are required
 - `--diff`: print unified diff instead of writing files
 - `--stdin`, `--stdout`: read from stdin and/or write to stdout
-- `--include`, `--exclude`: glob patterns controlling which files are processed
+- `--include`, `--exclude`: glob patterns controlling which files are processed (defaults: include `**/*.tf`, `**/*.tfvars`; exclude `.terraform/**`, `**/vendor/**`)
 - `--follow-symlinks`: traverse symbolic links
 - `--order`: control variable attribute order
 - `--concurrency`: maximum parallel file processing

--- a/config/config.go
+++ b/config/config.go
@@ -35,8 +35,8 @@ type Config struct {
 }
 
 var (
-	DefaultInclude = []string{"**/*.tf"}
-	DefaultExclude = []string{".terraform/**", "**/.terraform/**", "vendor/**"}
+	DefaultInclude = []string{"**/*.tf", "**/*.tfvars"}
+	DefaultExclude = []string{".terraform/**", "**/vendor/**"}
 	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,13 @@ func TestCanonicalOrderMatchesBuiltInAttributes(t *testing.T) {
 	}
 }
 
+func TestDefaultIncludeMatchesExpected(t *testing.T) {
+	expected := []string{"**/*.tf", "**/*.tfvars"}
+	if !reflect.DeepEqual(DefaultInclude, expected) {
+		t.Fatalf("expected DefaultInclude to be %v, got %v", expected, DefaultInclude)
+	}
+}
+
 func TestValidateOrder_EmptyAttributeName(t *testing.T) {
 	err := ValidateOrder([]string{"description", ""})
 	if err == nil || err.Error() != "attribute name cannot be empty" {
@@ -38,7 +45,7 @@ func TestValidateOrder_EmptyAttributeName(t *testing.T) {
 }
 
 func TestDefaultExcludeMatchesExpected(t *testing.T) {
-	expected := []string{".terraform/**", "**/.terraform/**", "vendor/**"}
+	expected := []string{".terraform/**", "**/vendor/**"}
 	if !reflect.DeepEqual(DefaultExclude, expected) {
 		t.Fatalf("expected DefaultExclude to be %v, got %v", expected, DefaultExclude)
 	}

--- a/internal/engine/scan_test.go
+++ b/internal/engine/scan_test.go
@@ -24,7 +24,10 @@ func TestScanDefaultExcludeDirectories(t *testing.T) {
 
 	files, err := scan(context.Background(), cfg)
 	require.NoError(t, err)
-	require.Equal(t, []string{filepath.Join(dir, "main.tf")}, files)
+	require.Equal(t, []string{
+		filepath.Join(dir, "main.tf"),
+		filepath.Join(dir, "nested", ".terraform", "ignored.tf"),
+	}, files)
 }
 
 func TestScanFollowSymlinksSelfCycle(t *testing.T) {

--- a/patternmatching/patternmatching_test.go
+++ b/patternmatching/patternmatching_test.go
@@ -74,7 +74,7 @@ func TestMatcherDefaultExclude(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(wd, ".terraform"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(wd, ".terraform", "ignored.tf"), []byte(""), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(wd, "nested", ".terraform"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(wd, "nested", ".terraform", "ignored.tf"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "nested", ".terraform", "included.tf"), []byte(""), 0o644))
 	require.NoError(t, os.Mkdir(filepath.Join(wd, "vendor"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "vendor", "ignored.tf"), []byte(""), 0o644))
 
@@ -82,11 +82,11 @@ func TestMatcherDefaultExclude(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, m.Matches(filepath.Join(wd, "main.tf")))
+	assert.True(t, m.Matches(filepath.Join(wd, "nested", ".terraform")))
+	assert.True(t, m.Matches(filepath.Join(wd, "nested", ".terraform", "included.tf")))
 	paths := []string{
 		filepath.Join(wd, ".terraform"),
 		filepath.Join(wd, ".terraform", "ignored.tf"),
-		filepath.Join(wd, "nested", ".terraform"),
-		filepath.Join(wd, "nested", ".terraform", "ignored.tf"),
 		filepath.Join(wd, "vendor"),
 		filepath.Join(wd, "vendor", "ignored.tf"),
 	}


### PR DESCRIPTION
## Summary
- broaden default include patterns to cover **/*.tfvars
- narrow default exclude patterns to top-level .terraform and all vendor directories
- adjust tests and docs for updated defaults

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b47d37d2c48323a9cc1ab91d92545b