### PR TITLE
align: preserve output attribute and block order

### DIFF
--- a/internal/align/output.go
+++ b/internal/align/output.go
@@ -2,8 +2,6 @@
 package align
 
 import (
-	"sort"
-
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	ihcl "github.com/oferchen/hclalign/internal/hcl"
 )
@@ -13,7 +11,8 @@ type outputStrategy struct{}
 func (outputStrategy) Name() string { return "output" }
 
 func (outputStrategy) Align(block *hclwrite.Block, opts *Options) error {
-	attrs := block.Body().Attributes()
+	body := block.Body()
+	attrs := body.Attributes()
 
 	canonical := CanonicalBlockAttrOrder["output"]
 	order := make([]string, 0, len(attrs))
@@ -25,7 +24,7 @@ func (outputStrategy) Align(block *hclwrite.Block, opts *Options) error {
 		reserved[name] = struct{}{}
 	}
 
-	original := ihcl.AttributeOrder(block.Body(), attrs)
+	original := ihcl.AttributeOrder(body, attrs)
 
 	nonCanonical := make([]string, 0)
 	for _, name := range original {
@@ -33,10 +32,31 @@ func (outputStrategy) Align(block *hclwrite.Block, opts *Options) error {
 			nonCanonical = append(nonCanonical, name)
 		}
 	}
-	if opts != nil && opts.PrefixOrder {
-		sort.Strings(nonCanonical)
-	}
 	order = append(order, nonCanonical...)
+
+	nested := body.Blocks()
+	if len(nested) > 0 {
+		pre := make([]*hclwrite.Block, 0)
+		post := make([]*hclwrite.Block, 0)
+		other := make([]*hclwrite.Block, 0)
+		for _, nb := range nested {
+			switch nb.Type() {
+			case "precondition":
+				pre = append(pre, nb)
+			case "postcondition":
+				post = append(post, nb)
+			default:
+				other = append(other, nb)
+			}
+		}
+		reordered := append(pre, append(post, other...)...)
+		for _, nb := range nested {
+			body.RemoveBlock(nb)
+		}
+		for _, nb := range reordered {
+			body.AppendBlock(nb)
+		}
+	}
 
 	return reorderBlock(block, order)
 }


### PR DESCRIPTION
## Summary
- keep non-canonical output attributes in source order
- ensure `precondition` blocks precede `postcondition` blocks
- extend tests for unsorted attributes and block ordering

## Testing
- `go test ./...` *(fails: PrefixOrder redeclared; provider undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cb3a5d748323aa116b90b48744bf