### PR TITLE
refactor: rename strip tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
       - run: make init
       - run: make tidy
       - run: make fmt
-      - run: make strip
+      - run: |
+          go run ./tools/strip --repo-root .
+          go run ./cmd/commentcheck
+          git diff --exit-code
       - run: make lint
       - run: make vet
       - run: make test-race

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ fmt: ## format code and regenerate test fixtures
 	xargs -0 -n1 -I{} sh -c 'dir=$$(dirname {}); $(GO) run ./cmd/hclalign --stdin --stdout < {} > $$dir/fmt.tf; $(GO) run ./cmd/hclalign --stdin --stdout --all < {} > $$dir/aligned.tf'
 
 strip: ## normalize Go file comments and enforce policy
-	@$(GO) run ./tools/stripcomments
+        @$(GO) run ./tools/strip --repo-root .
 	@$(GO) run ./cmd/commentcheck
 	@git diff --exit-code
 

--- a/tools/strip/main.go
+++ b/tools/strip/main.go
@@ -1,4 +1,4 @@
-// tools/stripcomments/main.go
+// tools/strip/main.go
 package main
 
 import (
@@ -127,7 +127,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() && rel == filepath.Join("tools", "stripcomments") {
+                if d.IsDir() && rel == filepath.Join("tools", "strip") {
 			return filepath.SkipDir
 		}
 		if d.IsDir() || !strings.HasSuffix(d.Name(), ".go") {

--- a/tools/strip/main_test.go
+++ b/tools/strip/main_test.go
@@ -1,4 +1,4 @@
-// tools/stripcomments/main_test.go
+// tools/strip/main_test.go
 package main
 
 import (
@@ -65,7 +65,7 @@ func TestMainRepoRoot(t *testing.T) {
 	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	toolDir := filepath.Join(dir, "tools", "stripcomments")
+        toolDir := filepath.Join(dir, "tools", "strip")
 	if err := os.MkdirAll(toolDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestMainRepoRoot(t *testing.T) {
 	}
 	old := os.Args
 	defer func() { os.Args = old }()
-	os.Args = []string{"stripcomments", "--repo-root", dir}
+        os.Args = []string{"strip", "--repo-root", dir}
 	main()
 	out, err := os.ReadFile(file)
 	if err != nil {


### PR DESCRIPTION
## Summary
- rename `tools/stripcomments` to `tools/strip`
- call strip tool with `--repo-root .` in Makefile and CI
- update tests to use new strip path

## Testing
- `go test ./tools/strip`
- `go test ./...` *(fails: PrefixOrder redeclared, undefined: ihcl)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bd0265ac832381b20f7828c1c7a5