### PR TITLE
docs: refresh default glob patterns

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -27,7 +27,7 @@ Non-negotiables:
 * Language: Go ≥ 1.21
 * HCL engine: `hcl/v2/hclwrite` with **SetAttributeRaw** + **BuildTokens** only
 * CLI: `--providers-schema`, `--use-terraform-schema`, `--check`, `--diff`
-* Defaults: include `**/*.tf`, `**/*.tfvars`; exclude `.terraform/**`, `**/vendor/**`
+* Defaults: include `**/*.tf`; exclude `.terraform/**`, `vendor/**`
 * Structure (target):
 
   * `/cmd/hclalign/`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Supported Blocks and Canonical Order
 
-`hclalign` aligns attributes inside Terraform blocks. By default it processes only `variable` blocks and targets files matching the glob patterns `**/*.tf` and `**/*.tfvars` while excluding `.terraform/**`, `.terraform.lock.hcl`, and `**/vendor/**`.
+`hclalign` aligns attributes inside Terraform blocks. By default it processes only `variable` blocks and targets files matching the glob pattern `**/*.tf` while excluding `.terraform/**` and `vendor/**`.
 
 Attributes are reordered inside these block types using canonical schemas:
 
@@ -86,7 +86,7 @@ By default `hclalign` rewrites files in place. The following flags adjust this b
 - `--diff`: print unified diff instead of writing files
 - `--follow-symlinks`: follow symbolic links when searching for files
 - `--stdin`, `--stdout`: read from stdin and/or write to stdout
-- `--include`, `--exclude`: glob patterns controlling which files are processed (defaults: include `**/*.tf`, `**/*.tfvars`; exclude `.terraform/**`, `.terraform.lock.hcl`, `**/vendor/**`)
+- `--include`, `--exclude`: glob patterns controlling which files are processed (defaults: include `**/*.tf`; exclude `.terraform/**`, `vendor/**`)
 - `--order`: control variable attribute order
 - `--concurrency`: maximum parallel file processing
 - `--providers-schema`: path to a provider schema JSON file

--- a/internal/engine/scan_test.go
+++ b/internal/engine/scan_test.go
@@ -26,5 +26,6 @@ func TestScanDefaultExcludeDirectories(t *testing.T) {
 	require.Equal(t, []string{
 		filepath.Join(dir, "main.tf"),
 		filepath.Join(dir, "nested", ".terraform", "ignored.tf"),
+		filepath.Join(dir, "nested", "vendor", "included.tf"),
 	}, files)
 }

--- a/patternmatching/patternmatching_test.go
+++ b/patternmatching/patternmatching_test.go
@@ -77,6 +77,8 @@ func TestMatcherDefaultExclude(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "nested", ".terraform", "included.tf"), []byte(""), 0o644))
 	require.NoError(t, os.Mkdir(filepath.Join(wd, "vendor"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "vendor", "ignored.tf"), []byte(""), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(wd, "nested", "vendor"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "nested", "vendor", "included.tf"), []byte(""), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "tempfile~"), []byte(""), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "swap.swp"), []byte(""), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "temporary.tmp"), []byte(""), 0o644))
@@ -90,6 +92,8 @@ func TestMatcherDefaultExclude(t *testing.T) {
 	assert.True(t, m.Matches(filepath.Join(wd, "main.tf")))
 	assert.True(t, m.Matches(filepath.Join(wd, "nested", ".terraform")))
 	assert.True(t, m.Matches(filepath.Join(wd, "nested", ".terraform", "included.tf")))
+	assert.True(t, m.Matches(filepath.Join(wd, "nested", "vendor")))
+	assert.True(t, m.Matches(filepath.Join(wd, "nested", "vendor", "included.tf")))
 	paths := []string{
 		filepath.Join(wd, ".terraform"),
 		filepath.Join(wd, ".terraform", "ignored.tf"),

--- a/tests/cases/default_excludes/nested/vendor/included.tf
+++ b/tests/cases/default_excludes/nested/vendor/included.tf
@@ -1,0 +1,1 @@
+variable "included" {}


### PR DESCRIPTION
## Summary
- document and test new default include/exclude globs
- ensure nested `vendor` directories are processed by default

## Testing
- `make tidy` *(fails: missing separator in Makefile)*
- `make lint` *(fails: missing separator in Makefile)*
- `go mod tidy -v`
- `golangci-lint run --timeout=5m` *(fails: can't load config version)*
- `go test -shuffle=on -cover ./...`
- `go test -shuffle=on -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...` *(fails: terraform fmt failed: fork/exec /tmp/TestRunUsesTerraformCLI4228126600/001/terraform: no such file or directory)*
- `go tool cover -func=coverage.out`
- `go build ./cmd/hclalign`


------
https://chatgpt.com/codex/tasks/task_e_68b4d4684a3c8323acd76d7c84de0650