### PR TITLE
Expand default exclusion patterns for temp and state files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Supported Blocks and Canonical Order
 
-`hclalign` aligns attributes inside Terraform blocks. By default it processes only `variable` blocks and targets files matching the glob patterns `**/*.tf` and `**/*.tfvars` while excluding `.terraform/**` and `**/vendor/**`.
+`hclalign` aligns attributes inside Terraform blocks. By default it processes only `variable` blocks and targets files matching the glob patterns `**/*.tf` and `**/*.tfvars` while excluding `.terraform/**`, `**/vendor/**`, `**/*~`, `**/*.swp`, `**/*.tmp`, and `**/*.tfstate*`.
 
 Attributes are reordered inside these block types using canonical schemas:
 
@@ -83,7 +83,7 @@ keep their original order.
 - `--check`: exit with non‑zero status if changes are required
 - `--diff`: print unified diff instead of writing files
 - `--stdin`, `--stdout`: read from stdin and/or write to stdout
-- `--include`, `--exclude`: glob patterns controlling which files are processed (defaults: include `**/*.tf`, `**/*.tfvars`; exclude `.terraform/**`, `**/vendor/**`)
+- `--include`, `--exclude`: glob patterns controlling which files are processed (defaults: include `**/*.tf`, `**/*.tfvars`; exclude `.terraform/**`, `**/vendor/**`, `**/*~`, `**/*.swp`, `**/*.tmp`, `**/*.tfstate*`)
 - `--follow-symlinks`: traverse symbolic links
 - `--order`: control variable attribute order
 - `--concurrency`: maximum parallel file processing

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ type Config struct {
 
 var (
 	DefaultInclude = []string{"**/*.tf", "**/*.tfvars"}
-	DefaultExclude = []string{".terraform/**", "**/vendor/**"}
+	DefaultExclude = []string{".terraform/**", "**/vendor/**", "**/*~", "**/*.swp", "**/*.tmp", "**/*.tfstate*"}
 	CanonicalOrder = []string{"description", "type", "default", "sensitive", "nullable"}
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -45,7 +45,7 @@ func TestValidateOrder_EmptyAttributeName(t *testing.T) {
 }
 
 func TestDefaultExcludeMatchesExpected(t *testing.T) {
-	expected := []string{".terraform/**", "**/vendor/**"}
+	expected := []string{".terraform/**", "**/vendor/**", "**/*~", "**/*.swp", "**/*.tmp", "**/*.tfstate*"}
 	if !reflect.DeepEqual(DefaultExclude, expected) {
 		t.Fatalf("expected DefaultExclude to be %v, got %v", expected, DefaultExclude)
 	}

--- a/patternmatching/patternmatching_test.go
+++ b/patternmatching/patternmatching_test.go
@@ -77,6 +77,12 @@ func TestMatcherDefaultExclude(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "nested", ".terraform", "included.tf"), []byte(""), 0o644))
 	require.NoError(t, os.Mkdir(filepath.Join(wd, "vendor"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "vendor", "ignored.tf"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "tempfile~"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "swap.swp"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "temporary.tmp"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "terraform.tfstate"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "terraform.tfstate.backup"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "nested", "state.tfstate"), []byte(""), 0o644))
 
 	m, err := patternmatching.NewMatcher(config.DefaultInclude, config.DefaultExclude, wd)
 	require.NoError(t, err)
@@ -89,6 +95,12 @@ func TestMatcherDefaultExclude(t *testing.T) {
 		filepath.Join(wd, ".terraform", "ignored.tf"),
 		filepath.Join(wd, "vendor"),
 		filepath.Join(wd, "vendor", "ignored.tf"),
+		filepath.Join(wd, "tempfile~"),
+		filepath.Join(wd, "swap.swp"),
+		filepath.Join(wd, "temporary.tmp"),
+		filepath.Join(wd, "terraform.tfstate"),
+		filepath.Join(wd, "terraform.tfstate.backup"),
+		filepath.Join(wd, "nested", "state.tfstate"),
 	}
 	for _, p := range paths {
 		assert.False(t, m.Matches(p))


### PR DESCRIPTION
## Summary
- ignore temporary and state files by default (`**/*~`, `**/*.swp`, `**/*.tmp`, `**/*.tfstate*`)
- extend pattern matcher tests for the new defaults
- document expanded exclusion list in README

## Testing
- `make tidy`
- `make lint` *(fails: could not import unicode/utf8 (unsupported version: 2))*
- `make test`
- `make cover` *(fails: coverage 87.1% is below 95%)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b4b21dad148323a1f7e1f6773e0490