### PR TITLE
align: remove terraform prefix order

### DIFF
--- a/internal/align/terraform.go
+++ b/internal/align/terraform.go
@@ -13,7 +13,7 @@ type terraformStrategy struct{}
 
 func (terraformStrategy) Name() string { return "terraform" }
 
-func (terraformStrategy) Align(block *hclwrite.Block, opts *Options) error {
+func (terraformStrategy) Align(block *hclwrite.Block, _ *Options) error {
 	body := block.Body()
 
 	attrs := body.Attributes()
@@ -73,9 +73,6 @@ func (terraformStrategy) Align(block *hclwrite.Block, opts *Options) error {
 			continue
 		}
 		otherAttrs = append(otherAttrs, name)
-	}
-	if opts != nil && opts.PrefixOrder {
-		sort.Strings(otherAttrs)
 	}
 
 	type item struct {

--- a/internal/align/terraform_test.go
+++ b/internal/align/terraform_test.go
@@ -81,18 +81,3 @@ func TestTerraformBlocksOrderWithoutExperiments(t *testing.T) {
 }`
 	require.Equal(t, exp, string(file.Bytes()))
 }
-
-func TestTerraformPrefixOrder(t *testing.T) {
-	src := []byte(`terraform {
-  b = 2
-  a = 1
-}`)
-	file, diags := hclwrite.ParseConfig(src, "in.tf", hcl.InitialPos)
-	require.False(t, diags.HasErrors())
-	require.NoError(t, alignpkg.Apply(file, &alignpkg.Options{PrefixOrder: true}))
-	exp := `terraform {
-  a = 1
-  b = 2
-}`
-	require.Equal(t, exp, string(file.Bytes()))
-}


### PR DESCRIPTION
## Summary
- drop PrefixOrder option from terraform block alignment
- keep required_providers keys sorted while leaving other fields in original order

## Testing
- `go test ./...` *(fails: PrefixOrder redeclared in internal/align/strategy.go; undefined: ihcl in internal/align/provider.go)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cb440eac8323b7ba0a9bca2cab2d