### PR TITLE
Default to write mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ keep their original order.
 
 ## CLI Flags
 
-- `--write` (default): rewrite files in place
+By default `hclalign` rewrites files in place. The following flags adjust this behavior:
+
 - `--check`: exit with non‑zero status if changes are required
 - `--diff`: print unified diff instead of writing files
 - `--stdin`, `--stdout`: read from stdin and/or write to stdout

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -25,7 +25,6 @@ func newTestRootCmd(exclusive bool) *cobra.Command {
 		RunE:         RunE,
 		SilenceUsage: true,
 	}
-	cmd.Flags().Bool("write", false, "write result to file(s)")
 	cmd.Flags().Bool("check", false, "check if files are formatted")
 	cmd.Flags().Bool("diff", false, "print the diff of required changes")
 	cmd.Flags().Bool("stdin", false, "read from STDIN")
@@ -43,7 +42,7 @@ func newTestRootCmd(exclusive bool) *cobra.Command {
 	cmd.Flags().Bool("all", false, "align all block types")
 	cmd.MarkFlagsMutuallyExclusive("types", "all")
 	if exclusive {
-		cmd.MarkFlagsMutuallyExclusive("write", "check", "diff")
+		cmd.MarkFlagsMutuallyExclusive("check", "diff")
 	}
 	return cmd
 }
@@ -211,8 +210,8 @@ func TestRunEModes(t *testing.T) {
 			wantStdout: formatted,
 		},
 		{
-			name:     "write",
-			flags:    []string{"--write"},
+			name:     "default",
+			flags:    nil,
 			wantCode: 0,
 			withFile: true,
 			wantFile: formatted,

--- a/cli/parse.go
+++ b/cli/parse.go
@@ -16,7 +16,6 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 	}
 
 	var err error
-	writeMode := getBool(cmd, "write", &err)
 	checkMode := getBool(cmd, "check", &err)
 	diffMode := getBool(cmd, "diff", &err)
 	stdin := getBool(cmd, "stdin", &err)
@@ -36,8 +35,8 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 		return nil, err
 	}
 
-	if (writeMode && checkMode) || (writeMode && diffMode) || (checkMode && diffMode) {
-		return nil, &ExitCodeError{Err: fmt.Errorf("cannot specify more than one of --write, --check, or --diff"), Code: 2}
+	if checkMode && diffMode {
+		return nil, &ExitCodeError{Err: fmt.Errorf("cannot specify both --check and --diff"), Code: 2}
 	}
 
 	attrOrder, err := config.ParseOrder(orderRaw)
@@ -57,8 +56,6 @@ func parseConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 
 	var mode config.Mode
 	switch {
-	case writeMode:
-		mode = config.ModeWrite
 	case checkMode:
 		mode = config.ModeCheck
 	case diffMode:

--- a/cmd/hclalign/main.go
+++ b/cmd/hclalign/main.go
@@ -29,10 +29,9 @@ func run(args []string) int {
 		SilenceUsage: true,
 	}
 
-	rootCmd.Flags().Bool("write", false, "write result to file(s)")
 	rootCmd.Flags().Bool("check", false, "check if files are formatted")
 	rootCmd.Flags().Bool("diff", false, "print the diff of required changes")
-	rootCmd.MarkFlagsMutuallyExclusive("write", "check", "diff")
+	rootCmd.MarkFlagsMutuallyExclusive("check", "diff")
 	rootCmd.Flags().Bool("stdin", false, "read from STDIN")
 	rootCmd.Flags().Bool("stdout", false, "write result to STDOUT")
 	rootCmd.Flags().StringSlice("include", config.DefaultInclude, "glob patterns to include")

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -26,7 +26,7 @@ func buildBinary(t *testing.T) string {
 func TestCLI(t *testing.T) {
 	bin := buildBinary(t)
 
-	t.Run("write", func(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
 		unformatted := "variable \"a\" {\n  type = string\n  description = \"d\"\n}\n"
 		want := "variable \"a\" {\n  description = \"d\"\n  type        = string\n}\n"
 
@@ -34,7 +34,7 @@ func TestCLI(t *testing.T) {
 		file := filepath.Join(dir, "test.tf")
 		require.NoError(t, os.WriteFile(file, []byte(unformatted), 0o644))
 
-		cmd := exec.Command(bin, file, "--write")
+		cmd := exec.Command(bin, file)
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
@@ -95,7 +95,7 @@ func TestCLI(t *testing.T) {
 		require.NoError(t, os.WriteFile(includedFile, []byte(unformatted), 0o644))
 		require.NoError(t, os.WriteFile(excludedFile, []byte(unformatted), 0o644))
 
-		cmd := exec.Command(bin, dir, "--write", "--include", "included.tf", "--exclude", "excluded.tf")
+		cmd := exec.Command(bin, dir, "--include", "included.tf", "--exclude", "excluded.tf")
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
@@ -128,7 +128,7 @@ func TestCLI(t *testing.T) {
 		require.NoError(t, os.WriteFile(terraformFile, []byte(unformatted), 0o644))
 		require.NoError(t, os.WriteFile(vendorFile, []byte(unformatted), 0o644))
 
-		cmd := exec.Command(bin, dir, "--write")
+		cmd := exec.Command(bin, dir)
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
@@ -191,7 +191,7 @@ func TestCLI(t *testing.T) {
 		file := filepath.Join(dir, "test.tf")
 		require.NoError(t, os.WriteFile(file, []byte(unformatted), 0o644))
 
-		cmd := exec.Command(bin, file, "--write", "--types", "output")
+		cmd := exec.Command(bin, file, "--types", "output")
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr


### PR DESCRIPTION
## Summary
- default CLI to write files unless `--check` or `--diff` are specified
- simplify mode selection logic in CLI parser
- update tests and docs for implicit write mode

## Testing
- `make tidy`
- `make lint` *(fails: PrefixOrder redeclared, undefined: ihcl)*
- `make test` *(fails: PrefixOrder redeclared, undefined: ihcl)*
- `make cover` *(fails: PrefixOrder redeclared, undefined: ihcl)*
- `make build` *(fails: PrefixOrder redeclared, undefined: ihcl)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bd43cec08323b402fde5248010a7