### PR TITLE
Add experiments attribute to terraform canonical order

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -67,7 +67,7 @@ Non-negotiables:
     * `locals`: **no reordering** (fmt only)
     * `module`: `source, version, providers, count, for_each, depends_on, <inputs alpha>, <other>`
     * `provider`: `alias, <config attrs alpha>, <blocks>`
-    * `terraform`: `required_version, required_providers(alpha), backend, cloud, <other>`
+    * `terraform`: `required_version, experiments, required_providers(alpha), backend, cloud, <other>`
     * `resource/data`: meta-args first `provider, count, for_each, depends_on, lifecycle, provisioner*`, then **schema-driven** tiers: required → optional → computed (each alpha). Fallback to alpha when schema unknown.
   * Move **attributes** only; keep nested blocks & their order unless explicitly defined.
   * Use `BuildTokens(nil)` + `SetAttributeRaw`; never rebuild expressions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ All notable changes to this project will be documented in this file.
 - Documented exit codes and provided CI/editor usage examples to encourage safe automation.
 - Enforced single-line SPDX comment rule.
 - Achieved ≥95% line coverage across core packages.
+- Added `experiments` after `required_version` in the canonical `terraform` block order.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Attributes are reordered inside these block types using canonical schemas:
 - **locals:** no reordering
 - **module:** `source`, `version`, `providers`, `count`, `for_each`, `depends_on`, then input variables alphabetically and other attributes
 - **provider:** `alias` followed by remaining attributes in their original order
-- **terraform:** `required_version`, `required_providers` (entries sorted alphabetically), `backend`, `cloud`, then other attributes and blocks
+- **terraform:** `required_version`, `experiments`, `required_providers` (entries sorted alphabetically), `backend`, `cloud`, then other attributes and blocks
 - **resource/data:** `provider`, `count`, `for_each`, `depends_on`, `lifecycle`, `provisioner`, then provider schema attributes grouped as required → optional → computed (each alphabetical), followed by any other attributes
 
 Validation blocks are placed immediately after canonical attributes. Attributes not covered by a canonical list or provider schema keep their original order. Entries within `required_providers` are sorted alphabetically by provider name.

--- a/internal/align/canonical.go
+++ b/internal/align/canonical.go
@@ -12,6 +12,7 @@ var CanonicalBlockAttrOrder = map[string][]string{
 	"data":     {"provider", "count", "for_each", "depends_on"},
 	"terraform": {
 		"required_version",
+		"experiments",
 		"required_providers",
 		"backend",
 		"cloud",

--- a/internal/align/canonical_test.go
+++ b/internal/align/canonical_test.go
@@ -9,6 +9,6 @@ import (
 )
 
 func TestCanonicalTerraformOrder(t *testing.T) {
-	exp := []string{"required_version", "required_providers", "backend", "cloud"}
+	exp := []string{"required_version", "experiments", "required_providers", "backend", "cloud"}
 	require.Equal(t, exp, alignpkg.CanonicalBlockAttrOrder["terraform"])
 }

--- a/internal/align/terraform_test.go
+++ b/internal/align/terraform_test.go
@@ -13,6 +13,7 @@ import (
 func TestTerraformAttributeOrderAndBlocks(t *testing.T) {
 	src := []byte(`terraform {
   backend "s3" {}
+  experiments = ["a"]
   required_providers {}
   required_version = ">= 1.2.0"
   other = 1
@@ -24,6 +25,7 @@ func TestTerraformAttributeOrderAndBlocks(t *testing.T) {
 	got := string(file.Bytes())
 	exp := `terraform {
   required_version = ">= 1.2.0"
+  experiments      = ["a"]
 
   required_providers {}
 

--- a/tests/cases/terraform/experiments/in.tf
+++ b/tests/cases/terraform/experiments/in.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {}
+  experiments = ["a"]
+  required_providers {}
+  required_version = ">= 1.2.0"
+  other = 1
+  cloud {}
+}

--- a/tests/cases/terraform/experiments/out.tf
+++ b/tests/cases/terraform/experiments/out.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.2.0"
+  experiments      = ["a"]
+
+  required_providers {}
+
+  backend "s3" {}
+
+  cloud {}
+  other = 1
+}


### PR DESCRIPTION
## Summary
- handle `experiments` after `required_version` in canonical terraform ordering
- exercise and document new canonical order

## Testing
- `go test ./...`
- `make lint` *(fails: could not load export data: unsupported version)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b20fded08323ba4d69ba2e925da4