### PR TITLE
feat: add prefix-order flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ All notable changes to this project will be documented in this file.
 - Documented exit codes and provided CI/editor usage examples to encourage safe automation.
 - Enforced single-line SPDX comment rule.
 - Achieved ≥95% line coverage across core packages.
+- Introduced `--prefix-order` flag to alphabetize non-canonical attributes and sort module provider maps.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ keep their original order.
 - `--include`, `--exclude`: glob patterns controlling which files are processed (defaults: include `**/*.tf`, `**/*.tfvars`; exclude `.terraform/**`, `**/vendor/**`)
 - `--follow-symlinks`: traverse symbolic links
 - `--order`: control variable attribute order
+- `--prefix-order`: alphabetize attributes not in canonical lists
 - `--concurrency`: maximum parallel file processing
 - `-v, --verbose`: enable verbose logging
 - `--providers-schema`: path to a provider schema JSON file

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -33,6 +33,7 @@ func newTestRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().StringSlice("include", config.DefaultInclude, "glob patterns to include")
 	cmd.Flags().StringSlice("exclude", config.DefaultExclude, "glob patterns to exclude")
 	cmd.Flags().StringSlice("order", config.CanonicalOrder, "order of variable block fields")
+	cmd.Flags().Bool("prefix-order", false, "alphabetize attributes not in canonical lists")
 	cmd.Flags().String("providers-schema", "", "path to providers schema file")
 	cmd.Flags().Bool("use-terraform-schema", false, "use terraform schema for providers")
 	cmd.Flags().Int("concurrency", runtime.GOMAXPROCS(0), "maximum concurrency")

--- a/cli/parse.go
+++ b/cli/parse.go
@@ -24,6 +24,7 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 	include := getStringSlice(cmd, "include", &err)
 	exclude := getStringSlice(cmd, "exclude", &err)
 	orderRaw := getStringSlice(cmd, "order", &err)
+	prefixOrder := getBool(cmd, "prefix-order", &err)
 	providersSchema := getString(cmd, "providers-schema", &err)
 	useTerraformSchema := getBool(cmd, "use-terraform-schema", &err)
 	concurrency := getInt(cmd, "concurrency", &err)
@@ -81,6 +82,7 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 		Include:            include,
 		Exclude:            exclude,
 		Order:              attrOrder,
+		PrefixOrder:        prefixOrder,
 		ProvidersSchema:    providersSchema,
 		UseTerraformSchema: useTerraformSchema,
 		Concurrency:        concurrency,

--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -20,6 +20,14 @@ func TestParseConfigValid(t *testing.T) {
 	require.Equal(t, config.ModeCheck, cfg.Mode)
 }
 
+func TestParseConfigPrefixOrder(t *testing.T) {
+	cmd := newRootCmd(true)
+	require.NoError(t, cmd.ParseFlags([]string{"--prefix-order"}))
+	cfg, err := parseConfig(cmd, []string{"target"})
+	require.NoError(t, err)
+	require.True(t, cfg.PrefixOrder)
+}
+
 func TestParseConfigTargetWithStdin(t *testing.T) {
 	cmd := newRootCmd(true)
 	require.NoError(t, cmd.ParseFlags([]string{"--stdin", "--stdout"}))

--- a/cmd/hclalign/main.go
+++ b/cmd/hclalign/main.go
@@ -38,6 +38,7 @@ func run(args []string) int {
 	rootCmd.Flags().StringSlice("include", config.DefaultInclude, "glob patterns to include")
 	rootCmd.Flags().StringSlice("exclude", config.DefaultExclude, "glob patterns to exclude")
 	rootCmd.Flags().StringSlice("order", config.CanonicalOrder, "order of variable block fields")
+	rootCmd.Flags().Bool("prefix-order", false, "alphabetize attributes not in canonical lists")
 	rootCmd.Flags().String("providers-schema", "", "path to providers schema file")
 	rootCmd.Flags().Bool("use-terraform-schema", false, "use terraform schema for providers")
 	rootCmd.Flags().Int("concurrency", runtime.GOMAXPROCS(0), "maximum concurrency")

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Include            []string
 	Exclude            []string
 	Order              []string
+	PrefixOrder        bool
 	Concurrency        int
 	Verbose            bool
 	FollowSymlinks     bool

--- a/internal/align/data_test.go
+++ b/internal/align/data_test.go
@@ -1,0 +1,26 @@
+// internal/align/data_test.go
+package align_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	alignpkg "github.com/oferchen/hclalign/internal/align"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataPrefixOrder(t *testing.T) {
+	src := []byte(`data "x" "y" {
+  z = 1
+  a = 2
+}`)
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{PrefixOrder: true}))
+	exp := `data "x" "y" {
+  a = 2
+  z = 1
+}`
+	require.Equal(t, exp, string(file.Bytes()))
+}

--- a/internal/align/golden_test.go
+++ b/internal/align/golden_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -86,6 +87,9 @@ func TestGolden(t *testing.T) {
 				t.Fatalf("parse fmt: %v", diags)
 			}
 			opts := &alignpkg.Options{}
+			if strings.Contains(name, "prefix_order") {
+				opts.PrefixOrder = true
+			}
 			if name == "resource" || name == "data" {
 				opts.Schemas = schemas
 			}
@@ -139,6 +143,27 @@ func TestUnknownAttributesOrder(t *testing.T) {
   default     = 1
   foo         = "foo"
   bar         = "bar"
+}`)
+		if !bytes.Equal(got, exp) {
+			t.Fatalf("output mismatch:\n-- got --\n%s\n-- want --\n%s", got, exp)
+		}
+	})
+
+	t.Run("prefix", func(t *testing.T) {
+		file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+		if diags.HasErrors() {
+			t.Fatalf("parse input: %v", diags)
+		}
+		if err := alignpkg.Apply(file, &alignpkg.Options{PrefixOrder: true}); err != nil {
+			t.Fatalf("reorder: %v", err)
+		}
+		got := file.Bytes()
+		exp := []byte(`variable "example" {
+  description = "example"
+  type        = number
+  default     = 1
+  bar         = "bar"
+  foo         = "foo"
 }`)
 		if !bytes.Equal(got, exp) {
 			t.Fatalf("output mismatch:\n-- got --\n%s\n-- want --\n%s", got, exp)

--- a/internal/align/module.go
+++ b/internal/align/module.go
@@ -2,8 +2,10 @@
 package align
 
 import (
+	"bytes"
 	"sort"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	ihcl "github.com/oferchen/hclalign/internal/hcl"
@@ -25,6 +27,15 @@ func (moduleStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	attrTokens := make(map[string]ihcl.AttrTokens, len(attrs))
 	for name, attr := range attrs {
 		attrTokens[name] = ihcl.ExtractAttrTokens(attr)
+	}
+	if opts != nil && opts.PrefixOrder {
+		if at, ok := attrTokens["providers"]; ok {
+			sorted, err := sortProvidersMap(at)
+			if err != nil {
+				return err
+			}
+			attrTokens["providers"] = sorted
+		}
 	}
 	blocks := body.Blocks()
 
@@ -140,3 +151,34 @@ func orderModuleAttrs(names, canonical []string) []string {
 }
 
 func init() { Register(moduleStrategy{}) }
+
+func sortProvidersMap(at ihcl.AttrTokens) (ihcl.AttrTokens, error) {
+	exprTokens := at.ExprTokens
+	if len(exprTokens) < 2 || exprTokens[0].Type != hclsyntax.TokenOBrace {
+		return at, nil
+	}
+	var buf bytes.Buffer
+	buf.WriteString("dummy ")
+	for _, t := range exprTokens {
+		buf.Write(t.Bytes)
+	}
+	buf.WriteByte('\n')
+	file, diags := hclwrite.ParseConfig(buf.Bytes(), "providers.hcl", hcl.InitialPos)
+	if diags.HasErrors() {
+		return at, diags
+	}
+	block := file.Body().Blocks()[0]
+	attrs := block.Body().Attributes()
+	names := make([]string, 0, len(attrs))
+	for name := range attrs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if err := reorderBlock(block, names); err != nil {
+		return at, err
+	}
+	inner := block.Body().BuildTokens(nil)
+	at.ExprTokens = append(hclwrite.Tokens{exprTokens[0]}, inner...)
+	at.ExprTokens = append(at.ExprTokens, exprTokens[len(exprTokens)-1])
+	return at, nil
+}

--- a/internal/align/module_test.go
+++ b/internal/align/module_test.go
@@ -39,3 +39,22 @@ func TestModuleProvisionerAndProviders(t *testing.T) {
 }`
 	require.Equal(t, exp, got)
 }
+
+func TestModuleProvidersPrefixOrder(t *testing.T) {
+	src := []byte(`module "example" {
+  providers = {
+    b = aws.b
+    a = aws.a
+  }
+}`)
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{PrefixOrder: true}))
+	exp := `module "example" {
+  providers = {
+    a = aws.a
+    b = aws.b
+  }
+}`
+	require.Equal(t, exp, string(file.Bytes()))
+}

--- a/internal/align/output.go
+++ b/internal/align/output.go
@@ -2,6 +2,8 @@
 package align
 
 import (
+	"sort"
+
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	ihcl "github.com/oferchen/hclalign/internal/hcl"
 )
@@ -25,11 +27,16 @@ func (outputStrategy) Align(block *hclwrite.Block, opts *Options) error {
 
 	original := ihcl.AttributeOrder(block.Body(), attrs)
 
+	nonCanonical := make([]string, 0)
 	for _, name := range original {
 		if _, ok := reserved[name]; !ok {
-			order = append(order, name)
+			nonCanonical = append(nonCanonical, name)
 		}
 	}
+	if opts != nil && opts.PrefixOrder {
+		sort.Strings(nonCanonical)
+	}
+	order = append(order, nonCanonical...)
 
 	return reorderBlock(block, order)
 }

--- a/internal/align/output_test.go
+++ b/internal/align/output_test.go
@@ -29,3 +29,19 @@ func TestOutputAttributeOrder(t *testing.T) {
 }`
 	require.Equal(t, exp, got)
 }
+
+func TestOutputAttributePrefixOrder(t *testing.T) {
+	src := []byte(`output "example" {
+  c = 1
+  a = 1
+}`)
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{PrefixOrder: true}))
+	got := string(file.Bytes())
+	exp := `output "example" {
+  a = 1
+  c = 1
+}`
+	require.Equal(t, exp, got)
+}

--- a/internal/align/provider.go
+++ b/internal/align/provider.go
@@ -2,6 +2,8 @@
 package align
 
 import (
+	"sort"
+
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	ihcl "github.com/oferchen/hclalign/internal/hcl"
 )
@@ -24,12 +26,17 @@ func (providerStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	}
 
 	original := ihcl.AttributeOrder(block.Body(), attrs)
+	extra := make([]string, 0)
 	for _, name := range original {
 		if _, ok := reserved[name]; ok {
 			continue
 		}
-		names = append(names, name)
+		extra = append(extra, name)
 	}
+	if opts != nil && opts.PrefixOrder {
+		sort.Strings(extra)
+	}
+	names = append(names, extra...)
 
 	return reorderBlock(block, names)
 }

--- a/internal/align/provider_test.go
+++ b/internal/align/provider_test.go
@@ -48,3 +48,19 @@ func TestProviderAttributeOrder(t *testing.T) {
 }`
 	require.Equal(t, exp, got)
 }
+
+func TestProviderAttributePrefixOrder(t *testing.T) {
+	src := []byte(`provider "aws" {
+  zz = 1
+  aa = 2
+}`)
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{PrefixOrder: true}))
+	got := string(file.Bytes())
+	exp := `provider "aws" {
+  aa = 2
+  zz = 1
+}`
+	require.Equal(t, exp, got)
+}

--- a/internal/align/resource.go
+++ b/internal/align/resource.go
@@ -46,6 +46,9 @@ func schemaAwareOrder(block *hclwrite.Block, opts *Options) error {
 				rest = append(rest, n)
 			}
 		}
+		if opts != nil && opts.PrefixOrder {
+			sort.Strings(rest)
+		}
 		order := append(metaAttrs, rest...)
 		return reorderBlock(block, order)
 	}
@@ -96,6 +99,9 @@ func schemaAwareOrder(block *hclwrite.Block, opts *Options) error {
 		if _, ok := known[n]; !ok {
 			unk = append(unk, n)
 		}
+	}
+	if opts != nil && opts.PrefixOrder {
+		sort.Strings(unk)
 	}
 
 	blocks := body.Blocks()

--- a/internal/align/resource_test.go
+++ b/internal/align/resource_test.go
@@ -167,3 +167,34 @@ func TestLifecycleProvisionerOrder(t *testing.T) {
 	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{Schemas: schemas}))
 	require.Equal(t, exp, string(file.Bytes()))
 }
+
+func TestSchemaAwareOrderPrefix(t *testing.T) {
+	src := []byte(`resource "test" "ex" {
+  foo = 1
+  zz  = 5
+  bar = 2
+  baz = 3
+  aa  = 4
+}`)
+
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	sch := &alignpkg.Schema{
+		Required: map[string]struct{}{"foo": {}},
+		Optional: map[string]struct{}{"bar": {}},
+		Computed: map[string]struct{}{"baz": {}},
+	}
+	schemas := map[string]*alignpkg.Schema{"test": sch}
+
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{Schemas: schemas, PrefixOrder: true}))
+
+	exp := `resource "test" "ex" {
+  foo = 1
+  bar = 2
+  baz = 3
+  aa  = 4
+  zz  = 5
+}`
+	require.Equal(t, exp, string(file.Bytes()))
+}

--- a/internal/align/strategy.go
+++ b/internal/align/strategy.go
@@ -11,6 +11,8 @@ type Options struct {
 	Schema *Schema
 
 	Types map[string]struct{}
+
+	PrefixOrder bool
 }
 
 type Schema struct {

--- a/internal/align/terraform.go
+++ b/internal/align/terraform.go
@@ -74,6 +74,9 @@ func (terraformStrategy) Align(block *hclwrite.Block, opts *Options) error {
 		}
 		otherAttrs = append(otherAttrs, name)
 	}
+	if opts != nil && opts.PrefixOrder {
+		sort.Strings(otherAttrs)
+	}
 
 	type item struct {
 		name   string

--- a/internal/align/terraform_test.go
+++ b/internal/align/terraform_test.go
@@ -79,3 +79,18 @@ func TestTerraformBlocksOrderWithoutExperiments(t *testing.T) {
 }`
 	require.Equal(t, exp, string(file.Bytes()))
 }
+
+func TestTerraformPrefixOrder(t *testing.T) {
+	src := []byte(`terraform {
+  b = 2
+  a = 1
+}`)
+	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{PrefixOrder: true}))
+	exp := `terraform {
+  a = 1
+  b = 2
+}`
+	require.Equal(t, exp, string(file.Bytes()))
+}

--- a/internal/align/variable.go
+++ b/internal/align/variable.go
@@ -3,6 +3,7 @@ package align
 
 import (
 	"bytes"
+	"sort"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -44,14 +45,14 @@ func (variableStrategy) Align(block *hclwrite.Block, opts *Options) error {
 	if len(knownOrder) == 0 {
 		knownOrder = canonical
 	}
-	return reorderVariableBlock(block, knownOrder, canonical, canonicalSet, validationPos)
+	return reorderVariableBlock(block, knownOrder, canonical, canonicalSet, validationPos, opts != nil && opts.PrefixOrder)
 }
 
 func init() {
 	Register(variableStrategy{})
 }
 
-func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalOrder []string, canonicalSet map[string]struct{}, validationPos int) error {
+func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalOrder []string, canonicalSet map[string]struct{}, validationPos int, prefix bool) error {
 	body := block.Body()
 
 	attrs := body.Attributes()
@@ -210,6 +211,9 @@ func reorderVariableBlock(block *hclwrite.Block, order []string, canonicalOrder 
 			unknown = append(unknown, name)
 			seenUnknown[name] = struct{}{}
 		}
+	}
+	if prefix {
+		sort.Strings(unknown)
 	}
 
 	insertedValidation := false

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -105,7 +105,7 @@ func processReader(ctx context.Context, r io.Reader, w io.Writer, cfg *config.Co
 			typesMap[t] = struct{}{}
 		}
 	}
-	if err := align.Apply(file, &align.Options{Order: cfg.Order, Schemas: schemas, Types: typesMap}); err != nil {
+	if err := align.Apply(file, &align.Options{Order: cfg.Order, Schemas: schemas, Types: typesMap, PrefixOrder: cfg.PrefixOrder}); err != nil {
 		return false, err
 	}
 	if testHookAfterReorder != nil {

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -195,7 +195,7 @@ func (p *Processor) processFile(ctx context.Context, filePath string) (bool, []b
 			typesMap[t] = struct{}{}
 		}
 	}
-	if err := align.Apply(file, &align.Options{Order: p.cfg.Order, Schemas: p.schemas, Types: typesMap}); err != nil {
+	if err := align.Apply(file, &align.Options{Order: p.cfg.Order, Schemas: p.schemas, Types: typesMap, PrefixOrder: p.cfg.PrefixOrder}); err != nil {
 		return false, nil, err
 	}
 	if testHookAfterReorder != nil {

--- a/tests/cases/module/prefix_order/in.tf
+++ b/tests/cases/module/prefix_order/in.tf
@@ -1,0 +1,7 @@
+module "example" {
+  providers = {
+    b = aws.b
+    a = aws.a
+  }
+  source = "./m"
+}

--- a/tests/cases/module/prefix_order/out.tf
+++ b/tests/cases/module/prefix_order/out.tf
@@ -1,0 +1,7 @@
+module "example" {
+  source = "./m"
+  providers = {
+    a = aws.a
+    b = aws.b
+  }
+}


### PR DESCRIPTION
## Summary
- support `--prefix-order` to alphabetize non-canonical attributes and sort module provider maps
- add prefix-order option to config and alignment strategies
- document new flag and provide golden fixtures

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b4b21380288323b2224e4ce6dc9d84