### PR TITLE
build: add coverage checker and update Makefile

### DIFF
--- a/tools/covercheck/main.go
+++ b/tools/covercheck/main.go
@@ -1,0 +1,39 @@
+// tools/covercheck/main.go
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	min := 95.0
+	if len(os.Args) > 1 {
+		if v, err := strconv.ParseFloat(os.Args[1], 64); err == nil {
+			min = v
+		}
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	var line string
+	for scanner.Scan() {
+		line = scanner.Text()
+	}
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		fmt.Fprintln(os.Stderr, "no coverage data")
+		os.Exit(1)
+	}
+	pctStr := strings.TrimSuffix(fields[len(fields)-1], "%")
+	pct, err := strconv.ParseFloat(pctStr, 64)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if pct < min {
+		fmt.Printf("coverage %.1f%% is below %.0f%%\n", pct, min)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- refine Makefile targets for fmt, strip, cover, and clean
- add small Go helper to enforce coverage threshold

## Testing
- `make tidy`
- `make lint` *(fails: could not import unicode/utf8, terraform binary issues)*
- `make test` *(fails: terraform fmt failed: no such file or directory)*
- `make cover` *(fails: TestPhases/templates: Should be false)*
- `make build`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_68b480dd29d4832380a017884f5b9a4b