### PR TITLE
Preserve attribute comments and newlines

### DIFF
--- a/internal/hcl/fuzz_tokens_test.go
+++ b/internal/hcl/fuzz_tokens_test.go
@@ -18,11 +18,15 @@ func FuzzExtractAttrTokens(f *testing.F) {
 			t.Skip()
 		}
 		attr := file.Body().GetAttribute("a")
-		toks := ExtractAttrTokens(attr)
+		toksMap, start := ExtractAttrTokens(file.Body(), map[string]*hclwrite.Attribute{"a": attr})
+		toks := toksMap["a"]
 		body := hclwrite.NewEmptyFile().Body()
+		body.AppendUnstructuredTokens(start)
 		raw := append(hclwrite.Tokens{}, toks.LeadTokens...)
 		raw = append(raw, toks.ExprTokens...)
+		body.AppendUnstructuredTokens(toks.PreTokens)
 		body.SetAttributeRaw("a", raw)
+		body.AppendUnstructuredTokens(toks.PostTokens)
 		out := hclwrite.Format(body.BuildTokens(nil).Bytes())
 		_, diags = hclwrite.ParseConfig(out, "fuzz.hcl", hcl.InitialPos)
 		if diags.HasErrors() {

--- a/internal/hcl/tokens.go
+++ b/internal/hcl/tokens.go
@@ -9,30 +9,89 @@ import (
 )
 
 type AttrTokens struct {
+	PreTokens  hclwrite.Tokens
 	LeadTokens hclwrite.Tokens
 	ExprTokens hclwrite.Tokens
+	PostTokens hclwrite.Tokens
 }
 
-func ExtractAttrTokens(attr *hclwrite.Attribute) AttrTokens {
-	toks := attr.BuildTokens(nil)
-	i := 0
-	for i < len(toks) && toks[i].Type == hclsyntax.TokenComment {
-		i++
-	}
-	lead := toks[:i]
-	expr := toks[i+2:]
-	if n := len(expr); n > 0 {
-		last := expr[n-1]
-		if last.Type == hclsyntax.TokenNewline {
-			expr = expr[:n-1]
-		} else if last.Type == hclsyntax.TokenComment {
-			b := last.Bytes
-			if len(b) > 0 && b[len(b)-1] == '\n' {
-				expr[n-1].Bytes = b[:len(b)-1]
+func ExtractAttrTokens(body *hclwrite.Body, attrs map[string]*hclwrite.Attribute) (map[string]AttrTokens, hclwrite.Tokens) {
+	tokens := body.BuildTokens(nil)
+	res := make(map[string]AttrTokens, len(attrs))
+	depth := 0
+	cursor := 0
+	prev := ""
+	start := hclwrite.Tokens{}
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i]
+		switch tok.Type {
+		case hclsyntax.TokenOBrace, hclsyntax.TokenOParen:
+			depth++
+			continue
+		case hclsyntax.TokenCBrace, hclsyntax.TokenCParen:
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if depth == 0 && tok.Type == hclsyntax.TokenIdent {
+			name := string(tok.Bytes)
+			attr, ok := attrs[name]
+			if ok && i+1 < len(tokens) && tokens[i+1].Type == hclsyntax.TokenEqual {
+				attrToks := attr.BuildTokens(nil)
+				leadCount := 0
+				for leadCount < len(attrToks) && attrToks[leadCount].Type == hclsyntax.TokenComment {
+					leadCount++
+				}
+				lead := attrToks[:leadCount]
+				expr := attrToks[leadCount+2:]
+				if n := len(expr); n > 0 {
+					last := expr[n-1]
+					if last.Type == hclsyntax.TokenNewline {
+						expr = expr[:n-1]
+					} else if last.Type == hclsyntax.TokenComment {
+						b := last.Bytes
+						if len(b) > 0 && b[len(b)-1] == '\n' {
+							expr[n-1] = &hclwrite.Token{Type: hclsyntax.TokenComment, Bytes: b[:len(b)-1]}
+						}
+					}
+				}
+
+				attrStart := i - leadCount
+				between := tokens[cursor:attrStart]
+				split := len(between)
+				for split > 0 && between[split-1].Type == hclsyntax.TokenNewline {
+					split--
+				}
+				prevPost := between[:split]
+				pre := between[split:]
+				if split == 0 {
+					prevPost = between
+					pre = nil
+				}
+				if prev != "" {
+					at := res[prev]
+					at.PostTokens = append(at.PostTokens, prevPost...)
+					res[prev] = at
+				} else {
+					start = prevPost
+				}
+				res[name] = AttrTokens{PreTokens: pre, LeadTokens: lead, ExprTokens: expr}
+				prev = name
+				cursor = attrStart + len(attrToks)
+				i = cursor - 1
+				continue
 			}
 		}
 	}
-	return AttrTokens{LeadTokens: lead, ExprTokens: expr}
+	if prev != "" {
+		at := res[prev]
+		at.PostTokens = append(at.PostTokens, tokens[cursor:]...)
+		res[prev] = at
+	} else if cursor < len(tokens) {
+		start = append(start, tokens[cursor:]...)
+	}
+	return res, start
 }
 
 func HasTrailingComma(tokens hclwrite.Tokens) bool {

--- a/tests/cases/comments_blanklines/in.tf
+++ b/tests/cases/comments_blanklines/in.tf
@@ -1,0 +1,21 @@
+variable "example" {
+
+  # desc lead hash
+  // desc lead sl
+  /* desc lead block */
+  description = "example" // desc inline
+  // desc trail sl
+  # desc trail hash
+
+  /* type lead block */
+  type = number /* type inline block */ // type inline sl
+  /* type trail block */
+  # type trail hash
+
+
+  // default lead sl
+  default = 1 // default inline sl
+  /* default trail block */
+  # default trail hash
+
+}

--- a/tests/cases/comments_blanklines/out.tf
+++ b/tests/cases/comments_blanklines/out.tf
@@ -1,0 +1,21 @@
+variable "example" {
+
+  # desc lead hash
+  // desc lead sl
+  /* desc lead block */
+  description = "example" // desc inline
+  // desc trail sl
+  # desc trail hash
+
+  /* type lead block */
+  type = number /* type inline block */ // type inline sl
+  /* type trail block */
+  # type trail hash
+
+
+  // default lead sl
+  default = 1 // default inline sl
+  /* default trail block */
+  # default trail hash
+
+}


### PR DESCRIPTION
## Summary
- track pre and post tokens around attributes
- replay exact spacing in block reordering
- add regression fixture for mixed comment spacing

## Testing
- `go test ./...` *(fails: unexpected formatting and diff mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dadaa6708323ac8df336e5393fe1