### PR TITLE
feat: retain schema attribute order

### DIFF
--- a/internal/align/resource.go
+++ b/internal/align/resource.go
@@ -44,21 +44,41 @@ func schemaAwareOrder(block *hclwrite.Block, opts *Options) error {
 		return reorderBlock(block, order)
 	}
 
-	var req, opt, comp, unk []string
+	reqSet := map[string]struct{}{}
+	optSet := map[string]struct{}{}
+	compSet := map[string]struct{}{}
+	var unk []string
 	for _, name := range rest {
 		if _, ok := opts.Schema.Required[name]; ok {
-			req = append(req, name)
+			reqSet[name] = struct{}{}
 			continue
 		}
 		if _, ok := opts.Schema.Optional[name]; ok {
-			opt = append(opt, name)
+			optSet[name] = struct{}{}
 			continue
 		}
 		if _, ok := opts.Schema.Computed[name]; ok {
-			comp = append(comp, name)
+			compSet[name] = struct{}{}
 			continue
 		}
 		unk = append(unk, name)
+	}
+
+	var req, opt, comp []string
+	for _, n := range opts.Schema.RequiredOrder {
+		if _, ok := reqSet[n]; ok {
+			req = append(req, n)
+		}
+	}
+	for _, n := range opts.Schema.OptionalOrder {
+		if _, ok := optSet[n]; ok {
+			opt = append(opt, n)
+		}
+	}
+	for _, n := range opts.Schema.ComputedOrder {
+		if _, ok := compSet[n]; ok {
+			comp = append(comp, n)
+		}
 	}
 
 	order := append(metaAttrs, req...)

--- a/internal/align/resource_test.go
+++ b/internal/align/resource_test.go
@@ -26,10 +26,13 @@ func TestSchemaAwareOrder(t *testing.T) {
 	require.False(t, diags.HasErrors())
 
 	sch := &alignpkg.Schema{
-		Required: map[string]struct{}{"foo": {}},
-		Optional: map[string]struct{}{"bar": {}},
-		Computed: map[string]struct{}{"baz": {}},
-		Meta:     map[string]struct{}{"provider": {}, "depends_on": {}, "count": {}, "for_each": {}},
+		Required:      map[string]struct{}{"foo": {}},
+		Optional:      map[string]struct{}{"bar": {}},
+		Computed:      map[string]struct{}{"baz": {}},
+		Meta:          map[string]struct{}{"provider": {}, "depends_on": {}, "count": {}, "for_each": {}},
+		RequiredOrder: []string{"foo"},
+		OptionalOrder: []string{"bar"},
+		ComputedOrder: []string{"baz"},
 	}
 	schemas := map[string]*alignpkg.Schema{"test_thing": sch}
 
@@ -134,10 +137,13 @@ func TestLifecycleProvisionerOrder(t *testing.T) {
 	require.False(t, diags.HasErrors())
 
 	sch := &alignpkg.Schema{
-		Required: map[string]struct{}{"foo": {}},
-		Optional: map[string]struct{}{"bar": {}},
-		Computed: map[string]struct{}{"baz": {}},
-		Meta:     map[string]struct{}{"provider": {}, "depends_on": {}, "count": {}, "for_each": {}},
+		Required:      map[string]struct{}{"foo": {}},
+		Optional:      map[string]struct{}{"bar": {}},
+		Computed:      map[string]struct{}{"baz": {}},
+		Meta:          map[string]struct{}{"provider": {}, "depends_on": {}, "count": {}, "for_each": {}},
+		RequiredOrder: []string{"foo"},
+		OptionalOrder: []string{"bar"},
+		ComputedOrder: []string{"baz"},
 	}
 	schemas := map[string]*alignpkg.Schema{"test_thing": sch}
 

--- a/internal/align/strategy.go
+++ b/internal/align/strategy.go
@@ -1,7 +1,11 @@
 // internal/align/strategy.go
 package align
 
-import "github.com/hashicorp/hcl/v2/hclwrite"
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
 
 type Options struct {
 	Order   []string
@@ -17,6 +21,13 @@ type Schema struct {
 	Optional map[string]struct{}
 	Computed map[string]struct{}
 	Meta     map[string]struct{}
+
+	RequiredOrder []string
+	OptionalOrder []string
+	ComputedOrder []string
+
+	Blocks      map[string]*Schema
+	BlocksOrder []string
 }
 
 type Strategy interface {
@@ -40,27 +51,40 @@ func Apply(file *hclwrite.File, opts *Options) error {
 
 func applyBody(body *hclwrite.Body, opts *Options) error {
 	for _, b := range body.Blocks() {
+		sub := *opts
+		sub.Schema = nil
+		if len(b.Labels()) > 0 && opts.Schemas != nil {
+			typ := b.Labels()[0]
+			if s, ok := opts.Schemas[typ]; ok {
+				sub.Schema = s
+			} else {
+				for k, s := range opts.Schemas {
+					if strings.HasSuffix(k, "/"+typ) {
+						sub.Schema = s
+						break
+					}
+				}
+			}
+		} else if opts.Schema != nil {
+			if s, ok := opts.Schema.Blocks[b.Type()]; ok {
+				sub.Schema = s
+			}
+		}
+
 		if strategy, ok := registry[b.Type()]; ok {
 			if opts.Types != nil {
 				if _, ok := opts.Types[b.Type()]; !ok {
-					if err := applyBody(b.Body(), opts); err != nil {
+					if err := applyBody(b.Body(), &sub); err != nil {
 						return err
 					}
 					continue
-				}
-			}
-			sub := *opts
-			sub.Schema = nil
-			if len(b.Labels()) > 0 && opts.Schemas != nil {
-				if s, ok := opts.Schemas[b.Labels()[0]]; ok {
-					sub.Schema = s
 				}
 			}
 			if err := strategy.Align(b, &sub); err != nil {
 				return err
 			}
 		}
-		if err := applyBody(b.Body(), opts); err != nil {
+		if err := applyBody(b.Body(), &sub); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- capture schema attribute and nested block order from Terraform output
- support fully-qualified provider/type keys in schema loader and alignment
- honor provider schema attribute tiers when reordering resources

## Testing
- `go test ./...` *(fails: internal/hcl/tokens.go:33:6: undefined: depth)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e0f6889083239681e06c706d08b3