### PR TITLE
align: order ephemeral output attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ All notable changes to this project will be documented in this file.
 - Documented exit codes and provided CI/editor usage examples to encourage safe automation.
 - Enforced single-line SPDX comment rule.
 - Achieved ≥95% line coverage across core packages.
+- Added `ephemeral` to canonical ordering for output blocks.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Attributes are reordered inside these block types using canonical schemas:
 
 - **variable:** `description`, `type`, `default`, `sensitive`, `nullable`, then any other attributes followed by `validation` blocks
-- **output:** `description`, `value`, `sensitive`, `depends_on`, then other attributes
+- **output:** `description`, `value`, `sensitive`, `ephemeral`, `depends_on`, then other attributes
 - **locals:** no reordering
 - **module:** `source`, `version`, `providers`, `count`, `for_each`, `depends_on`, then input variables alphabetically and other attributes
 - **provider:** `alias` followed by remaining attributes in their original order

--- a/internal/align/canonical.go
+++ b/internal/align/canonical.go
@@ -5,7 +5,7 @@ import "github.com/oferchen/hclalign/config"
 
 var CanonicalBlockAttrOrder = map[string][]string{
 	"variable": append([]string(nil), config.CanonicalOrder...),
-	"output":   {"description", "value", "sensitive", "depends_on"},
+	"output":   {"description", "value", "sensitive", "ephemeral", "depends_on"},
 	"module":   {"source", "version", "providers", "count", "for_each", "depends_on"},
 	"provider": {"alias"},
 	"resource": {"provider", "count", "for_each", "depends_on"},

--- a/internal/align/output_test.go
+++ b/internal/align/output_test.go
@@ -14,6 +14,7 @@ func TestOutputAttributeOrder(t *testing.T) {
 	src := []byte(`output "example" {
   depends_on  = [var.x]
   value       = var.v
+  ephemeral   = true
   description = "desc"
   sensitive   = true
 }`)
@@ -25,6 +26,7 @@ func TestOutputAttributeOrder(t *testing.T) {
   description = "desc"
   value       = var.v
   sensitive   = true
+  ephemeral   = true
   depends_on  = [var.x]
 }`
 	require.Equal(t, exp, got)

--- a/tests/cases/output/ephemeral/in.tf
+++ b/tests/cases/output/ephemeral/in.tf
@@ -1,0 +1,7 @@
+output "demo" {
+  ephemeral  = true
+  value      = var.v
+  depends_on = [var.dep]
+  description = "desc"
+  sensitive  = true
+}

--- a/tests/cases/output/ephemeral/out.tf
+++ b/tests/cases/output/ephemeral/out.tf
@@ -1,0 +1,7 @@
+output "demo" {
+  description = "desc"
+  value       = var.v
+  sensitive   = true
+  ephemeral   = true
+  depends_on  = [var.dep]
+}


### PR DESCRIPTION
## Summary
- include `ephemeral` in canonical output attribute list
- document and test the new output ordering
- add golden case covering ephemeral output attribute

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b4b20e5a208323a22340f350a05b95