### PR TITLE
chore: update toolchain versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Aligned toolchain with Go 1.23 and gofumpt v0.8.0.
 - Changed project license to Apache-2.0.
 - Added variable-attribute reordering tool with support for include/exclude globs and the `--order` flag for custom schemas.
 - Introduced safety features such as check and diff modes, idempotent operation, and atomic file writes.

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ tidy: ## tidy modules
 	@$(GO) mod tidy -v
 
 fmt: ## format code and regenerate test fixtures
-	@$(GO) run mvdan.cc/gofumpt@v0.6.0 -l -w .
+	@$(GO) run mvdan.cc/gofumpt@v0.8.0 -l -w .
 	@if command -v terraform >/dev/null 2>&1; then \
 	terraform fmt -recursive tests/cases; \
 	else \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oferchen/hclalign
 
-go 1.24.5
+go 1.23.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1


### PR DESCRIPTION
## Summary
- target Go 1.23 and update gofumpt usage to v0.8.0
- document Go 1.23 and gofumpt v0.8.0 in changelog

## Testing
- `go mod tidy`
- `make init` *(fails: building golangci-lint takes too long)*
- `make fmt` *(fails: terraform not found)*
- `make test` *(fails: terraform fmt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b221af708323b889a8eee932060a