### PR TITLE
Refactor Terraform fmt integration

### DIFF
--- a/internal/engine/error_test.go
+++ b/internal/engine/error_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/oferchen/hclalign/config"
+	internalfs "github.com/oferchen/hclalign/internal/fs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,8 +28,8 @@ func TestProcessInvalidHCLFile(t *testing.T) {
 	}
 
 	origFmt := terraformFmtFormatFile
-	terraformFmtFormatFile = func(ctx context.Context, p string) (bool, error) {
-		return false, fmt.Errorf("boom")
+	terraformFmtFormatFile = func(ctx context.Context, p string) ([]byte, internalfs.Hints, bool, error) {
+		return nil, internalfs.Hints{}, false, fmt.Errorf("boom")
 	}
 	defer func() { terraformFmtFormatFile = origFmt }()
 

--- a/internal/engine/pipeline_test.go
+++ b/internal/engine/pipeline_test.go
@@ -20,9 +20,9 @@ func TestProcessFileTerraformFmt(t *testing.T) {
 	var formatCalls, runCalls int
 	origFormat := terraformFmtFormatFile
 	origRun := terraformFmtRun
-	terraformFmtFormatFile = func(ctx context.Context, path string) (bool, error) {
+	terraformFmtFormatFile = func(ctx context.Context, path string) ([]byte, internalfs.Hints, bool, error) {
 		formatCalls++
-		return false, nil
+		return nil, internalfs.Hints{}, false, nil
 	}
 	terraformFmtRun = func(ctx context.Context, b []byte) ([]byte, internalfs.Hints, error) {
 		runCalls++
@@ -49,9 +49,9 @@ func TestProcessFileTerraformFmtPreservesCRLF(t *testing.T) {
 
 	origFormat := terraformFmtFormatFile
 	origRun := terraformFmtRun
-	terraformFmtFormatFile = func(ctx context.Context, path string) (bool, error) {
+	terraformFmtFormatFile = func(ctx context.Context, path string) ([]byte, internalfs.Hints, bool, error) {
 		formatted := []byte("variable \"a\" {\n  type = string\n}\n")
-		return true, os.WriteFile(path, formatted, 0o644)
+		return formatted, internalfs.Hints{}, true, nil
 	}
 	terraformFmtRun = func(ctx context.Context, b []byte) ([]byte, internalfs.Hints, error) {
 		return b, internalfs.Hints{}, nil
@@ -82,9 +82,9 @@ func TestProcessFileTerraformFmtPreservesBOM(t *testing.T) {
 
 	origFormat := terraformFmtFormatFile
 	origRun := terraformFmtRun
-	terraformFmtFormatFile = func(ctx context.Context, path string) (bool, error) {
+	terraformFmtFormatFile = func(ctx context.Context, path string) ([]byte, internalfs.Hints, bool, error) {
 		formatted := []byte("variable \"a\" {\n  type = string\n}\n")
-		return true, os.WriteFile(path, formatted, 0o644)
+		return formatted, internalfs.Hints{}, true, nil
 	}
 	terraformFmtRun = func(ctx context.Context, b []byte) ([]byte, internalfs.Hints, error) {
 		return b, internalfs.Hints{}, nil

--- a/internal/fmt/formatfile_test.go
+++ b/internal/fmt/formatfile_test.go
@@ -7,32 +7,36 @@ import (
 	"path/filepath"
 	"testing"
 
+	internalfs "github.com/oferchen/hclalign/internal/fs"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFormatFileUsesCLI(t *testing.T) {
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "terraform")
-	script := []byte("#!/bin/sh\nout=$5\nprintf 'cli\\n' > \"$out\"")
+	script := []byte("#!/bin/sh\nprintf 'cli\\n'")
 	require.NoError(t, os.WriteFile(bin, script, 0o755))
 	oldPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", oldPath)
 	os.Setenv("PATH", dir)
 	f := filepath.Join(dir, "file.tf")
 	require.NoError(t, os.WriteFile(f, []byte("orig\n"), 0o644))
-	ran, err := FormatFile(context.Background(), f)
+	out, _, ran, err := FormatFile(context.Background(), f)
 	require.NoError(t, err)
 	require.True(t, ran)
-	out, err := os.ReadFile(f)
-	require.NoError(t, err)
 	require.Equal(t, "cli\n", string(out))
+	content, err := os.ReadFile(f)
+	require.NoError(t, err)
+	require.Equal(t, "orig\n", string(content))
 }
 
 func TestFormatFileMissingCLI(t *testing.T) {
 	oldPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", oldPath)
 	os.Setenv("PATH", "")
-	ran, err := FormatFile(context.Background(), "file.tf")
+	out, hints, ran, err := FormatFile(context.Background(), "file.tf")
 	require.NoError(t, err)
 	require.False(t, ran)
+	require.Nil(t, out)
+	require.Equal(t, internalfs.Hints{}, hints)
 }


### PR DESCRIPTION
## Summary
- return formatted bytes and hints from `FormatFile`
- consume `terraform fmt` output directly in pipeline
- adjust unit tests for the new formatter API

## Testing
- `go test ./internal/fmt`
- `go test ./internal/engine` *(fails: PrefixOrder redeclared, undefined ihcl)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bd007be48323aa083a167a57e1b5