### PR TITLE
Guard symlink traversal

### DIFF
--- a/internal/engine/scan_test.go
+++ b/internal/engine/scan_test.go
@@ -3,6 +3,7 @@ package engine
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -14,6 +15,9 @@ func TestScanDefaultExcludeDirectories(t *testing.T) {
 	t.Parallel()
 
 	dir := filepath.Join("..", "..", "tests", "cases", "default_excludes")
+	absDir, err := filepath.Abs(dir)
+	require.NoError(t, err)
+	dir = absDir
 
 	cfg := &config.Config{
 		Target:  dir,
@@ -27,4 +31,29 @@ func TestScanDefaultExcludeDirectories(t *testing.T) {
 		filepath.Join(dir, "main.tf"),
 		filepath.Join(dir, "nested", ".terraform", "ignored.tf"),
 	}, files)
+}
+
+func TestScanFollowSymlinks(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.tf")
+	require.NoError(t, os.WriteFile(target, []byte(""), 0o644))
+	require.NoError(t, os.Symlink(target, filepath.Join(dir, "link.tf")))
+
+	outsideDir := t.TempDir()
+	outside := filepath.Join(outsideDir, "outside.tf")
+	require.NoError(t, os.WriteFile(outside, []byte(""), 0o644))
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "out.tf")))
+
+	cfg := &config.Config{Target: dir, Include: config.DefaultInclude}
+
+	files, err := scan(context.Background(), cfg)
+	require.NoError(t, err)
+	require.Equal(t, []string{target}, files)
+
+	cfg.FollowSymlinks = true
+	files, err = scan(context.Background(), cfg)
+	require.NoError(t, err)
+	require.Equal(t, []string{target, target}, files)
 }


### PR DESCRIPTION
## Summary
- only traverse filesystem symlinks when `--follow-symlinks` is provided
- skip symlink targets outside the scan root and avoid directory cycles
- test scanning with and without `FollowSymlinks`

## Testing
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1 run --timeout=5m` *(fails: unsupported version: 2)*
- `go test -shuffle=on -cover ./...`

------
https://chatgpt.com/codex/tasks/task_e_68b4d4590ae48323b329700d72e358a4