### PR TITLE
Wrap flag errors with context

### DIFF
--- a/cli/parse.go
+++ b/cli/parse.go
@@ -102,6 +102,9 @@ func getBool(cmd *cobra.Command, name string, err *error) bool {
 	}
 	var v bool
 	v, *err = cmd.Flags().GetBool(name)
+	if *err != nil {
+		*err = fmt.Errorf("get flag %s: %w", name, *err)
+	}
 	return v
 }
 
@@ -111,6 +114,9 @@ func getStringSlice(cmd *cobra.Command, name string, err *error) []string {
 	}
 	var v []string
 	v, *err = cmd.Flags().GetStringSlice(name)
+	if *err != nil {
+		*err = fmt.Errorf("get flag %s: %w", name, *err)
+	}
 	return v
 }
 
@@ -120,6 +126,9 @@ func getString(cmd *cobra.Command, name string, err *error) string {
 	}
 	var v string
 	v, *err = cmd.Flags().GetString(name)
+	if *err != nil {
+		*err = fmt.Errorf("get flag %s: %w", name, *err)
+	}
 	return v
 }
 
@@ -129,5 +138,8 @@ func getInt(cmd *cobra.Command, name string, err *error) int {
 	}
 	var v int
 	v, *err = cmd.Flags().GetInt(name)
+	if *err != nil {
+		*err = fmt.Errorf("get flag %s: %w", name, *err)
+	}
 	return v
 }

--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/oferchen/hclalign/config"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,4 +69,32 @@ func TestParseConfigConcurrencyValidation(t *testing.T) {
 	var exitErr *ExitCodeError
 	require.ErrorAs(t, err, &exitErr)
 	require.Equal(t, 2, exitErr.Code)
+}
+
+func TestGetBoolError(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	var err error
+	_ = getBool(cmd, "missing", &err)
+	require.EqualError(t, err, "get flag missing: flag accessed but not defined: missing")
+}
+
+func TestGetStringSliceError(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	var err error
+	_ = getStringSlice(cmd, "missing", &err)
+	require.EqualError(t, err, "get flag missing: flag accessed but not defined: missing")
+}
+
+func TestGetStringError(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	var err error
+	_ = getString(cmd, "missing", &err)
+	require.EqualError(t, err, "get flag missing: flag accessed but not defined: missing")
+}
+
+func TestGetIntError(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	var err error
+	_ = getInt(cmd, "missing", &err)
+	require.EqualError(t, err, "get flag missing: flag accessed but not defined: missing")
 }


### PR DESCRIPTION
## Summary
- wrap flag retrieval errors with flag name for easier diagnostics
- add tests covering missing flag errors

## Testing
- `go test ./cli -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68b48bd09b788323b2bb43f10731f0b2